### PR TITLE
[JBIDE-13664] added log4j.properties to build.properties

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.client/build.properties
+++ b/plugins/org.jboss.tools.openshift.express.client/build.properties
@@ -8,4 +8,5 @@ bin.includes = META-INF/,\
                jboss-dmr-1.0.0.Final.jar,\
                log4j-1.2.17.jar,\
                plugin.xml,\
-               openshift-java-client-2.1.0-SNAPSHOT.jar
+               openshift-java-client-2.1.0-SNAPSHOT.jar,\
+               log4j.properties


### PR DESCRIPTION
to solve the missing tracing options, Nick Boldt added .options
file to build.properties. To solve the logging I now furthermore
added the log4j.properties to build.properties
