### PR TITLE
[JBIDE-13066] replaced dependecies to hardwired cartridges by matchers

### DIFF
--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/EmbedCartridgeStrategyTest.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/EmbedCartridgeStrategyTest.java
@@ -17,42 +17,68 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Future;
 
 import org.jboss.tools.openshift.express.internal.core.EmbedCartridgeStrategy;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.jcraft.jsch.Session;
-import com.openshift.client.ApplicationScale;
 import com.openshift.client.IApplication;
-import com.openshift.client.IApplicationGear;
-import com.openshift.client.IApplicationPortForwarding;
 import com.openshift.client.ICartridge;
 import com.openshift.client.IDomain;
 import com.openshift.client.IEmbeddableCartridge;
-import com.openshift.client.IEmbeddedCartridge;
-import com.openshift.client.IGearProfile;
-import com.openshift.client.IUser;
 import com.openshift.client.OpenShiftException;
-import com.openshift.client.OpenShiftSSHOperationException;
 
 /**
  * @author Andre Dietisheim
  */
 public class EmbedCartridgeStrategyTest {
 
+	
+	
 	private EmbedCartridgeStrategy embedStrategy;
-	private DomainFake domainFake;
 
 	@Before
 	public void setUp() throws OpenShiftException {
-		this.domainFake = new DomainFake();
-		this.embedStrategy = new EmbedCartridgeStrategy(domainFake);
+		createEmbeddableCartridgeStrategy();
+	}
+
+	protected void createEmbeddableCartridgeStrategy(ICartridge... cartridges) {
+		List<IEmbeddableCartridge> allEmbeddableCartridgeList = createCartridgesList(
+				IEmbeddableCartridge.MYSQL_51, 
+				IEmbeddableCartridge.PHPMYADMIN_34,
+				IEmbeddableCartridge.POSTGRESQL_84, 
+				IEmbeddableCartridge.ROCKMONGO_11, 
+				IEmbeddableCartridge.MONGODB_22, 
+				IEmbeddableCartridge.JENKINS_14,
+				IEmbeddableCartridge._10GEN_MMS_AGENT_01);
+		List<ICartridge> allCartridgeList = createCartridgesList(
+				ICartridge.JBOSSAS_7, 
+				ICartridge.JENKINS_14);
+		List<IApplication> allApplications = createAllApplicationsList(new NoopDomainFake(), cartridges);
+		this.embedStrategy = new EmbedCartridgeStrategy(allEmbeddableCartridgeList, allCartridgeList, allApplications);
+	}
+
+	private List<IApplication> createAllApplicationsList(IDomain domain, ICartridge... cartridges) {
+		List<IApplication> applications = new ArrayList<IApplication>();
+		if (cartridges != null) {
+			for(ICartridge cartridge : cartridges) {
+				applications.add(new ApplicationFake(cartridge));
+			}
+		}
+		return applications;
+	}
+
+	private <C> List<C> createCartridgesList(C... cartridges) {
+		List<C> embeddableCartridges = new ArrayList<C>();
+		if (cartridges != null) {
+			for(C cartridge : cartridges) {
+				embeddableCartridges.add(cartridge);
+			}
+		}
+		return embeddableCartridges;
 	}
 
 	@Test
@@ -98,10 +124,10 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.PHPMYADMIN_34, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 1);
+		assertEquals(1, diff.getAdditions().size());
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getAdditions().get(0));
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 	}
 
 	@Test
@@ -117,9 +143,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.PHPMYADMIN_34, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 	}
 
 	@Test
@@ -135,9 +161,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 1);
+		assertEquals(1, diff.getRemovals().size());
 		assertTrue(diff.getRemovals().contains(IEmbeddableCartridge.PHPMYADMIN_34));
 	}
 
@@ -153,9 +179,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 1);
+		assertEquals(1, diff.getRemovals().size());
 		assertEquals(IEmbeddableCartridge.POSTGRESQL_84, diff.getRemovals().get(0));
 	}
 
