### PR TITLE
JBIDE-16080 - VerifySSHSessionJob display name is sometimes inappropriate

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/job/VerifySSHSessionJob.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/job/VerifySSHSessionJob.java
@@ -33,7 +33,7 @@ public class VerifySSHSessionJob extends Job {
 	private boolean validSession = false;
 
 	public VerifySSHSessionJob(final IApplication application) {
-		super("Verifying SSH session to retrieve Application's ports...");
+		super("Verifying SSH session...");
 		this.application = application;
 	}
 


### PR DESCRIPTION
Changed the label to something more generic.
