### PR TITLE
[JBIDE-15054] reintroducing timeouts with high values

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizard.java
@@ -66,6 +66,11 @@ import com.openshift.client.cartridge.IEmbeddedCartridge;
  */
 public abstract class OpenShiftApplicationWizard extends Wizard implements IImportWizard, INewWizard {
 
+	private static final int APP_CREATE_TIMEOUT = 10 * 60 * 1000;
+	private static final int APP_WAIT_TIMEOUT = 10 * 60 * 1000;
+	private static final long EMBED_CARTRIDGES_TIMEOUT = 10 * 60 * 1000;
+	private static final int IMPORT_TIMEOUT = 20 * 60 * 1000;
+
 	private final boolean skipCredentialsPage;
 	private final OpenShiftApplicationWizardModel model;
 
@@ -186,7 +191,7 @@ public abstract class OpenShiftApplicationWizard extends Wizard implements IImpo
 		try {
 			AbstractDelegatingMonitorJob job = new WaitForApplicationJob(application, getShell());
 			IStatus status = WizardUtils.runInWizard(
-					job, job.getDelegatingProgressMonitor(), getContainer());
+					job, job.getDelegatingProgressMonitor(), getContainer(), APP_WAIT_TIMEOUT);
 			return status;
 		} catch (Exception e) {
 			return OpenShiftUIActivator.createErrorStatus(
@@ -198,7 +203,7 @@ public abstract class OpenShiftApplicationWizard extends Wizard implements IImpo
 		try {
 			final DelegatingProgressMonitor delegatingMonitor = new DelegatingProgressMonitor();
 			IStatus jobResult = WizardUtils.runInWizard(
-					new ImportJob(delegatingMonitor), delegatingMonitor, getContainer());
+					new ImportJob(delegatingMonitor), delegatingMonitor, getContainer(), IMPORT_TIMEOUT);
 			return JobUtils.isOk(jobResult);
 		} catch (Exception e) {
 			ErrorDialog.openError(getShell(), "Error", "Could not create local git repository.", OpenShiftUIActivator
@@ -256,7 +261,7 @@ public abstract class OpenShiftApplicationWizard extends Wizard implements IImpo
 					, model.getInitialGitUrl()
 					, model.getConnection().getDefaultDomain());
 			IStatus status = WizardUtils.runInWizard(
-					job, job.getDelegatingProgressMonitor(), getContainer());
+					job, job.getDelegatingProgressMonitor(), getContainer(), APP_CREATE_TIMEOUT);
 			IApplication application = job.getApplication();
 			model.setApplication(application);
 			if (status.isOK()) {
@@ -290,7 +295,7 @@ public abstract class OpenShiftApplicationWizard extends Wizard implements IImpo
 					true, // dont remove cartridges
 					model.getApplication());
 			IStatus result = WizardUtils.runInWizard(
-					job, job.getDelegatingProgressMonitor(), getContainer());
+					job, job.getDelegatingProgressMonitor(), getContainer(), EMBED_CARTRIDGES_TIMEOUT);
 			if (result.isOK()) {
 				openLogDialog(job.getAddedCartridges(), job.isTimeouted(result));
 			}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeStrategyAdapter.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeStrategyAdapter.java
@@ -59,8 +59,8 @@ import com.openshift.client.cartridge.selector.LatestVersionOf;
  */
 public class EmbedCartridgeStrategyAdapter implements ICheckStateListener {
 
-	private static final int APP_CREATE_TIMEOUT = 2 * 60 * 1000;
-	private static final int APP_WAIT_TIMEOUT = 2 * 60 * 1000;
+	private static final int APP_CREATE_TIMEOUT = 10 * 60 * 1000;
+	private static final int APP_WAIT_TIMEOUT = 10 * 60 * 1000;
 
 	private IEmbedCartridgesWizardPageModel pageModel;
 	private IWizardPage wizardPage;

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/embed/EmbedCartridgeWizardPage.java
@@ -57,7 +57,7 @@ import com.openshift.client.cartridge.IEmbeddedCartridge;
  */
 public class EmbedCartridgeWizardPage extends AbstractOpenShiftWizardPage {
 
-	private static final long EMBED_CARTRIDGES_TIMEOUT = 2 * 60 * 1000;
+	private static final long EMBED_CARTRIDGES_TIMEOUT = 10 * 60 * 1000;
 	private EmbedCartridgeWizardPageModel pageModel;
 	private CheckboxTableViewer viewer;
 


### PR DESCRIPTION
WizardUtils#runInWizard uses a default timeout of 2 minutes if no
timeout is given. Therefore we need to pass a timeout in and postpone
the change of WizardUtils to later.
