### PR TITLE
JBIDE-10861 : use selected project by default

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizard.java
@@ -46,6 +46,7 @@ import org.jboss.tools.openshift.express.internal.ui.WontOverwriteException;
 import org.jboss.tools.openshift.express.internal.ui.job.AbstractDelegatingMonitorJob;
 import org.jboss.tools.openshift.express.internal.ui.job.CreateApplicationJob;
 import org.jboss.tools.openshift.express.internal.ui.job.WaitForApplicationJob;
+import org.jboss.tools.openshift.express.internal.ui.utils.UIUtils;
 import org.jboss.tools.openshift.express.internal.ui.wizard.CreationLogDialog;
 import org.jboss.tools.openshift.express.internal.ui.wizard.CreationLogDialog.LogEntry;
 import org.jboss.tools.openshift.express.internal.ui.wizard.LogEntryFactory;
@@ -107,6 +108,16 @@ public abstract class OpenShiftApplicationWizard extends Wizard implements IImpo
 
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
+		if (!UIUtils.isSingleSelection(selection)) {
+			return; // we can't decide which selected project to use
+			// Note that we could try to be more clever and check if multiple selection 
+			// contains only one open project
+		}
+		
+		IProject project = UIUtils.getFirstElement(selection, IProject.class);
+		if (project != null && project.isAccessible()) {
+			getModel().setProject(project);
+		}
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
@@ -563,7 +563,7 @@ public class OpenShiftApplicationWizardModel extends ObservableUIPojo implements
 		setApplication(getDefaultApplication());
 		setUseExistingApplication(getDefaultUseExistingApplication());
 		setSelectedEmbeddableCartridges(new HashSet<IEmbeddableCartridge>());
-		setNewProject(true);
+		setNewProject(getProject() == null);
 		setCreateServerAdapter(true);
 		setSkipMavenBuild(false);
 		setRepositoryPath(IOpenShiftWizardModel.DEFAULT_REPOSITORY_PATH);

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ProjectAndServerAdapterSettingsWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ProjectAndServerAdapterSettingsWizardPageModel.java
@@ -40,7 +40,7 @@ public class ProjectAndServerAdapterSettingsWizardPageModel extends ObservableUI
 
 	public ProjectAndServerAdapterSettingsWizardPageModel(IOpenShiftWizardModel wizardModel) {
 		this.wizardModel = wizardModel;
-		setNewProject(true);
+		setNewProject(wizardModel.getProject() == null);
 		wizardModel.addPropertyChangeListener(IOpenShiftWizardModel.PROP_APPLICATION_NAME, onWizardApplicationNameChanged());
 	}
 


### PR DESCRIPTION
- selecting 1 project + create New Openshift Application unchecks the "create new project" in the wizard and uses the proper name
- selecting 2 projects does nothing
- selecting 1 closed project does nothing
- selecting 1 project + create New Openshift Application from Openshift Explorer does nothing

Signed-off-by: Fred Bricon fbricon@gmail.com