@@ -171,10 +197,10 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.PHPMYADMIN_34, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 1);
+		assertEquals(1, diff.getAdditions().size());
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getAdditions().get(0));
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 1);
+		assertEquals(1, diff.getRemovals().size());
 		assertEquals(IEmbeddableCartridge.POSTGRESQL_84, diff.getRemovals().get(0));
 	}
 
@@ -189,10 +215,10 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.ROCKMONGO_11, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 1);
+		assertEquals(1, diff.getAdditions().size());
 		assertEquals(IEmbeddableCartridge.MONGODB_22, diff.getAdditions().get(0));
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 	}
 
 	@Test
@@ -209,9 +235,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.MONGODB_22, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 2);
+		assertEquals(2, diff.getRemovals().size());
 		assertTrue(diff.getRemovals().contains(IEmbeddableCartridge.ROCKMONGO_11));
 		assertTrue(diff.getRemovals().contains(IEmbeddableCartridge._10GEN_MMS_AGENT_01));
 	}
@@ -220,7 +246,7 @@ public class EmbedCartridgeStrategyTest {
 	public void shouldNotAddJenkinsApplication() throws OpenShiftException{
 		// given
 		Set<IEmbeddableCartridge> currentCartridges = Collections.<IEmbeddableCartridge>emptySet();
-		domainFake.createApplication("adietish", ICartridge.JENKINS_14);
+		createEmbeddableCartridgeStrategy(ICartridge.JENKINS_14);
 		
 		// when
 		EmbedCartridgeStrategy.EmbeddableCartridgeDiff diff = embedStrategy.add(IEmbeddableCartridge.JENKINS_14, currentCartridges);
@@ -228,11 +254,11 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.JENKINS_14, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 		assertNotNull(diff.getApplicationAdditions());
-		assertTrue(diff.getApplicationAdditions().size() == 0);
+		assertEquals(0, diff.getApplicationAdditions().size());
 	}
 	
 	@Test
@@ -246,387 +272,25 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.JENKINS_14, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 		assertNotNull(diff.getApplicationAdditions());
-		assertTrue(diff.getApplicationAdditions().size() == 1);
+		assertEquals(1, diff.getApplicationAdditions().size());
 		assertTrue(diff.getApplicationAdditions().contains(ICartridge.JENKINS_14));
 	}
 
