### PR TITLE
[JBIDE-15665] make sure outputFolder in maven profile matches app type

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/behaviour/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/behaviour/OpenShiftServerUtils.java
@@ -59,13 +59,13 @@ import org.jboss.tools.openshift.express.internal.core.OpenShiftCoreActivator;
 import org.jboss.tools.openshift.express.internal.core.connection.Connection;
 import org.jboss.tools.openshift.express.internal.core.connection.ConnectionURL;
 import org.jboss.tools.openshift.express.internal.core.connection.ConnectionsModelSingleton;
+import org.jboss.tools.openshift.express.internal.core.util.DeployFolder;
 import org.jboss.tools.openshift.express.internal.core.util.StringUtils;
 import org.osgi.service.prefs.BackingStoreException;
 
 import com.openshift.client.IApplication;
 import com.openshift.client.IDomain;
 import com.openshift.client.OpenShiftException;
-import com.openshift.client.cartridge.IStandaloneCartridge;
 
 /**
  * This class holds the attribute names whose values will be stored inside a
@@ -231,36 +231,6 @@ public class OpenShiftServerUtils {
 		return getDefaultDeployFolder(getApplication(server));
 	}
 	
-	private enum DeployFolder {
-		JBOSSAS(IStandaloneCartridge.NAME_JBOSSAS, "deployments"), 
-		JBOSSEAP(IStandaloneCartridge.NAME_JBOSSEAP, "deployments"), 
-		JBOSSEWS(IStandaloneCartridge.NAME_JBOSSEWS, "webapps");
-
-		private String cartridgeName;
-		private String deployFolder;
-
-		DeployFolder(String cartridgeName, String deployFolder) {
-			this.cartridgeName = cartridgeName;
-			this.deployFolder = deployFolder;
-		}
-		
-		public String getDeployFolder() {
-			return deployFolder;
-		}
-		
-		public static DeployFolder getByCartridgeName(String cartridgeName) {
-			if (cartridgeName == null) {
-				return null;
-			}
-			
-			for (DeployFolder deployFolder : values()) {
-				if (cartridgeName.startsWith(deployFolder.cartridgeName)) {
-					return deployFolder;
-				}
-			}
-			return null;
-		}
-	}
 	
 	public static String getDefaultDeployFolder(IApplication application) {
 		Assert.isNotNull(application);

--- a/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/util/DeployFolder.java
+++ b/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/util/DeployFolder.java
@@ -1,0 +1,48 @@
+/******************************************************************************* 
+ * Copyright (c) 2012 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.internal.core.util;
+
+import com.openshift.client.cartridge.IStandaloneCartridge;
+
+/**
+ * @author Andre Dietisheim
+ */
+public enum DeployFolder {
+
+	JBOSSAS(IStandaloneCartridge.NAME_JBOSSAS, "deployments"), 
+	JBOSSEAP(IStandaloneCartridge.NAME_JBOSSEAP, "deployments"), 
+	JBOSSEWS(IStandaloneCartridge.NAME_JBOSSEWS, "webapps");
+
+	private String cartridgeName;
+	private String deployFolder;
+
+	DeployFolder(String cartridgeName, String deployFolder) {
+		this.cartridgeName = cartridgeName;
+		this.deployFolder = deployFolder;
+	}
+	
+	public String getDeployFolder() {
+		return deployFolder;
+	}
+	
+	public static DeployFolder getByCartridgeName(String cartridgeName) {
+		if (cartridgeName == null) {
+			return null;
+		}
+		
+		for (DeployFolder deployFolder : values()) {
+			if (cartridgeName.startsWith(deployFolder.cartridgeName)) {
+				return deployFolder;
+			}
+		}
+		return null;
+	}
+}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/AbstractImportApplicationOperation.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/AbstractImportApplicationOperation.java
@@ -40,6 +40,7 @@ import org.jboss.tools.openshift.egit.ui.util.EGitUIUtils;
 import org.jboss.tools.openshift.express.internal.core.behaviour.OpenShiftServerUtils;
 import org.jboss.tools.openshift.express.internal.core.connection.Connection;
 import org.jboss.tools.openshift.express.internal.core.marker.IOpenShiftMarker;
+import org.jboss.tools.openshift.express.internal.core.util.DeployFolder;
 import org.jboss.tools.openshift.express.internal.ui.OpenShiftUIActivator;
 import org.jboss.tools.openshift.express.internal.ui.OpenShiftUIException;
 
@@ -240,7 +241,7 @@ abstract class AbstractImportApplicationOperation implements IImportApplicationS
 		EGitUtils.addRemoteTo(getRemoteName(), getApplication().getGitUrl(), repository);
 	}
 	
