### PR TITLE
[JBIDE-13975] fixed wrong connection selected when importing

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/explorer/OpenShiftExplorerUtils.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/explorer/OpenShiftExplorerUtils.java
@@ -41,7 +41,7 @@ public class OpenShiftExplorerUtils {
 	 */
 	public static Connection getConnectionFor(ITreeSelection selection) {
 		if (selection == null
-				|| selection.size() <= 1) {
+				|| selection.size() < 1) {
 			return null;
 		}
 


### PR DESCRIPTION
When importing via context menu in OpenShift Explorer, the wrong
connection was selected in the credentials dialog. This is now fixed.
Furthermore it turns out that the credentials page is not required/not
show as soon as the correct connection is selected.
