### PR TITLE
[JBIDE-13171] storing & erasing password when editing connection

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/connection/Connection.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/connection/Connection.java
@@ -193,6 +193,7 @@ public class Connection {
 	 */
 	public boolean connect() throws OpenShiftException {
 		if (isConnected()) {
+			save();
 			return true;
 		}
 		if (createUser()) {

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/connection/ConnectionWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/connection/ConnectionWizardPageModel.java
@@ -237,6 +237,7 @@ public class ConnectionWizardPageModel extends ObservableUIPojo {
 					connection = createConnection();
 				} else {
 					connection = selectedConnection;
+					connection.setRememberPassword(isRememberPassword());
 				}
 				connection.connect();
 				this.newConnection = connection;


### PR DESCRIPTION
Fixed bug where a change in the "save password" checkbox did not get
propagated to the connection that was edited. Thus unchecking/checking
"save password" did not store/erase the password in the secure storage
for existing connections.