-	protected IResource setupOpenShiftMavenProfile(IProject project, IProgressMonitor monitor) throws CoreException {
+	protected IResource setupOpenShiftMavenProfile(IApplication application, IProject project, IProgressMonitor monitor) throws CoreException {
 		if (!OpenShiftMavenProfile.isMavenProject(project)) {
 			return null;
 		}
@@ -249,8 +250,17 @@ abstract class AbstractImportApplicationOperation implements IImportApplicationS
 		if (profile.existsInPom()) {
 			return null;
 		}
-		profile.addToPom(project.getName());
+		
+		profile.addToPom(project.getName(), getDeployFolder(application));
 		return profile.savePom(monitor);
+	}
+
+	private String getDeployFolder(IApplication application) {
+		DeployFolder deployFolder = DeployFolder.getByCartridgeName(application.getCartridge().getName());
+		if (deployFolder == null) {
+			return null;
+		}
+		return deployFolder.getDeployFolder();
 	}
 
 	protected List<IResource> setupMarkers(IProject project, IProgressMonitor monitor) throws CoreException {

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/MergeIntoGitSharedProject.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/MergeIntoGitSharedProject.java
@@ -100,7 +100,7 @@ public class MergeIntoGitSharedProject extends AbstractImportApplicationOperatio
 
 		addToModified(copyOpenshiftConfigurations(getApplication(), getRemoteName(), project, monitor));
 		addToModified(setupGitIgnore(project, monitor));
-		addToModified(setupOpenShiftMavenProfile(project, monitor));
+		addToModified(setupOpenShiftMavenProfile(getApplication(), project, monitor));
 		addSettingsFile(project, monitor);
 		addToModified(setupMarkers(project, monitor));
 

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/MergeIntoUnsharedProject.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/MergeIntoUnsharedProject.java
@@ -94,7 +94,7 @@ public class MergeIntoUnsharedProject extends AbstractImportApplicationOperation
 
 		copyOpenshiftConfigurations(getApplication(), getRemoteName(), project, monitor);
 		setupGitIgnore(project, monitor);
-		setupOpenShiftMavenProfile(project, monitor);
+		setupOpenShiftMavenProfile(getApplication(), project, monitor);
 		addSettingsFile(project, monitor);
 		setupMarkers(project, monitor);
 		shareProject(project, monitor);

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/OpenShiftMavenProfile.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/importoperation/OpenShiftMavenProfile.java
@@ -69,7 +69,7 @@ public class OpenShiftMavenProfile {
 					+ "       <artifactId>maven-war-plugin</artifactId>\n"
 					+ "       <version>2.2</version>\n"
 					+ "       <configuration>\n"
-					+ "         <outputDirectory>deployments</outputDirectory>\n"
+					+ "         <outputDirectory>{1}</outputDirectory>\n"
 					+ "         <warName>ROOT</warName>\n"
 					+ "       </configuration>\n"
 					+ "     </plugin>\n"
@@ -160,19 +160,20 @@ public class OpenShiftMavenProfile {
 	/**
 	 * Adds the openshift profile to the pom this is instance is bound to.
 	 * Returns <code>true</code> if it was added, <code>false</code> otherwise.
+	 * @param string 
 	 * 
 	 * @return true if the profile was added to the pom this instance is bound
 	 *         to.
 	 * @throws CoreException
 	 */
-	public boolean addToPom(String finalName) throws CoreException {
+	public boolean addToPom(String finalName, String outputDirectory) throws CoreException {
 		try {
 			if (existsInPom()) {
 				return false;
 			}
 			Document document = getDocument();
 			Element profilesElement = getOrCreateProfilesElement(document);
-			Node profileNode = document.importNode(createOpenShiftProfileElement(finalName), true);
+			Node profileNode = document.importNode(createOpenShiftProfileElement(finalName, outputDirectory), true);
 			profilesElement.appendChild(profileNode);
 			return true;
 		} catch (SAXException e) {
@@ -184,16 +185,15 @@ public class OpenShiftMavenProfile {
 		}
 	}
 
-	private Element createOpenShiftProfileElement(String finalName) throws ParserConfigurationException, SAXException,
+	private Element createOpenShiftProfileElement(String finalName, String outputDirectory) throws ParserConfigurationException, SAXException,
 			IOException {
 		DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		String openShiftProfile = MessageFormat.format(getProfileTemplate(), finalName);
+		String openShiftProfile = MessageFormat.format(getProfileTemplate(), finalName, outputDirectory);
 		Document document = documentBuilder.parse(new ByteArrayInputStream(openShiftProfile.getBytes()));
 		return document.getDocumentElement();
 	}
 
 	private String getProfileTemplate() {
-		
 		return OPENSHIFT_WAR_PROFILE;
 	}
 

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/ui/wizard/application/importoperation/OpenShiftMavenProfileTests.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/ui/wizard/application/importoperation/OpenShiftMavenProfileTests.java
@@ -38,7 +38,10 @@ public class OpenShiftMavenProfileTests {
 
 	private static final String PLUGIN_ID = "org.jboss.tools.openshift.express.test";
 	private static final String POM_FILENAME = "pom.xml";
-
+	private static final String JBOSSAS_DEPLOYMENTS_FOLDER = "deployments";
+	private static final String JBOSSEWS_DEPLOYMENTS_FOLDER = "webapps";
+	private static final String OUTPUT_DIRECTORY_TAG = "<outputDirectory>";
+	
 	private static final String POM_WITHOUT_OPENSHIFT =
 			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 					+ "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" "
@@ -314,14 +317,14 @@ public class OpenShiftMavenProfileTests {
 	@Test
 	public void canAddOpenShiftProfile() throws CoreException {
 		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(pomWithoutOpenShiftProfile, PLUGIN_ID);
-		boolean added = profile.addToPom(nonOpenShiftProject.getName());
+		boolean added = profile.addToPom(nonOpenShiftProject.getName(), JBOSSAS_DEPLOYMENTS_FOLDER);
 		assertTrue(added);
 	}
 
 	@Test
 	public void pomHasOpenShiftProfileAfterAdd() throws CoreException {
 		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(pomWithoutOpenShiftProfile, PLUGIN_ID);
-		profile.addToPom(nonOpenShiftProject.getName());
+		profile.addToPom(nonOpenShiftProject.getName(), JBOSSAS_DEPLOYMENTS_FOLDER);
 		profile.savePom(new NullProgressMonitor());
 		profile = new OpenShiftMavenProfile(pomWithoutOpenShiftProfile, PLUGIN_ID);
 		assertTrue(profile.existsInPom());
@@ -330,7 +333,7 @@ public class OpenShiftMavenProfileTests {
 	@Test
 	public void canAddOpenShiftProfileToComplexPom() throws CoreException, IOException {
 		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(nonOpenShiftProfilesProject, PLUGIN_ID);
-		boolean added = profile.addToPom(nonOpenShiftProfilesProject.getName());
+		boolean added = profile.addToPom(nonOpenShiftProfilesProject.getName(), JBOSSAS_DEPLOYMENTS_FOLDER);
 		assertTrue(added);
 		profile.savePom(new NullProgressMonitor());
 		profile = new OpenShiftMavenProfile(nonOpenShiftProfilesProject, PLUGIN_ID);
@@ -340,7 +343,7 @@ public class OpenShiftMavenProfileTests {
 	@Test
 	public void addedOpenShiftProfileIsCorrect() throws CoreException, IOException {
 		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(nonOpenShiftProfilesProject, PLUGIN_ID);
-		boolean added = profile.addToPom(nonOpenShiftProfilesProject.getName());
+		boolean added = profile.addToPom(nonOpenShiftProfilesProject.getName(), JBOSSAS_DEPLOYMENTS_FOLDER);
 		assertTrue(added);
 		profile.savePom(new NullProgressMonitor());
 		String pomContent = toString(nonOpenShiftProfilesProject.getFile(POM_FILENAME));
@@ -348,9 +351,33 @@ public class OpenShiftMavenProfileTests {
 	}
 
 	@Test
+	public void addedOpenShiftProfileHasDeploymentsOutputDirectory() throws CoreException, IOException {
+		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(nonOpenShiftProfilesProject, PLUGIN_ID);
+		boolean added = profile.addToPom(nonOpenShiftProfilesProject.getName(), JBOSSAS_DEPLOYMENTS_FOLDER);
+		assertTrue(added);
+		profile.savePom(new NullProgressMonitor());
+		String pomContent = toString(nonOpenShiftProfilesProject.getFile(POM_FILENAME));
+		int tagIndex = pomContent.indexOf(OUTPUT_DIRECTORY_TAG);
+		assertTrue(tagIndex >= 0);
+		assertTrue(pomContent.substring(tagIndex + OUTPUT_DIRECTORY_TAG.length()).startsWith(JBOSSAS_DEPLOYMENTS_FOLDER));
+	}
+
+	@Test
+	public void addedOpenShiftProfileHasWebappsOutputDirectory() throws CoreException, IOException {
+		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(nonOpenShiftProfilesProject, PLUGIN_ID);
+		boolean added = profile.addToPom(nonOpenShiftProfilesProject.getName(), JBOSSEWS_DEPLOYMENTS_FOLDER);
+		assertTrue(added);
+		profile.savePom(new NullProgressMonitor());
+		String pomContent = toString(nonOpenShiftProfilesProject.getFile(POM_FILENAME));
+		int tagIndex = pomContent.indexOf(OUTPUT_DIRECTORY_TAG);
+		assertTrue(tagIndex >= 0);
+		assertTrue(pomContent.substring(tagIndex + OUTPUT_DIRECTORY_TAG.length()).startsWith(JBOSSEWS_DEPLOYMENTS_FOLDER));
+	}
+
+	@Test
 	public void doesNotAddOpenShiftProfileIfAlreadyPresent() throws CoreException {
 		OpenShiftMavenProfile profile = new OpenShiftMavenProfile(pomWithOpenShiftProfile, PLUGIN_ID);
-		boolean added = profile.addToPom(openShiftProject.getName());
+		boolean added = profile.addToPom(openShiftProject.getName(), JBOSSAS_DEPLOYMENTS_FOLDER);
 		assertFalse(added);
 	}
 


### PR DESCRIPTION
We have to make sure that the maven profile that we add to a project is
using the correct outputFolder for the app that we're using (ex.
jbossas: deployments, jbossews: webapps
