### PR TITLE
[JBIDE-13319] removed fixed cartridge names when editing cartridges

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/EmbedCartridgeStrategy.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/core/EmbedCartridgeStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 Red Hat, Inc.
+ * Copyright (c) 2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -11,14 +11,15 @@
 package org.jboss.tools.openshift.express.internal.core;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.openshift.client.IApplication;
 import com.openshift.client.ICartridge;
-import com.openshift.client.IDomain;
 import com.openshift.client.IEmbeddableCartridge;
 import com.openshift.client.OpenShiftException;
 
@@ -34,93 +35,121 @@ import com.openshift.client.OpenShiftException;
  */
 public class EmbedCartridgeStrategy {
 
-	private static final EmbeddableCartridgeRelations[] dependencies =
+	private final EmbeddableCartridgeRelations[] dependencies =
 			new EmbeddableCartridgeRelations[] {
-					new EmbeddableCartridgeRelations(IEmbeddableCartridge.JENKINS_14,
-							null, null, ICartridge.JENKINS_14),
-					new EmbeddableCartridgeRelations(IEmbeddableCartridge.PHPMYADMIN_34,
-							null, IEmbeddableCartridge.MYSQL_51, null),
-					new EmbeddableCartridgeRelations(IEmbeddableCartridge.ROCKMONGO_11,
-							null, IEmbeddableCartridge.MONGODB_20, null),
-					new EmbeddableCartridgeRelations(IEmbeddableCartridge._10GEN_MMS_AGENT_01,
-							null, IEmbeddableCartridge.MONGODB_20, null),
-					new EmbeddableCartridgeRelations(IEmbeddableCartridge.POSTGRESQL_84,
-							IEmbeddableCartridge.MYSQL_51, null, null),
-					new EmbeddableCartridgeRelations(IEmbeddableCartridge.MYSQL_51,
-							IEmbeddableCartridge.POSTGRESQL_84, null, null),
+					new EmbeddableCartridgeRelations(new EmbeddableCartridgeSelector("jenkins-client-"),
+							null, null, new CartridgeSelector("jenkins-")),
+					new EmbeddableCartridgeRelations(new EmbeddableCartridgeSelector("phpmyadmin-"),
+							null, new EmbeddableCartridgeSelector("mysql-"), null),
+					new EmbeddableCartridgeRelations(new EmbeddableCartridgeSelector("rockmongo-"),
+							null, new EmbeddableCartridgeSelector("mongodb-"), null),
+					new EmbeddableCartridgeRelations(new EmbeddableCartridgeSelector("10gen-mms-agent-"),
+							null, new EmbeddableCartridgeSelector("mongodb-"), null),
+					new EmbeddableCartridgeRelations(new EmbeddableCartridgeSelector("postgresql-"),
+							new EmbeddableCartridgeSelector("mysql-"), null, null),
+					new EmbeddableCartridgeRelations(new EmbeddableCartridgeSelector("mysql-"),
+							new EmbeddableCartridgeSelector("postgresql-"), null, null)
 			};
 
 	private Map<IEmbeddableCartridge, EmbeddableCartridgeRelations> dependenciesByCartridge;
 	private HashMap<IEmbeddableCartridge, Set<IEmbeddableCartridge>> dependantsByCartridge;
 
-	private IDomain domain;
+	private Collection<IEmbeddableCartridge> allEmbeddableCartridges;
+	private Collection<ICartridge> allStandaloneCartridges;
+	private Collection<IApplication> allApplications;
 
-	public EmbedCartridgeStrategy(IDomain domain) {
-		this.domain = domain;
-		initDependencyMaps(dependencies);
+	public EmbedCartridgeStrategy(Collection<IEmbeddableCartridge> allEmbeddableCartridges,
+			Collection<ICartridge> allStandaloneCartridges, Collection<IApplication> allApplications) {
+		this.allEmbeddableCartridges = allEmbeddableCartridges;
+		this.allStandaloneCartridges = allStandaloneCartridges;
+		this.allApplications = allApplications;
+		initDependencyMaps(allEmbeddableCartridges, allStandaloneCartridges, dependencies);
 	}
 
-	private void initDependencyMaps(EmbeddableCartridgeRelations... dependencies) {
+	private void initDependencyMaps(Collection<IEmbeddableCartridge> allEmbeddableCartridges,
+			Collection<ICartridge> allCartridges, EmbeddableCartridgeRelations... dependencies) {
 		this.dependenciesByCartridge = new HashMap<IEmbeddableCartridge, EmbeddableCartridgeRelations>();
 
 		this.dependantsByCartridge = new HashMap<IEmbeddableCartridge, Set<IEmbeddableCartridge>>();
 		for (EmbeddableCartridgeRelations dependency : dependencies) {
-			dependenciesByCartridge.put(dependency.getSubject(), dependency);
-			Set<IEmbeddableCartridge> dependants = getDependants(dependency);
-			dependants.add(dependency.getSubject());
+			createDependency(allEmbeddableCartridges, dependency);
+			createDependants(allEmbeddableCartridges, dependency);
 		}
 	}
 
-	private Set<IEmbeddableCartridge> getDependants(EmbeddableCartridgeRelations relation) {
-		Set<IEmbeddableCartridge> dependants = dependantsByCartridge.get(relation.getRequired());
+	protected void createDependants(Collection<IEmbeddableCartridge> allEmbeddableCartridges,
+			EmbeddableCartridgeRelations dependency) {
+		Set<IEmbeddableCartridge> dependants = dependantsByCartridge.get(dependency.getRequired(allEmbeddableCartridges));
 		if (dependants == null) {
-			dependantsByCartridge.put(
-					relation.getRequired(),
-					dependants = new HashSet<IEmbeddableCartridge>());
+			IEmbeddableCartridge dependantCartridge = dependency.getRequired(allEmbeddableCartridges); 
+			if (dependantCartridge != null) {
+				dependantsByCartridge.put(
+						dependantCartridge,
+						dependants = new HashSet<IEmbeddableCartridge>());
+			}
 		}
-		return dependants;
+		if (dependants != null) {
+			dependants.add(dependency.getSubject(allEmbeddableCartridges));
+		}
+	}
+
+	protected void createDependency(Collection<IEmbeddableCartridge> allEmbeddableCartridges,
+			EmbeddableCartridgeRelations dependency) {
+		IEmbeddableCartridge requiringCartridge = dependency.getSubject(allEmbeddableCartridges);
+		dependenciesByCartridge.put(requiringCartridge, dependency);
 	}
 
 	public EmbeddableCartridgeDiff add(IEmbeddableCartridge cartridge, Set<IEmbeddableCartridge> currentCartridges)
 			throws OpenShiftException {
 		EmbeddableCartridgeDiff cartridgeDiff = new EmbeddableCartridgeDiff(cartridge);
-		add(cartridge, currentCartridges, cartridgeDiff);
+		add(cartridge, currentCartridges, cartridgeDiff, allEmbeddableCartridges, allStandaloneCartridges, allApplications);
 		return cartridgeDiff;
 	}
 
 	private void add(IEmbeddableCartridge cartridge, Set<IEmbeddableCartridge> currentCartridges,
-			EmbeddableCartridgeDiff diff)
+			EmbeddableCartridgeDiff diff, Collection<IEmbeddableCartridge> allEmbeddableCartridges,
+			Collection<ICartridge> allStandaloneCartridges, Collection<IApplication> allApplications)
 			throws OpenShiftException {
 		EmbeddableCartridgeRelations relation = dependenciesByCartridge.get(cartridge);
 		if (relation == null) {
 			return;
 		}
-		removeConflicting(currentCartridges, diff, relation);
-		addRequired(currentCartridges, diff, relation.getRequired());
-		addRequiredApplication(diff, relation);
+		removeConflicting(currentCartridges, diff, relation, allEmbeddableCartridges);
+		addRequired(currentCartridges, diff, relation.getRequired(allEmbeddableCartridges), allEmbeddableCartridges);
+		addRequiredApplication(diff, relation, allStandaloneCartridges, allApplications);
 	}
 
 	private void addRequired(Set<IEmbeddableCartridge> currentCartridges, EmbeddableCartridgeDiff diff,
-			IEmbeddableCartridge requiredCartridge) throws OpenShiftException {
+			IEmbeddableCartridge requiredCartridge, Collection<IEmbeddableCartridge> allEmbeddableCartridges) throws OpenShiftException {
 		if (requiredCartridge != null
 				&& !currentCartridges.contains(requiredCartridge)) {
 			// recurse
-			add(requiredCartridge, currentCartridges, diff);
+			add(requiredCartridge, currentCartridges, diff, allEmbeddableCartridges, allStandaloneCartridges, allApplications);
 			diff.addAddition(requiredCartridge);
 		}
 	}
 
 	private void addRequiredApplication(EmbeddableCartridgeDiff diff,
-			EmbeddableCartridgeRelations relation) throws OpenShiftException {
-		if (relation.getRequiredApplication() != null
-				&& !domain.hasApplicationByCartridge(relation.getRequiredApplication())) {
-			diff.addApplicationAddition(relation.getRequiredApplication());
+			EmbeddableCartridgeRelations relation, Collection<ICartridge> allStandaloneCartridges, Collection<IApplication> allApplications) throws OpenShiftException {
+		ICartridge requiredCartridge = relation.getRequiredApplication(allStandaloneCartridges);
+		if (requiredCartridge != null
+				&& !containsApplicationByCartridge(requiredCartridge, allApplications)) {
+			diff.addApplicationAddition(requiredCartridge);
 		}
 	}
 
+	private boolean containsApplicationByCartridge(ICartridge cartridge, Collection<IApplication> applications) {
+		for(IApplication application : applications) {
+			if (cartridge.equals(application.getCartridge())) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	private void removeConflicting(Set<IEmbeddableCartridge> currentCartridges, EmbeddableCartridgeDiff cartridgeDiff,
-			EmbeddableCartridgeRelations relation) throws OpenShiftException {
-		IEmbeddableCartridge conflictingCartridge = relation.getConflicting();
+			EmbeddableCartridgeRelations relation, Collection<IEmbeddableCartridge> allEmbeddableCartridges) throws OpenShiftException {
+		IEmbeddableCartridge conflictingCartridge = relation.getConflicting(allEmbeddableCartridges);
 		if (conflictingCartridge != null) {
 			remove(conflictingCartridge, currentCartridges, cartridgeDiff);
 			if (currentCartridges.contains(conflictingCartridge)) {
@@ -153,35 +182,43 @@ public class EmbedCartridgeStrategy {
 
 	private static class EmbeddableCartridgeRelations {
 
-		private IEmbeddableCartridge subject;
-		private IEmbeddableCartridge conflicting;
-		private IEmbeddableCartridge required;
-		private ICartridge requiredApplication;
+		private EmbeddableCartridgeSelector subject;
+		private EmbeddableCartridgeSelector conflicting;
+		private EmbeddableCartridgeSelector required;
+		private CartridgeSelector requiredApplication;
 
-		protected EmbeddableCartridgeRelations(IEmbeddableCartridge cartridge,
-				IEmbeddableCartridge conflicting, IEmbeddableCartridge required, ICartridge requiredApplication) {
-			this.subject = cartridge;
+		protected EmbeddableCartridgeRelations(EmbeddableCartridgeSelector cartridgeSelector,
+				EmbeddableCartridgeSelector conflicting, EmbeddableCartridgeSelector required, CartridgeSelector requiredApplication) {
+			this.subject = cartridgeSelector;
 			this.conflicting = conflicting;
 			this.required = required;
 			this.requiredApplication = requiredApplication;
 		}
 
-		protected IEmbeddableCartridge getSubject() {
-			return subject;
+		protected IEmbeddableCartridge getSubject(Collection<IEmbeddableCartridge> allEmbeddableCartridges) {
+			return subject.getCartridge(allEmbeddableCartridges);
 		}
 
-		protected IEmbeddableCartridge getConflicting() {
-			return conflicting;
+		protected IEmbeddableCartridge getConflicting(Collection<IEmbeddableCartridge> allEmbeddableCartridges) {
+			if (conflicting == null) {
+				return null;
+			}
+			return conflicting.getCartridge(allEmbeddableCartridges);
 		}
 
-		protected IEmbeddableCartridge getRequired() {
-			return required;
+		protected IEmbeddableCartridge getRequired(Collection<IEmbeddableCartridge> allEmbeddableCartridges) {
+			if (required == null) {
+				return null;
+			}
+			return required.getCartridge(allEmbeddableCartridges);
 		}
 
-		protected ICartridge getRequiredApplication() {
-			return requiredApplication;
+		protected ICartridge getRequiredApplication(Collection<ICartridge> allCartridges) {
+			if (requiredApplication == null) {
+				return null;
+			}
+			return requiredApplication.getCartridge(allCartridges);
 		}
-
 	}
 
 	public static class EmbeddableCartridgeDiff {
@@ -245,4 +282,53 @@ public class EmbedCartridgeStrategy {
 		}
 	}
 
+	private static class EmbeddableCartridgeSelector {
+
+		private String nameStartsWith;
+
+		private EmbeddableCartridgeSelector(String nameStartsWith) {
+			this.nameStartsWith = nameStartsWith;
+		}
+
+		private IEmbeddableCartridge getCartridge(Collection<IEmbeddableCartridge> embeddableCartridges) {
+			if (embeddableCartridges == null
+					|| embeddableCartridges.isEmpty()) {
+				return null;
+			}
+			
+			for(IEmbeddableCartridge cartridge : embeddableCartridges) {
+				if (cartridge.getName() != null
+						&& cartridge.getName().startsWith(nameStartsWith)) {
+					return cartridge;
+				}
+			}
+			return null;
+		}
+		
+	}
+	
+	private static class CartridgeSelector {
+
+		private String nameStartsWith;
+
+		private CartridgeSelector(String nameStartsWith) {
+			this.nameStartsWith = nameStartsWith;
+		}
+
+		private ICartridge getCartridge(Collection<ICartridge> cartridges) {
+			if (cartridges == null
+					|| cartridges.isEmpty()) {
+				return null;
+			}
+			
+			for(ICartridge cartridge : cartridges) {
+				if (cartridge.getName() != null
+						&& cartridge.getName().startsWith(nameStartsWith)) {
+					return cartridge;
+				}
+			}
+			return null;
+		}
+		
+	}
 }

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/EmbedCartridgeStrategyTest.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/EmbedCartridgeStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Red Hat, Inc.
+ * Copyright (c) 2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -26,32 +25,60 @@ import org.jboss.tools.openshift.express.internal.core.EmbedCartridgeStrategy;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.jcraft.jsch.Session;
-import com.openshift.client.ApplicationScale;
 import com.openshift.client.IApplication;
-import com.openshift.client.IApplicationGear;
-import com.openshift.client.IApplicationPortForwarding;
 import com.openshift.client.ICartridge;
 import com.openshift.client.IDomain;
 import com.openshift.client.IEmbeddableCartridge;
-import com.openshift.client.IEmbeddedCartridge;
-import com.openshift.client.IGearProfile;
-import com.openshift.client.IUser;
 import com.openshift.client.OpenShiftException;
-import com.openshift.client.OpenShiftSSHOperationException;
 
 /**
  * @author Andre Dietisheim
  */
 public class EmbedCartridgeStrategyTest {
 
+	
+	
 	private EmbedCartridgeStrategy embedStrategy;
-	private DomainFake domainFake;
 
 	@Before
 	public void setUp() throws OpenShiftException {
-		this.domainFake = new DomainFake();
-		this.embedStrategy = new EmbedCartridgeStrategy(domainFake);
+		createEmbeddableCartridgeStrategy();
+	}
+
+	protected void createEmbeddableCartridgeStrategy(ICartridge... cartridges) {
+		List<IEmbeddableCartridge> allEmbeddableCartridgeList = createCartridgesList(
+				IEmbeddableCartridge.MYSQL_51, 
+				IEmbeddableCartridge.PHPMYADMIN_34,
+				IEmbeddableCartridge.POSTGRESQL_84, 
+				IEmbeddableCartridge.ROCKMONGO_11, 
+				IEmbeddableCartridge.MONGODB_20, 
+				IEmbeddableCartridge.JENKINS_14,
+				IEmbeddableCartridge._10GEN_MMS_AGENT_01);
+		List<ICartridge> allCartridgeList = createCartridgesList(
+				ICartridge.JBOSSAS_7, 
+				ICartridge.JENKINS_14);
+		List<IApplication> allApplications = createAllApplicationsList(new NoopDomainFake(), cartridges);
+		this.embedStrategy = new EmbedCartridgeStrategy(allEmbeddableCartridgeList, allCartridgeList, allApplications);
+	}
+
+	private List<IApplication> createAllApplicationsList(IDomain domain, ICartridge... cartridges) {
+		List<IApplication> applications = new ArrayList<IApplication>();
+		if (cartridges != null) {
+			for(ICartridge cartridge : cartridges) {
+				applications.add(new ApplicationFake(cartridge));
+			}
+		}
+		return applications;
+	}
+
+	private <C> List<C> createCartridgesList(C... cartridges) {
+		List<C> embeddableCartridges = new ArrayList<C>();
+		if (cartridges != null) {
+			for(C cartridge : cartridges) {
+				embeddableCartridges.add(cartridge);
+			}
+		}
+		return embeddableCartridges;
 	}
 
 	@Test
@@ -97,10 +124,10 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.PHPMYADMIN_34, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 1);
+		assertEquals(1, diff.getAdditions().size());
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getAdditions().get(0));
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 	}
 
 	@Test
@@ -116,9 +143,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.PHPMYADMIN_34, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 	}
 
 	@Test
@@ -134,9 +161,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 1);
+		assertEquals(1, diff.getRemovals().size());
 		assertTrue(diff.getRemovals().contains(IEmbeddableCartridge.PHPMYADMIN_34));
 	}
 
@@ -152,9 +179,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 1);
+		assertEquals(1, diff.getRemovals().size());
 		assertEquals(IEmbeddableCartridge.POSTGRESQL_84, diff.getRemovals().get(0));
 	}
 
@@ -170,10 +197,10 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.PHPMYADMIN_34, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 1);
+		assertEquals(1, diff.getAdditions().size());
 		assertEquals(IEmbeddableCartridge.MYSQL_51, diff.getAdditions().get(0));
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 1);
+		assertEquals(1, diff.getRemovals().size());
 		assertEquals(IEmbeddableCartridge.POSTGRESQL_84, diff.getRemovals().get(0));
 	}
 
@@ -188,10 +215,10 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.ROCKMONGO_11, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 1);
+		assertEquals(1, diff.getAdditions().size());
 		assertEquals(IEmbeddableCartridge.MONGODB_20, diff.getAdditions().get(0));
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 	}
 
 	@Test
@@ -208,9 +235,9 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.MONGODB_20, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 2);
+		assertEquals(2, diff.getRemovals().size());
 		assertTrue(diff.getRemovals().contains(IEmbeddableCartridge.ROCKMONGO_11));
 		assertTrue(diff.getRemovals().contains(IEmbeddableCartridge._10GEN_MMS_AGENT_01));
 	}
