### PR TITLE
[JBIDE-13158] removed connection lookup by usename and host

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/connection/ConnectionURL.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/connection/ConnectionURL.java
@@ -109,21 +109,6 @@ public class ConnectionURL {
 		return new ConnectionURL(username, null, portions.getScheme());
 	}
 
-	public static ConnectionURL forUsernameAndHost(String username, String host) throws UnsupportedEncodingException {
-		String scheme = UrlUtils.SCHEME_HTTPS;
-		if (ConnectionUtils.isDefaultHost(host)) {
-			scheme = UrlUtils.ensureStartsWithScheme(UrlUtils.getScheme(host), UrlUtils.SCHEME_HTTPS);
-			if (scheme == null) {
-				scheme = UrlUtils.SCHEME_HTTPS;
-			}
-			host = null;
-		} else if (UrlUtils.hasScheme(host)) {
-			scheme = UrlUtils.getScheme(host);
-			host = UrlUtils.cutScheme(host);
-		}
-		return new ConnectionURL(username, host, scheme);
-	}
-
 	public static ConnectionURL forConnection(Connection connection) throws UnsupportedEncodingException,
 			MalformedURLException {
 		if (connection.isDefaultHost()) {

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/connection/ConnectionsModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/connection/ConnectionsModel.java
@@ -91,16 +91,6 @@ public class ConnectionsModel {
 		return addConnection(connectionUrl, connection);
 	}
 
-	public boolean hasConnection(String username, String host) {
-		try {
-			ConnectionURL connectionUrl = ConnectionURL.forUsernameAndHost(username, host);
-			return getConnectionByUrl(connectionUrl) != null;
-		} catch (UnsupportedEncodingException e) {
-			throw new OpenShiftUIException(e,
-					NLS.bind("Could not get url for connection {0} - {1}", username, host));
-		}
-	}
-
 	public boolean hasConnection(Connection connection) {
 		try {
 			ConnectionURL connectionUrl = ConnectionURL.forConnection(connection);
@@ -172,14 +162,6 @@ public class ConnectionsModel {
 			return null;
 		}
 		return connectionsByUrl.get(connectionUrl);
-	}
-
-	public Connection getConnectionByUsernameAndHost(String username, String host) {
-		try {
-			return getConnectionByUrl(ConnectionURL.forUsernameAndHost(username, host));
-		} catch (UnsupportedEncodingException e) {
-			throw new OpenShiftUIException(NLS.bind("Could not get url for connection {0} - {1}", username, host), e);
-		}
 	}
 
 	/**

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/action/EditCartridgesAction.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/action/EditCartridgesAction.java
@@ -14,19 +14,17 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.swt.widgets.Display;
 import org.jboss.tools.common.ui.WizardUtils;
-import org.jboss.tools.openshift.express.internal.core.connection.Connection;
-import org.jboss.tools.openshift.express.internal.core.connection.ConnectionsModelSingleton;
 import org.jboss.tools.openshift.express.internal.ui.OpenShiftImages;
 import org.jboss.tools.openshift.express.internal.ui.messages.OpenShiftExpressUIMessages;
 import org.jboss.tools.openshift.express.internal.ui.utils.Logger;
 import org.jboss.tools.openshift.express.internal.ui.wizard.embed.EmbedCartridgeWizard;
 
 import com.openshift.client.IApplication;
-import com.openshift.client.IUser;
 import com.openshift.client.OpenShiftException;
 
 /**
  * @author Xavier Coulon
+ * @author Andre Dietisheim
  */
 public class EditCartridgesAction extends AbstractAction {
 
@@ -41,10 +39,8 @@ public class EditCartridgesAction extends AbstractAction {
 		if (selection != null && selection instanceof ITreeSelection && treeSelection.getFirstElement() instanceof IApplication) {
 			try {
 				final IApplication application = (IApplication) treeSelection.getFirstElement();
-				final IUser user = application.getDomain().getUser();
-				final Connection connection = ConnectionsModelSingleton.getInstance().getConnectionByUsernameAndHost(user.getRhlogin(), user.getServer());
-				EmbedCartridgeWizard wizard = new EmbedCartridgeWizard(application, connection);
-				int result = WizardUtils.openWizardDialog(wizard, Display.getCurrent().getActiveShell());
+				int result = WizardUtils.openWizardDialog(
+						new EmbedCartridgeWizard(application), Display.getCurrent().getActiveShell());
 				if(result == Dialog.OK) {
 					RefreshViewerJob.refresh(viewer);
 				}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationWizardModel.java
@@ -12,9 +12,9 @@ package org.jboss.tools.openshift.express.internal.ui.wizard.application;
 
 import org.eclipse.core.runtime.Assert;
 import org.jboss.tools.common.ui.databinding.ObservableUIPojo;
-import org.jboss.tools.openshift.express.internal.core.connection.Connection;
 
 import com.openshift.client.IApplication;
+import com.openshift.client.IOpenShiftConnection;
 
 /**
  * @author André Dietisheim
@@ -22,20 +22,18 @@ import com.openshift.client.IApplication;
 public class ApplicationWizardModel extends ObservableUIPojo {
 
 	private IApplication application;
-	private Connection connection;
 
-	public ApplicationWizardModel(IApplication application, Connection connection) {
+	public ApplicationWizardModel(IApplication application) {
 		Assert.isLegal(application != null, "No application provided");
 		this.application = application;
-		Assert.isLegal(connection != null, "No connection provided");
-		this.connection = connection;
 	}
 
 	public IApplication getApplication() {
 		return application;
 	}
 
-	public Connection getConnection() {
-		return connection;
+	public IOpenShiftConnection getConnection() {
+		return application.getDomain().getUser().getConnection();
 	}
+
 }

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftExpressApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftExpressApplicationWizard.java
@@ -219,7 +219,7 @@ public abstract class OpenShiftExpressApplicationWizard extends Wizard implement
 					, wizardModel.getApplicationCartridge()
 					, wizardModel.getApplicationScale()
 					, wizardModel.getApplicationGearProfile()
-					, wizardModel.getConnection());
+					, wizardModel.getConnection().getDefaultDomain());
 			IStatus status = WizardUtils.runInWizard(
 					job, job.getDelegatingProgressMonitor(), getContainer(), APP_CREATE_TIMEOUT);
 			wizardModel.setApplication(job.getApplication());

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/connection/ConnectionWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/connection/ConnectionWizardPageModel.java
@@ -50,7 +50,6 @@ public class ConnectionWizardPageModel extends ObservableUIPojo {
 	public static final String PROPERTY_REMEMBER_PASSWORD = "rememberPassword";
 	public static final String PROPERTY_USE_DEFAULTSERVER = "useDefaultServer";
 	public static final String PROPERTY_VALID = "valid";
-	public static final String PROPERTY_DUPLICATE_CONNECTION = "duplicateConnection";
 	public static final String PROPERTY_CREATE_CONNECTION = "createConnection";
 
 	final private IConnectionAwareModel wizardModel;
@@ -174,7 +173,6 @@ public class ConnectionWizardPageModel extends ObservableUIPojo {
 		if (!Diffs.equals(this.username, username)) {
 			firePropertyChange(PROPERTY_USERNAME, this.username, this.username = username);
 			resetValid();
-			fireDuplicateConnectionUpdated();
 		}
 	}
 
@@ -197,7 +195,6 @@ public class ConnectionWizardPageModel extends ObservableUIPojo {
 		if (!Diffs.equals(this.host, host)) {
 			firePropertyChange(PROPERTY_HOST, this.host, this.host = host);
 			resetValid();
-			fireDuplicateConnectionUpdated();
 		}
 	}
 
@@ -274,14 +271,6 @@ public class ConnectionWizardPageModel extends ObservableUIPojo {
 	
 	private boolean isSelectedConnectionChanged() {
 		return !password.equals(selectedConnection.getPassword());
-	}
-
-	public boolean isDuplicateConnection() {
-		return ConnectionsModelSingleton.getInstance().hasConnection(username, host);
-	}
-
-	private void fireDuplicateConnectionUpdated() {
-		firePropertyChange(PROPERTY_DUPLICATE_CONNECTION, null, isDuplicateConnection());
 	}
 
 	public Connection getConnection() {

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeStrategyAdapter.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeStrategyAdapter.java
@@ -165,7 +165,7 @@ public class EmbedCartridgeStrategyAdapter implements ICheckStateListener {
 		try {
 			CreateApplicationJob createJob =
 					new CreateApplicationJob(name, ICartridge.JENKINS_14, ApplicationScale.NO_SCALE,
-							IGearProfile.SMALL, pageModel.getConnection());
+							IGearProfile.SMALL, pageModel.getDomain());
 			WizardUtils.runInWizard(
 					createJob, createJob.getDelegatingProgressMonitor(), getContainer(), APP_CREATE_TIMEOUT);
 

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeWizard.java
@@ -11,7 +11,6 @@
 package org.jboss.tools.openshift.express.internal.ui.wizard.embed;
 
 import org.eclipse.jface.wizard.Wizard;
-import org.jboss.tools.openshift.express.internal.core.connection.Connection;
 import org.jboss.tools.openshift.express.internal.ui.wizard.application.ApplicationWizardModel;
 
 import com.openshift.client.IApplication;
@@ -24,8 +23,8 @@ public class EmbedCartridgeWizard extends Wizard {
 	private ApplicationWizardModel wizardModel;
 	private EmbedCartridgeWizardPage embedCartridgeWizardPage;
 
-	public EmbedCartridgeWizard(IApplication application, Connection connection) {
-		this.wizardModel = new ApplicationWizardModel(application, connection);
+	public EmbedCartridgeWizard(IApplication application) {
+		this.wizardModel = new ApplicationWizardModel(application);
 		setNeedsProgressMonitor(true);
 		setWindowTitle("Edit Embedded Cartridges");
 	}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeWizardPageModel.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.tools.common.ui.databinding.ObservableUIPojo;
-import org.jboss.tools.openshift.express.internal.core.connection.Connection;
 import org.jboss.tools.openshift.express.internal.ui.wizard.application.ApplicationWizardModel;
 
 import com.openshift.client.IApplication;
@@ -94,7 +93,8 @@ public class EmbedCartridgeWizardPageModel extends ObservableUIPojo implements I
 	}
 	
 	public boolean hasApplication(ICartridge cartridge) throws SocketTimeoutException, OpenShiftException {
-		return wizardModel.getConnection().hasApplicationOfType(cartridge);
+		IDomain domain = wizardModel.getApplication().getDomain();
+		return domain.hasApplicationByCartridge(cartridge);
 	}
 
 	public IApplication getApplication() {
@@ -103,7 +103,7 @@ public class EmbedCartridgeWizardPageModel extends ObservableUIPojo implements I
 
 	@Override
 	public IDomain getDomain() throws SocketTimeoutException, OpenShiftException {
-		return wizardModel.getConnection().getDefaultDomain();
+		return getApplication().getDomain();
 	}
 
 	@Override
@@ -126,10 +126,4 @@ public class EmbedCartridgeWizardPageModel extends ObservableUIPojo implements I
 		setSelectedEmbeddableCartridges(getApplication().getEmbeddedCartridges());
 		return getSelectedEmbeddableCartridges();
 	}
-
-	@Override
-	public Connection getConnection() {
-		return wizardModel.getConnection();
-	}
-	
 }

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/IEmbedCartridgesWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/IEmbedCartridgesWizardPageModel.java
@@ -13,8 +13,6 @@ package org.jboss.tools.openshift.express.internal.ui.wizard.embed;
 import java.net.SocketTimeoutException;
 import java.util.Set;
 
-import org.jboss.tools.openshift.express.internal.core.connection.Connection;
-
 import com.openshift.client.IDomain;
 import com.openshift.client.IEmbeddableCartridge;
 import com.openshift.client.OpenShiftException;
@@ -37,6 +35,4 @@ public interface IEmbedCartridgesWizardPageModel {
 	public boolean isSelected(IEmbeddableCartridge cartridge) throws OpenShiftException, SocketTimeoutException;
 
 	public IDomain getDomain() throws SocketTimeoutException, OpenShiftException;
-
-	public Connection getConnection();
 }

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/connection/ConnectionsModelTest.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/connection/ConnectionsModelTest.java
@@ -209,36 +209,6 @@ public class ConnectionsModelTest {
 	}
 
 	@Test
-	public void shouldGetConnectionByUsernameAndHost() throws UnsupportedEncodingException {
-		// pre-conditions
-		String username = "adietisheim";
-		String host = "http://redhat.com";
-		Connection connection = new ConnectionFake(username, host);
-		connectionsModel.addConnection(connection);
-
-		// operations
-		Connection queriedConnection = connectionsModel.getConnectionByUsernameAndHost(username, host);
-
-		// verifications
-		assertEquals(connection, queriedConnection);
-	}
-
-	@Test
-	public void shouldGetConnectionByUsernameAndHostWithoutScheme() throws UnsupportedEncodingException {
-		// pre-conditions
-		String username = "adietisheim";
-		String host = "redhat.com";
-		Connection connection = new ConnectionFake(username, host);
-		connectionsModel.addConnection(connection);
-
-		// operations
-		Connection queriedConnection = connectionsModel.getConnectionByUsernameAndHost(username, host);
-
-		// verifications
-		assertEquals(connection, queriedConnection);
-	}
-
-	@Test
 	public void shouldHaveConnection() throws UnsupportedEncodingException {
 		// pre-conditions
 		connectionsModel.addConnection(connection);


### PR DESCRIPTION
Removed ConnectionsModel#getConnectionByUsernameAndHost since this is
not required any more. This was used when embedding cartridges on an
existing application. This code was created when JBT was using the
legacy client. With the new client applications can be create with the
domain, no need to lookup the connection any more
