### PR TITLE
[JBIDE-15708] lookup connection for default and non-default host

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/connection/ConnectionsModel.java
+++ b/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/connection/ConnectionsModel.java
@@ -177,6 +177,14 @@ public class ConnectionsModel {
 		return recentConnection;
 	}
 
+	/**
+	 * Returns the connection for a given application (OpenShift REST resource).
+	 * 
+	 * @param application the openshift application that we want the connection for
+	 * @return the connection that this applicaiton belongs to.
+	 * 
+	 * @throws OpenShiftCoreException
+	 */
 	public Connection getConnectionByResource(IApplication application) {
 		if (application == null) {
 			return null;
@@ -184,14 +192,28 @@ public class ConnectionsModel {
 		
 		return getConnectionByResource(application.getDomain().getUser());
 	}
-	
+
+	/**
+	 * Returns the connection for a given user (OpenShift REST resource).
+	 * 
+	 * @param user the openshift user
+	 * @return the connection that this user belongs to.
+	 * 
+	 * @throws OpenShiftCoreException
+	 */
 	public Connection getConnectionByResource(IUser user) throws OpenShiftCoreException {
 		if (user == null) {
 			return null;
 		}
 		try {
 			ConnectionURL connectionUrl = ConnectionURL.forUsernameAndServer(user.getRhlogin(), user.getServer());
-			return connectionsByUrl.get(connectionUrl);
+			Connection c = connectionsByUrl.get(connectionUrl);
+			String defHost = ConnectionUtils.getDefaultHostUrl();
+			if (c == null && defHost.equals(user.getServer())) {
+				connectionUrl = ConnectionURL.forUsername(user.getRhlogin());
+				c = connectionsByUrl.get(connectionUrl);
+			}
+			return c;
 		} catch (UnsupportedEncodingException e) {
 			throw new OpenShiftCoreException(e, 
 					NLS.bind(

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/connection/ConnectionsModelTest.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/core/connection/ConnectionsModelTest.java
@@ -184,6 +184,35 @@ public class ConnectionsModelTest {
 	}
 
 	@Test
+	public void shouldGetConnectionByUsername() throws UnsupportedEncodingException {
+		// pre-conditions
+		String username = "adietisheim";
+		Connection connection = new ConnectionFake(username);
+		connectionsModel.addConnection(connection);
+
+		// operations
+		Connection queriedConnection = connectionsModel.getConnectionByUsername(username);
+
+		// verifications
+		assertEquals(connection, queriedConnection);
+	}
+
+	@Test
+	public void shouldNotGetConnectionByUsername() throws UnsupportedEncodingException {
+		// pre-conditions
+		String username = "adietisheim";
+		String host = "fakeHost";
+		Connection connection = new ConnectionFake(username, host);
+		connectionsModel.addConnection(connection);
+
+		// operations
+		Connection queriedConnection = connectionsModel.getConnectionByUsername(username);
+
+		// verifications
+		assertEquals(null, queriedConnection);
+	}
+
+	@Test
 	public void shouldGetConnectionByUserResource() throws UnsupportedEncodingException, MalformedURLException {
 		// pre-conditions
 		final String server = "http://localhost";
@@ -211,32 +240,30 @@ public class ConnectionsModelTest {
 	}
 
 	@Test
-	public void shouldGetConnectionByUsername() throws UnsupportedEncodingException {
+	public void shouldGetConnectionByUserResourceWithDefaultHost() throws UnsupportedEncodingException, MalformedURLException {
 		// pre-conditions
-		String username = "adietisheim";
-		Connection connection = new ConnectionFake(username);
+		final String server = ConnectionUtils.getDefaultHostUrl();
+		final String username = "adietish@redhat.com";
+		Connection connection = new ConnectionFake(username, null);
 		connectionsModel.addConnection(connection);
+		IUser user = new NoopUserFake() {
+
+			@Override
+			public String getServer() {
+				return server;
+			}
+
+			@Override
+			public String getRhlogin() {
+				return username;
+			}
+		};
 
 		// operations
-		Connection queriedConnection = connectionsModel.getConnectionByUsername(username);
+		Connection queriedConnection = connectionsModel.getConnectionByResource(user);
 
 		// verifications
 		assertEquals(connection, queriedConnection);
-	}
-
-	@Test
-	public void shouldNotGetConnectionByUsername() throws UnsupportedEncodingException {
-		// pre-conditions
-		String username = "adietisheim";
-		String host = "fakeHost";
-		Connection connection = new ConnectionFake(username, host);
-		connectionsModel.addConnection(connection);
-
-		// operations
-		Connection queriedConnection = connectionsModel.getConnectionByUsername(username);
-
-		// verifications
-		assertEquals(null, queriedConnection);
 	}
 
 	@Test
@@ -355,4 +382,31 @@ public class ConnectionsModelTest {
 		assertEquals("http://toolsjboss%40gmail.com@openshift.local", customHosts.get(0));
 	}
 
+	@Test
+	public void shouldGetConnectionByResource() throws UnsupportedEncodingException {
+		// pre-conditions
+		final String username = "adietisheim";
+		final String hostUrl = "http://fakeHost";
+		IUser user = new NoopUserFake() {
+
+			@Override
+			public String getServer() {
+				return hostUrl;
+			}
+
+			@Override
+			public String getRhlogin() {
+				return username;
+			}
+			
+		};
+		Connection connection = new ConnectionFake(username, hostUrl);
+		connectionsModel.addConnection(connection);
+
+		// operations
+		Connection queriedConnection = connectionsModel.getConnectionByResource(user);
+
+		// verifications
+		assertEquals(connection, queriedConnection);
+	}
 }


### PR DESCRIPTION
When the user being searched for is using the default host, make sure to
search the connection map for both a full connection url or a truncated
one (implying default host).