@@ -219,7 +246,7 @@ public class EmbedCartridgeStrategyTest {
 	public void shouldNotAddJenkinsApplication() throws OpenShiftException{
 		// given
 		Set<IEmbeddableCartridge> currentCartridges = Collections.<IEmbeddableCartridge>emptySet();
-		domainFake.createApplication("adietish", ICartridge.JENKINS_14);
+		createEmbeddableCartridgeStrategy(ICartridge.JENKINS_14);
 		
 		// when
 		EmbedCartridgeStrategy.EmbeddableCartridgeDiff diff = embedStrategy.add(IEmbeddableCartridge.JENKINS_14, currentCartridges);
@@ -227,11 +254,11 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.JENKINS_14, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 		assertNotNull(diff.getApplicationAdditions());
-		assertTrue(diff.getApplicationAdditions().size() == 0);
+		assertEquals(0, diff.getApplicationAdditions().size());
 	}
 	
 	@Test
@@ -245,383 +272,25 @@ public class EmbedCartridgeStrategyTest {
 		// then
 		assertEquals(IEmbeddableCartridge.JENKINS_14, diff.getCartridge());
 		assertNotNull(diff.getAdditions());
-		assertTrue(diff.getAdditions().size() == 0);
+		assertEquals(0, diff.getAdditions().size());
 		assertNotNull(diff.getRemovals());
-		assertTrue(diff.getRemovals().size() == 0);
+		assertEquals(0, diff.getRemovals().size());
 		assertNotNull(diff.getApplicationAdditions());
-		assertTrue(diff.getApplicationAdditions().size() == 1);
+		assertEquals(1, diff.getApplicationAdditions().size());
 		assertTrue(diff.getApplicationAdditions().contains(ICartridge.JENKINS_14));
 	}
 
-	private static final class ApplicationFake implements IApplication {
+	private static final class ApplicationFake extends NoopApplicationFake {
 
 		private ICartridge cartridge;
-		private IDomain domain;
 
-		public ApplicationFake(ICartridge cartridge, IDomain domain) {
+		public ApplicationFake(ICartridge cartridge) {
 			this.cartridge = cartridge;
-			this.domain = domain;
-		}
-
-		@Override
-		public String getCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getName() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getUUID() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getGitUrl() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getApplicationUrl() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public ApplicationScale getApplicationScale() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IGearProfile getGearProfile() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getHealthCheckUrl() {
-			throw new UnsupportedOperationException();
 		}
 
 		@Override
 		public ICartridge getCartridge() {
 			return cartridge;
 		}
-
-		@Override
-		public IEmbeddedCartridge addEmbeddableCartridge(IEmbeddableCartridge cartridge) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IEmbeddedCartridge> addEmbeddableCartridges(List<IEmbeddableCartridge> cartridge)
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IEmbeddedCartridge> getEmbeddedCartridges() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasEmbeddedCartridge(IEmbeddableCartridge cartridge) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasEmbeddedCartridge(String cartridgeName) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IEmbeddedCartridge getEmbeddedCartridge(String cartridgeName) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IEmbeddedCartridge getEmbeddedCartridge(IEmbeddableCartridge cartridge) 
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void removeEmbeddedCartridge(IEmbeddableCartridge cartridge) throws OpenShiftException {
-			// TODO Auto-generated method stub
-			
-		}
-
-		@Override
-		public List<IApplicationGear> getGears() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Date getCreationTime() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void destroy() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void start() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void restart() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void stop() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void stop(boolean force) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean waitForAccessible(long timeout) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IDomain getDomain() {
-			return domain;
-		}
-
-		@Override
-		public void exposePort() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void concealPort() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void showPort() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void scaleDown() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void scaleUp() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void addAlias(String string) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<String> getAliases() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasAlias(String name) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void removeAlias(String alias) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void refresh() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasSSHSession() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException {
-			throw new UnsupportedOperationException();
-		}
-
-		public void setSSHSession(Session session) {
-			throw new UnsupportedOperationException();
-		}
-
-		public Session getSSHSession() {
-			throw new UnsupportedOperationException();
-		}
-	}
-
-	private static final class DomainFake implements IDomain {
-
-		private List<IApplication> applications;
-
-		public DomainFake() {
-			this.applications = new ArrayList<IApplication>();
-		}
-
-		@Override
-		public String getCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasCreationLog() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void refresh() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getId() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getSuffix() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void rename(String id) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IUser getUser() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void destroy() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void destroy(boolean force) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean waitForAccessible(long timeout) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale,
-				IGearProfile gearProfile) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale)
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge, IGearProfile gearProfile)
-				throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication createApplication(String name, ICartridge cartridge) {
-			IApplication application = new ApplicationFake(cartridge, this);
-			applications.add(application);
-			return application;
-		}
-
-		@Override
-		public List<IApplication> getApplications() throws OpenShiftException {
-			return applications;
-		}
-
-		@Override
-		public List<String> getAvailableCartridgeNames() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public IApplication getApplicationByName(String name) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean hasApplicationByName(String name) throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<IApplication> getApplicationsByCartridge(ICartridge cartridge) throws OpenShiftException {
-			List<IApplication> matchingApplications = new ArrayList<IApplication>();
-			for (IApplication application : applications) {
-				if (cartridge.equals(application.getCartridge())) {
-					matchingApplications.add(application);
-					break;
-				}
-			}
-			return matchingApplications;
-		}
-
-		@Override
-		public boolean hasApplicationByCartridge(ICartridge cartridge) throws OpenShiftException {
-			return getApplicationsByCartridge(cartridge).size() > 0;
-		}
-
-		@Override
-		public List<IGearProfile> getAvailableGearProfiles() throws OpenShiftException {
-			throw new UnsupportedOperationException();
-		}
-		
 	}
 }

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/NoopApplicationFake.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/NoopApplicationFake.java
@@ -1,0 +1,266 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test;
+
+import java.util.Date;
+import java.util.List;
+
+import com.jcraft.jsch.Session;
+import com.openshift.client.ApplicationScale;
+import com.openshift.client.IApplication;
+import com.openshift.client.IApplicationGear;
+import com.openshift.client.IApplicationPortForwarding;
+import com.openshift.client.ICartridge;
+import com.openshift.client.IDomain;
+import com.openshift.client.IEmbeddableCartridge;
+import com.openshift.client.IEmbeddedCartridge;
+import com.openshift.client.IGearProfile;
+import com.openshift.client.OpenShiftException;
+import com.openshift.client.OpenShiftSSHOperationException;
+
+/**
+ * @author Andre Dietisheim
+ */
+public class NoopApplicationFake implements IApplication {
+
+	@Override
+	public String getCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getUUID() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getGitUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getApplicationUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ApplicationScale getApplicationScale() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IGearProfile getGearProfile() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getHealthCheckUrl() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ICartridge getCartridge() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IEmbeddedCartridge addEmbeddableCartridge(IEmbeddableCartridge cartridge) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IEmbeddedCartridge> addEmbeddableCartridges(List<IEmbeddableCartridge> cartridge)
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IEmbeddedCartridge> getEmbeddedCartridges() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasEmbeddedCartridge(IEmbeddableCartridge cartridge) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasEmbeddedCartridge(String cartridgeName) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IEmbeddedCartridge getEmbeddedCartridge(String cartridgeName) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IEmbeddedCartridge getEmbeddedCartridge(IEmbeddableCartridge cartridge) 
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void removeEmbeddedCartridge(IEmbeddableCartridge cartridge) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationGear> getGears() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Date getCreationTime() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void destroy() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void start() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void restart() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void stop() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void stop(boolean force) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean waitForAccessible(long timeout) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IDomain getDomain() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void exposePort() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void concealPort() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void showPort() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void scaleDown() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void scaleUp() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void addAlias(String string) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> getAliases() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasAlias(String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void removeAlias(String alias) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void refresh() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasSSHSession() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isPortFowardingStarted() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> getForwardablePorts() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> startPortForwarding() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> stopPortForwarding() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplicationPortForwarding> refreshForwardablePorts() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> getEnvironmentProperties() throws OpenShiftSSHOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	public void setSSHSession(Session session) {
+		throw new UnsupportedOperationException();
+	}
+
+	public Session getSSHSession() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/NoopDomainFake.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/NoopDomainFake.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test;
+
+import java.util.List;
+
+import com.openshift.client.ApplicationScale;
+import com.openshift.client.IApplication;
+import com.openshift.client.ICartridge;
+import com.openshift.client.IDomain;
+import com.openshift.client.IGearProfile;
+import com.openshift.client.IUser;
+import com.openshift.client.OpenShiftException;
+
+/**
+ * @author Andre Dietisheim
+ */
+public class NoopDomainFake implements IDomain {
+
+	@Override
+	public String getCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasCreationLog() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void refresh() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getId() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getSuffix() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void rename(String id) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IUser getUser() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+
+	}
+
+	@Override
+	public void destroy() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void destroy(boolean force) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean waitForAccessible(long timeout) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale,
+			IGearProfile gearProfile) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge, ApplicationScale scale)
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge, IGearProfile gearProfile)
+			throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication createApplication(String name, ICartridge cartridge) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplication> getApplications() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> getAvailableCartridgeNames() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public IApplication getApplicationByName(String name) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasApplicationByName(String name) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<IApplication> getApplicationsByCartridge(ICartridge cartridge) throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean hasApplicationByCartridge(ICartridge cartridge) throws OpenShiftException {
+		return getApplicationsByCartridge(cartridge).size() > 0;
+	}
+
+	@Override
+	public List<IGearProfile> getAvailableGearProfiles() throws OpenShiftException {
+		throw new UnsupportedOperationException();
+	}
+	
+}


### PR DESCRIPTION
backported fix from 4.0.x that avoids hard coded cartridge names when
checking cartridge dependencies that should also get added/removed
