### PR TITLE
[JBIDE-14342] informing user of missing info when no creation log 

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/CreationLogDialog.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/CreationLogDialog.java
@@ -174,6 +174,9 @@ public class CreationLogDialog extends TitleAreaDialog {
 	private void appendLog(LogEntry logEntry, StringBuilder builder,
 			List<StyleRange> styles) {
 		String log = logEntry.getLog();
+		if (StringUtils.isEmpty(log)) {
+			log = "<no information reported by OpenShift>";
+		}
 		createLinks(log, builder.length(), styles);
 		builder.append(log);
 		builder.append(StringUtils.getLineSeparator());


### PR DESCRIPTION
It currently happens that OpenShift does not provide any creation log.
We inform the user with "<no information reported by OpenShift>"