-	private static final class ApplicationFake implements IApplication {
+	private static final class ApplicationFake extends NoopApplicationFake {
 
 		private ICartridge cartridge;
-		private IDomain domain;
 
-		public ApplicationFake(ICartridge cartridge, IDomain domain) {
+		public ApplicationFake(ICartridge cartridge) {
 			this.cartridge = cartridge;
-			this.domain = domain;
-		}
-
-		@Override
-		public String getCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getName() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getUUID() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getGitUrl() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getApplicationUrl() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public ApplicationScale getApplicationScale() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IGearProfile getGearProfile() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getHealthCheckUrl() {
-			throw new UnsupportedOperationException();
 		}
 
 		@Override
 		public ICartridge getCartridge() {
 			return cartridge;
 		}
-
-		@Override
-		public IEmbeddedCartridge addEmbeddableCartridge(IEmbeddableCartridge cartridge) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IEmbeddedCartridge> addEmbeddableCartridges(List<IEmbeddableCartridge> cartridge)
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IEmbeddedCartridge> getEmbeddedCartridges() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasEmbeddedCartridge(IEmbeddableCartridge cartridge) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasEmbeddedCartridge(String cartridgeName) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IEmbeddedCartridge getEmbeddedCartridge(String cartridgeName) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IEmbeddedCartridge getEmbeddedCartridge(IEmbeddableCartridge cartridge) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void removeEmbeddedCartridge(IEmbeddableCartridge cartridge) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationGear> getGears() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Date getCreationTime() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void destroy() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void start() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void restart() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void stop() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void stop(boolean force) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean waitForAccessible(long timeout) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IDomain getDomain() {
-			return domain;
-		}
-
-		@Override
-		public void exposePort() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void concealPort() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void showPort() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void scaleDown() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void scaleUp() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void addAlias(String string) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<String> getAliases() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasAlias(String name) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void removeAlias(String alias) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void refresh() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasSSHSession() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		public void setSSHSession(Session session) {
-			throw new UnsupportedOperationException();
-		}
-
-		public Session getSSHSession() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Future<Boolean> waitForAccessibleAsync(long timeout) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-	}
-
-	private static final class DomainFake implements IDomain {
-
-		private List<IApplication> applications;
-
-		public DomainFake() {
-			this.applications = new ArrayList<IApplication>();
-		}
-
-		@Override
-		public String getCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void refresh() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getId() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getSuffix() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void rename(String id) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IUser getUser() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void destroy() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void destroy(boolean force) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean waitForAccessible(long timeout) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale,
-				IGearProfile gearProfile) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale)
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge, IGearProfile gearProfile)
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge) {
-			IApplication application = new ApplicationFake(cartridge, this);
-			applications.add(application);
-			return application;
-		}
-
-		@Override
-		public List<IApplication> getApplications() throws OpenShiftException {
-			return applications;
-		}
-
-		@Override
-		public List<String> getAvailableCartridgeNames() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication getApplicationByName(String name) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasApplicationByName(String name) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplication> getApplicationsByCartridge(ICartridge cartridge) throws OpenShiftException {
-			List<IApplication> matchingApplications = new ArrayList<IApplication>();
-			for (IApplication application : applications) {
-				if (cartridge.equals(application.getCartridge())) {
-					matchingApplications.add(application);
-					break;
-				}
-			}
-			return matchingApplications;
-		}
-
-		@Override
-		public boolean hasApplicationByCartridge(ICartridge cartridge) throws OpenShiftException {
-			return getApplicationsByCartridge(cartridge).size() > 0;
-		}
-
-		@Override
-		public List<IGearProfile> getAvailableGearProfiles() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-		
 	}
 }

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopApplicationFake.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopApplicationFake.java
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test.core;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import com.jcraft.jsch.Session;
+import com.openshift.client.ApplicationScale;
+import com.openshift.client.IApplication;
+import com.openshift.client.IApplicationGear;
+import com.openshift.client.IApplicationPortForwarding;
+import com.openshift.client.ICartridge;
+import com.openshift.client.IDomain;
+import com.openshift.client.IEmbeddableCartridge;
+import com.openshift.client.IEmbeddedCartridge;
+import com.openshift.client.IGearProfile;
+import com.openshift.client.OpenShiftException;
+import com.openshift.client.OpenShiftSSHOperationException;
+
+/**
+ * @author Andre Dietisheim
+ */
+public class NoopApplicationFake implements IApplication {
+
+	@Override
+	public String getCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getUUID() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getGitUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getApplicationUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ApplicationScale getApplicationScale() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IGearProfile getGearProfile() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getHealthCheckUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ICartridge getCartridge() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IEmbeddedCartridge addEmbeddableCartridge(IEmbeddableCartridge cartridge) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IEmbeddedCartridge> addEmbeddableCartridges(List<IEmbeddableCartridge> cartridge)
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IEmbeddedCartridge> getEmbeddedCartridges() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasEmbeddedCartridge(IEmbeddableCartridge cartridge) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasEmbeddedCartridge(String cartridgeName) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IEmbeddedCartridge getEmbeddedCartridge(String cartridgeName) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IEmbeddedCartridge getEmbeddedCartridge(IEmbeddableCartridge cartridge) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void removeEmbeddedCartridge(IEmbeddableCartridge cartridge) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationGear> getGears() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Date getCreationTime() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void destroy() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void start() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void restart() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void stop() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void stop(boolean force) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean waitForAccessible(long timeout) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IDomain getDomain() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void exposePort() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void concealPort() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void showPort() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void scaleDown() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void scaleUp() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void addAlias(String string) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> getAliases() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasAlias(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void removeAlias(String alias) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void refresh() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasSSHSession() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	public void setSSHSession(Session session) {
+		throw new UnsupportedOperationException();
+	}
+
+	public Session getSSHSession() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Future<Boolean> waitForAccessibleAsync(long timeout) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopDomainFake.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopDomainFake.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test.core;
+
+import java.util.List;
+
+import com.openshift.client.ApplicationScale;
+import com.openshift.client.IApplication;
+import com.openshift.client.ICartridge;
+import com.openshift.client.IDomain;
+import com.openshift.client.IGearProfile;
+import com.openshift.client.IUser;
+import com.openshift.client.OpenShiftException;
+
+/**
+ * @author Andre Dietisheim
+ */
+public class NoopDomainFake implements IDomain {
+
+	@Override
+	public String getCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void refresh() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getId() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getSuffix() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void rename(String id) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IUser getUser() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+
+	}
+
+	@Override
+	public void destroy() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void destroy(boolean force) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean waitForAccessible(long timeout) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale,
+			IGearProfile gearProfile) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale)
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge, IGearProfile gearProfile)
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplication> getApplications() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> getAvailableCartridgeNames() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication getApplicationByName(String name) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasApplicationByName(String name) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplication> getApplicationsByCartridge(ICartridge cartridge) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasApplicationByCartridge(ICartridge cartridge) throws OpenShiftException {
+		return getApplicationsByCartridge(cartridge).size() > 0;
+	}
+
+	@Override
+	public List<IGearProfile> getAvailableGearProfiles() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+}

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopOpenShiftConnectionFake.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopOpenShiftConnectionFake.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test.core;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import com.openshift.client.ICartridge;
+import com.openshift.client.IDomain;
+import com.openshift.client.IEmbeddableCartridge;
+import com.openshift.client.IOpenShiftConnection;
+import com.openshift.client.IUser;
+import com.openshift.client.OpenShiftException;
+
+/**
+ * @author Andre Dietisheim
+ */
+public class NoopOpenShiftConnectionFake implements IOpenShiftConnection {
+
+	@Override
+	public void setProxySet(boolean proxySet) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setProxyPort(String proxyPort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setProxyHost(String proxyHost) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setEnableSSLCertChecks(boolean doSSLChecks) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IUser getUser() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<ICartridge> getStandaloneCartridges() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ExecutorService getExecutorService() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IEmbeddableCartridge> getEmbeddableCartridges() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IDomain> getDomains() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopUserFake.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/NoopUserFake.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test.core;
+
+import java.util.List;
+
+import com.openshift.client.IDomain;
+import com.openshift.client.IOpenShiftConnection;
+import com.openshift.client.IOpenShiftSSHKey;
+import com.openshift.client.ISSHPublicKey;
+import com.openshift.client.IUser;
+import com.openshift.client.OpenShiftException;
+import com.openshift.client.OpenShiftUnknonwSSHKeyTypeException;
+
+/**
+ * @author Andre Dietisheim
+ */
+public class NoopUserFake implements IUser {
+
+	@Override
+	public void refresh() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean hasCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public String getCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IOpenShiftSSHKey putSSHKey(String name, ISSHPublicKey key) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean hasSSHPublicKey(String publicKey) throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean hasSSHKeyName(String name) throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean hasDomain(String id) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean hasDomain() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public String getServer() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public List<IOpenShiftSSHKey> getSSHKeys() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IOpenShiftSSHKey getSSHKeyByPublicKey(String publicKey) throws OpenShiftUnknonwSSHKeyTypeException,
+			OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IOpenShiftSSHKey getSSHKeyByName(String name) throws OpenShiftUnknonwSSHKeyTypeException, OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public String getRhlogin() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public String getPassword() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public int getMaxGears() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public List<IDomain> getDomains() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IDomain getDomain(String id) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IDomain getDefaultDomain() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public int getConsumedGears() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IOpenShiftConnection getConnection() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public String getAuthKey() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public String getAuthIV() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public void deleteKey(String name) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public IDomain createDomain(String id) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+}


### PR DESCRIPTION
When the user checks/unchecks cartridges required (additional) cartridges/applications
and conflicting cartridges are checked for. So far these dependencies were expresses
by hardwired cartridge names. Now these were replaced by matchers which select
among the available ones
