### PR TITLE
[JBIDE-17106] fixed CodeAnythingCartridge not being removable from set

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/core/CodeAnythingCartridge.java
+++ b/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/core/CodeAnythingCartridge.java
@@ -56,29 +56,4 @@ public class CodeAnythingCartridge extends BaseCartridge implements IStandaloneC
 	public boolean isDownloadable() {
 		return true;
 	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + ((urlString == null) ? 0 : urlString.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (!super.equals(obj))
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		CodeAnythingCartridge other = (CodeAnythingCartridge) obj;
-		if (urlString == null) {
-			if (other.urlString != null)
-				return false;
-		} else if (!urlString.equals(other.urlString))
-			return false;
-		return true;
-	}
 }


### PR DESCRIPTION
Fixed it by removing the erroneous #hashCode and #equals methods that
overrode the correct ones in BaseCartridge superclass
