### PR TITLE
[JBIDE-13969] removed all occurrences of "lowercase"/"lower-case"

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationConfigurationWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationConfigurationWizardPage.java
@@ -773,7 +773,7 @@ public class ApplicationConfigurationWizardPage extends AbstractOpenShiftWizardP
 
 			if (!StringUtils.isAlphaNumeric(appName)) {
 				return ValidationStatus.error(
-						"The name may only contain lower-case letters and digits.");
+						"The name may only contain letters and digits.");
 			}
 
 			if (existingApplicationsLoaded != null
@@ -826,7 +826,7 @@ public class ApplicationConfigurationWizardPage extends AbstractOpenShiftWizardP
 			}
 			if (!StringUtils.isAlphaNumeric(applicationName)) {
 				return ValidationStatus.error(
-						"The name may only contain lower-case letters and digits.");
+						"The name may only contain letters and digits.");
 			}
 			if (pageModel.isExistingApplication(applicationName)) {
 				return ValidationStatus.error(

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ProjectAndServerAdapterSettingsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ProjectAndServerAdapterSettingsWizardPage.java
@@ -276,7 +276,7 @@ public class ProjectAndServerAdapterSettingsWizardPage extends AbstractOpenShift
 					status = OpenShiftUIActivator.createErrorStatus("You have to choose an application name");
 				} else if (!StringUtils.isAlphaNumeric(applicationName)) {
 					status = OpenShiftUIActivator.createErrorStatus(
-							"The name may only contain lower-case letters and digits.");
+							"The name may only contain letters and digits.");
 				} else {
 					final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(applicationName);
 					if (project.exists()) {

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/domain/EditDomainWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/domain/EditDomainWizardPage.java
@@ -92,11 +92,11 @@ public class EditDomainWizardPage extends AbstractOpenShiftWizardPage {
 			}
 			if (domainName.isEmpty()) {
 				return ValidationStatus.cancel(
-						"Enter a domain name with lower-case letters and digits only. Max length is 16 characters.");
+						"Enter a domain name with letters and digits only. Max length is 16 characters.");
 			}
 			if (!StringUtils.isAlphaNumeric(domainName)) {
 				return ValidationStatus.error(
-						"The domain name may only contain lower-case letters and digits.");
+						"The domain name may only contain letters and digits.");
 			}
 			if (domainName.length() > 16) {
 				return ValidationStatus.error(

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/domain/NewDomainWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/domain/NewDomainWizardPage.java
@@ -113,7 +113,7 @@ public class NewDomainWizardPage extends AbstractOpenShiftWizardPage {
 			}
 			if (!StringUtils.isAlphaNumeric(domainName)) {
 				return ValidationStatus.error(
-						"The domain name may only contain lower-case letters and digits.");
+						"The domain name may only contain letters and digits.");
 			}
 			return ValidationStatus.ok();
 		}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeStrategyAdapter.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeStrategyAdapter.java
@@ -248,7 +248,7 @@ public class EmbedCartridgeStrategyAdapter implements ICheckStateListener {
 					shell,
 					"New Jenkins application",
 					"To embed Jenkins into your application, you first have to create a separate Jenkins application. "
-							+ "Please provide a name for this new Jenkins application (lower-case letters and digits only):"
+							+ "Please provide a name for this new Jenkins application (letters and digits only):"
 					, null, new JenkinsNameValidator());
 		}
 
@@ -261,7 +261,7 @@ public class EmbedCartridgeStrategyAdapter implements ICheckStateListener {
 				}
 
 				if (!StringUtils.isAlphaNumeric(input)) {
-					return "The name may only contain lower-case letters and digits.";
+					return "The name may only contain letters and digits.";
 				}
 				return null;
 			}


### PR DESCRIPTION
Removed all occurrences of "lower-case" or "lowercase" when validating
domain and application names (or giving instructions to provide them)
since this restriction is not valid any more (names may contain lower-
and uppercase letters). See JBIDE-13921
