### PR TITLE
[JBIDE-15484] Provide support for scaled app when tailing log files

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.client/build.properties
+++ b/plugins/org.jboss.tools.openshift.express.client/build.properties
@@ -6,10 +6,4 @@ bin.includes = META-INF/,\
                .options,\
                lib/*,\
                plugin.xml,\
-               log4j.properties,\
-               lib/jboss-dmr-1.0.0.Final.jar,\
-               lib/log4j-1.2.17.jar,\
-               lib/openshift-java-client-2.5.0-SNAPSHOT.jar,\
-               lib/slf4j-api-1.6.1.jar,\
-               lib/slf4j-log4j12-1.6.1.jar
-
+               log4j.properties

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/GearGroupsUtils.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/GearGroupsUtils.java
@@ -1,0 +1,41 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.openshift.express.internal.ui.console;
+
+import java.util.Iterator;
+
+import com.openshift.client.IGearGroup;
+import com.openshift.client.cartridge.ICartridge;
+
+/**
+ * @author xcoulon
+ *
+ */
+public class GearGroupsUtils {
+
+	/**
+	 * Returns a concatenation of the display names of the cartridges of the given {@link IGearGroup}
+	 * @param gearGroup the Gear Group
+	 * @return the cartridges display names, separated by a comma ({@code ,}) character
+	 */
+	public static String getCartridgeDisplayNames(final IGearGroup gearGroup) {
+		final StringBuffer cartridgeNamesBuffer = new StringBuffer();
+		for(Iterator<ICartridge> iterator = gearGroup.getCartridges().iterator(); iterator.hasNext();) {
+			ICartridge cartridge = iterator.next();
+			cartridgeNamesBuffer.append(cartridge.getDisplayName());
+			if(iterator.hasNext()) {
+				cartridgeNamesBuffer.append(", ");
+			}
+		}
+		return cartridgeNamesBuffer.toString();
+	}
+}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/TailFilesWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/TailFilesWizard.java
@@ -10,12 +10,16 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.express.internal.ui.console;
 
+import java.util.Collection;
+
 import org.eclipse.jface.wizard.Wizard;
 
 import com.openshift.client.IApplication;
