### PR TITLE
[JBIDE-14569] only check existing remote for existing projects

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPage.java
@@ -420,9 +420,10 @@ public class GitCloningSettingsWizardPage extends AbstractOpenShiftWizardPage im
 			} else if (!remoteName.matches("\\S+")) {
 				return OpenShiftUIActivator.createErrorStatus(
 						"The custom remote name must not contain spaces.");
-			} else if (hasRemoteName(remoteName, getProject(projectName))) {
+			} else if (!pageModel.isNewProject()
+					&& hasRemoteName(remoteName, getProject(projectName))) {
 				return OpenShiftUIActivator.createErrorStatus(NLS.bind(
-						"The existing project already has a remote named {0}.", remoteName));
+						"The project {0} already has a remote named {1}.", projectName, remoteName));
 			}
 			return status;
 		}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
@@ -97,13 +97,6 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 		return wizardModel.isNewProject();
 	}
 
-	
-	/*public void setApplicationName(String name) {
-		firePropertyChange(PROPERTY_APPLICATION_NAME
-				, wizardModel.getApplicationName()
-				, wizardModel.setApplicationName(name));
-	}*/
-
 	public String getApplicationName() {
 		return wizardModel.getApplicationName();
 	}


### PR DESCRIPTION
only check if remote name already exists if we're up to merge with
existing project. When creating a new project, it's not possible that
the remote name is clashing with an existing one