+import com.openshift.client.IGearGroup;
 
 /**
- * @author Andr?? Dietisheim
+ * @author Andre Dietisheim
+ * @author Xavier Coulon
  */
 public class TailFilesWizard extends Wizard {
 
@@ -28,6 +32,13 @@ public class TailFilesWizard extends Wizard {
 	}
 
 	@Override
+	public boolean canFinish() {
+		final Collection<IGearGroup> selectedGearGroups = getSelectedGearGroups();
+		return selectedGearGroups != null && !selectedGearGroups.isEmpty();
+	}
+	
+	
+	@Override
 	public boolean performFinish() {
 		return true;
 	}
@@ -39,6 +50,14 @@ public class TailFilesWizard extends Wizard {
 	
 	public String getFilePattern() {
 		return model.getFilePattern();
+	}
+
+	/**
+	 * @return true if the 'tail' command be executed on all gears (if the
+	 *         application is scalable), false otherwise.
+	 */
+	public Collection<IGearGroup> getSelectedGearGroups() {
+		return model.getSelectedGearGroups();
 	}
 
 }

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/TailFilesWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/TailFilesWizardPage.java
@@ -10,12 +10,27 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.express.internal.ui.console;
 
+import java.util.Collection;
+
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.viewers.ViewerProperties;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.layout.TableColumnLayout;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.CellLabelProvider;
+import org.eclipse.jface.viewers.CheckboxTableViewer;
+import org.eclipse.jface.viewers.ColumnWeightData;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -23,10 +38,16 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
+import org.jboss.tools.common.ui.WizardUtils;
 import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
+import org.jboss.tools.openshift.express.internal.ui.OpenShiftUIActivator;
 import org.jboss.tools.openshift.express.internal.ui.utils.Logger;
 import org.jboss.tools.openshift.express.internal.ui.wizard.AbstractOpenShiftWizardPage;
+
+import com.openshift.client.IGearGroup;
+import com.openshift.client.NotFoundOpenShiftException;
 
 /**
  * @author Xavier Coulon
@@ -35,6 +56,7 @@ import org.jboss.tools.openshift.express.internal.ui.wizard.AbstractOpenShiftWiz
 public class TailFilesWizardPage extends AbstractOpenShiftWizardPage {
 
 	private final TailFilesWizardPageModel pageModel;
+	private CheckboxTableViewer viewer;
 
 	public TailFilesWizardPage(final TailFilesWizardPageModel pageModel, final IWizard wizard) {
 		super("Tail Log Files", "This will run tail on your OpenShift application '" + pageModel.getApplication().getName() +
@@ -47,7 +69,7 @@ public class TailFilesWizardPage extends AbstractOpenShiftWizardPage {
 	protected void doCreateControls(Composite parent, DataBindingContext dbc) {
 		GridLayoutFactory.fillDefaults().margins(6, 6).applyTo(parent);
 		Composite container = new Composite(parent, SWT.NONE);
-		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).grab(true, true).applyTo(container);
+		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).grab(true, false).applyTo(container);
 		GridLayoutFactory.fillDefaults().numColumns(3).applyTo(container);
 
 		// label
@@ -59,21 +81,107 @@ public class TailFilesWizardPage extends AbstractOpenShiftWizardPage {
 		final Text filePatternText = new Text(container, SWT.BORDER);
 		GridDataFactory.fillDefaults()
 				.align(SWT.FILL, SWT.CENTER).span(1, 1).grab(true, false).applyTo(filePatternText);
-		IObservableValue existingAppNameTextObservable = WidgetProperties.text(SWT.Modify).observe(filePatternText);
-		IObservableValue existingAppNameModelObservable = BeanProperties.value(
+		final IObservableValue filePatternTextObservable = WidgetProperties.text(SWT.Modify).observe(filePatternText);
+		final IObservableValue filePatternModelObservable = BeanProperties.value(
 				TailFilesWizardPageModel.PROPERTY_FILE_PATTERN).observe(pageModel);
-		ValueBindingBuilder.bind(existingAppNameTextObservable).to(existingAppNameModelObservable).in(dbc);
+		ValueBindingBuilder.bind(filePatternTextObservable).to(filePatternModelObservable).in(dbc);
 		// reset button (in case user inputs something and wants/needs to revert)
 		final Button resetButton = new Button(container, SWT.PUSH);
 		resetButton.setText("Reset");
 		GridDataFactory.fillDefaults()
-				.span(1, 1).align(SWT.FILL, SWT.CENTER).grab(false, false).applyTo(resetButton);
+				.hint(100, SWT.DEFAULT).span(1, 1).align(SWT.FILL, SWT.CENTER).grab(false, false).applyTo(resetButton);
 		resetButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				pageModel.resetFilePattern();
 			}
 		});
+		
+		// gears selection container
+		final Composite gearsSelectionContainer = new Composite(container, SWT.NONE);
+		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).span(3, 1)
+			.applyTo(gearsSelectionContainer);
+		GridLayoutFactory.fillDefaults().numColumns(2).applyTo(gearsSelectionContainer);
+		// enable tail logs on all gears at the same time
+		final Label selectGearsLabel = new Label(gearsSelectionContainer, SWT.NONE);
+		selectGearsLabel.setText("Please, select the gears on which you want to tail files:");
+		GridDataFactory.fillDefaults().align(SWT.LEFT, SWT.CENTER).grab(true, false).span(2, 1)
+				.applyTo(selectGearsLabel);
+		
+		final Composite tableContainer = new Composite(gearsSelectionContainer, SWT.NONE);
+		GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).grab(true, true).span(1, 2)
+			.applyTo(tableContainer);
+		this.viewer = createTable(tableContainer);
+		dbc.bindSet(
+				ViewerProperties.checkedElements(IGearGroup.class).observe(viewer),
+				BeanProperties.set(
+						TailFilesWizardPageModel.PROPERTY_SELECTED_GEAR_GROUPS)
+						.observe(pageModel));
+		final Button selectAllButton = new Button(gearsSelectionContainer, SWT.PUSH);
+		selectAllButton.setText("Select all");
+		selectAllButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				pageModel.selectAllGears(); 
+			}
+		});
+		GridDataFactory.fillDefaults()
+				.hint(100, SWT.DEFAULT).align(SWT.FILL, SWT.TOP).grab(false, false).applyTo(selectAllButton);
+		final Button deselectAllButton = new Button(gearsSelectionContainer, SWT.PUSH);
+		deselectAllButton.setText("Deselect all");
+		deselectAllButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				pageModel.deselectAllGears();
+			}
+		});
+
+		GridDataFactory.fillDefaults()
+				.hint(100, SWT.DEFAULT).align(SWT.FILL, SWT.TOP).grab(false, false).applyTo(deselectAllButton);		
+
+	}
+	
+	private CheckboxTableViewer createTable(Composite tableContainer) {
+		Table table =
+				new Table(tableContainer, SWT.BORDER | SWT.FULL_SELECTION | SWT.V_SCROLL | SWT.H_SCROLL | SWT.CHECK);
+		table.setHeaderVisible(true);
+		table.setLinesVisible(true);
+		TableColumnLayout tableLayout = new TableColumnLayout();
+		tableContainer.setLayout(tableLayout);
+		CheckboxTableViewer viewer = new CheckboxTableViewer(table);
+		viewer.setContentProvider(new ArrayContentProvider());
+		createTableColumn("Cartridges", 5, SWT.LEFT, new CellLabelProvider() {
+			@Override
+			public void update(ViewerCell cell) {
+				final IGearGroup gearGroup = (IGearGroup) cell.getElement();
+				final String cartridgeNames = GearGroupsUtils.getCartridgeDisplayNames(gearGroup);
+				cell.setText(cartridgeNames);
+			}
+		}, viewer, tableLayout);
+		createTableColumn("Number of Gears", 3, SWT.RIGHT, new CellLabelProvider() {
+			@Override
+			public void update(ViewerCell cell) {
+				final IGearGroup gearGroup = (IGearGroup) cell.getElement();
+				cell.setText(Integer.toString(gearGroup.getGears().size()));
+			}
+		}, viewer, tableLayout);
+		createTableColumn("", 1, SWT.RIGHT, new CellLabelProvider(){
+			@Override
+			public void update(ViewerCell cell) {
+			}
+		}, viewer, tableLayout);
+		return viewer;
+	}
+	
+	private void createTableColumn(String name, int weight, int alignment, CellLabelProvider cellLabelProvider, TableViewer viewer,
+			TableColumnLayout layout) {
+		TableViewerColumn column = new TableViewerColumn(viewer, SWT.LEFT);
+		column.getColumn().setText(name);
+		column.getColumn().setAlignment(alignment);
+		if(cellLabelProvider != null) {
+			column.setLabelProvider(cellLabelProvider);
+		}
+		layout.setColumnData(column.getColumn(), new ColumnWeightData(weight, true));
 	}
 
 	// private SelectionListener onCheckAll() {
@@ -105,17 +213,46 @@ public class TailFilesWizardPage extends AbstractOpenShiftWizardPage {
 	// };
 	// }
 
-	private void resetFilePatternText() {
-//		pageModel.resetFilePattern();
-	}
-	
 	@Override
 	protected void onPageActivated(DataBindingContext dbc) {
 		try {
-			resetFilePatternText();
+			loadApplicationGearGroups(dbc);
 		} catch (Exception e) {
 			Logger.error("Could not reset File Pattern text field", e);
 		}
+	}
+
+	private void loadApplicationGearGroups(final DataBindingContext dbc) {
+		try {
+			WizardUtils.runInWizard(new Job("Loading gear groups for application '" + pageModel.getApplication().getName() + "'...") {
+				@Override
+				protected IStatus run(IProgressMonitor monitor) {
+					try {
+						pageModel.loadGearGroups();
+						setViewerInput(pageModel.getGearGroups());
+						return Status.OK_STATUS;
+					} catch (NotFoundOpenShiftException e) {
+						return Status.OK_STATUS;
+					} catch (Exception e) {
+						return OpenShiftUIActivator.createErrorStatus(
+								"Could not load application's gear list", e);
+					}
+				}
+			}, getContainer(), dbc);
+		} catch (Exception ex) {
+			// ignore
+		}
+	}
+	
+	private void setViewerInput(final Collection<IGearGroup> gearGroups) {
+		getShell().getDisplay().syncExec(new Runnable() {
+			@Override
+			public void run() {
+				if (viewer != null) {
+					viewer.setInput(gearGroups);
+				}
+			}
+		});
 	}
 
 }

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/TailFilesWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/console/TailFilesWizardPageModel.java
@@ -10,25 +10,43 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.express.internal.ui.console;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jboss.tools.common.ui.databinding.ObservableUIPojo;
 import org.jboss.tools.openshift.express.internal.core.preferences.OpenShiftPreferences;
+import org.jboss.tools.openshift.express.internal.core.util.StringUtils;
 
 import com.openshift.client.IApplication;
+import com.openshift.client.IGearGroup;
+import com.openshift.client.cartridge.ICartridge;
+import com.openshift.client.cartridge.IStandaloneCartridge;
 
 /**
  * @author Andre Dietisheim
  */
 public class TailFilesWizardPageModel extends ObservableUIPojo {
 
+	private static final String DEFAULT_FILE_PATTERN = "-f -n 100 */logs/*";
+
 	public static final String PROPERTY_FILE_PATTERN = "filePattern";
 
+	public static final String PROPERTY_GEAR_GROUPS = "gearGroups";
+
+	public static final String PROPERTY_SELECTED_GEAR_GROUPS = "selectedGearGroups";
+	
 	private final IApplication application;
 
-	private String filePattern;
+	private String filePattern = DEFAULT_FILE_PATTERN;
+
+	private Collection<IGearGroup> gearGroups;
+
+	private Collection<IGearGroup> selectedGearGroups;
 
 	public TailFilesWizardPageModel(final IApplication app) {
 		this.application = app;
-		this.filePattern = OpenShiftPreferences.INSTANCE.getTailFileOptions(application);
+		setFilePattern(ensureValidDefault(OpenShiftPreferences.INSTANCE.getTailFileOptions(application)));
 	}
 
 	public void setFilePattern(final String filePattern) {
@@ -42,11 +60,70 @@ public class TailFilesWizardPageModel extends ObservableUIPojo {
 	}
 
 	public void resetFilePattern() {
-		setFilePattern(OpenShiftPreferences.INSTANCE.getTailFileOptions(null));
+		setFilePattern(ensureValidDefault(null));
+	}
+
+	private String ensureValidDefault(String filePattern) {
+		if (StringUtils.isEmpty(filePattern)) {
+			return DEFAULT_FILE_PATTERN;
+		}
+		return filePattern;
 	}
 
 	public IApplication getApplication() {
 		return application;
 	}
 
+	/**
+	 * Loads and refresh the {@link IGearGroup} for the current application
+	 */
+	public void loadGearGroups() {
+		setGearGroups(application.getGearGroups());
+	}
+
+	/**
+	 * @return the gearGroups
+	 */
+	public Collection<IGearGroup> getGearGroups() {
+		return gearGroups;
+	}
+	
+	/**
+	 * @param gearGroups the gearGroups to set
+	 */
+	public void setGearGroups(final Collection<IGearGroup> gearGroups) {
+		firePropertyChange(
+				PROPERTY_GEAR_GROUPS, this.gearGroups, this.gearGroups = gearGroups);
+		// pre-select gear groups that contain the main (Standalone cartridge)
+		Set<IGearGroup> selectedGearGroups = new HashSet<IGearGroup>();
+		for(IGearGroup gearGroup : gearGroups) {
+			for(ICartridge cartridge : gearGroup.getCartridges()) {
+				if(cartridge instanceof IStandaloneCartridge) {
+					selectedGearGroups.add(gearGroup);
+					continue;
+				}
+			}
+		}
+		setSelectedGearGroups(selectedGearGroups);
+	}
+
+	/**
+	 * @return the selected {@link IGearGroup} in the UI.
+	 */
+	public Collection<IGearGroup> getSelectedGearGroups() {
+		return this.selectedGearGroups;
+	}
+	
+	public void setSelectedGearGroups(final Collection<IGearGroup> selectedGearGroups) {
+		firePropertyChange(
+				PROPERTY_SELECTED_GEAR_GROUPS, this.selectedGearGroups, this.selectedGearGroups = selectedGearGroups);
+	}
+
+	public void selectAllGears() {
+		setSelectedGearGroups(new HashSet<IGearGroup>(getGearGroups()));
+	}
+
+	public void deselectAllGears() {
+		setSelectedGearGroups(new HashSet<IGearGroup>());
+	}
 }


### PR DESCRIPTION
Added a table in the wizard page to let the user select the gear(s) on
which the 'tail' command should be executed.
The table displays the name of the cartridges for each GearGroup along
with the number of gears that each group consumes.
The content is the table is refreshed each time the wizard is opened.
