### PR TITLE
[JBIDE-17226] corrected cropping in application wizard

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/utils/DialogChildVisibilityAdapter.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/utils/DialogChildVisibilityAdapter.java
@@ -28,7 +28,7 @@ import org.eclipse.swt.widgets.Shell;
  * 
  * @author Andre Dietisheim
  */
-public class DialogChildToggleAdapter {
+public class DialogChildVisibilityAdapter {
 
 	private boolean visible;
 	private final Composite composite;
@@ -37,7 +37,7 @@ public class DialogChildToggleAdapter {
 	private int invisibleChildShellHeight;
 	private boolean resizing;
 	
-	public DialogChildToggleAdapter(Composite child, boolean visible) {
+	public DialogChildVisibilityAdapter(Composite child, boolean visible) {
 		Assert.isTrue(child != null && !child.isDisposed());
 		this.composite = child;
 		Object layoutData = child.getLayoutData();
@@ -58,7 +58,7 @@ public class DialogChildToggleAdapter {
 			@Override
 			public void controlResized(ControlEvent e) {
 				if (!resizing) {
-					DialogChildToggleAdapter.this.invisibleChildShellHeight = shell.getSize().y;
+					DialogChildVisibilityAdapter.this.invisibleChildShellHeight = shell.getSize().y;
 				}
 			}
 

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationConfigurationWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationConfigurationWizardPage.java
@@ -76,7 +76,7 @@ import org.jboss.tools.openshift.express.internal.ui.databinding.RequiredControl
 import org.jboss.tools.openshift.express.internal.ui.databinding.TrimmingStringConverter;
 import org.jboss.tools.openshift.express.internal.ui.explorer.AbstractLabelProvider;
 import org.jboss.tools.openshift.express.internal.ui.job.AbstractDelegatingMonitorJob;
-import org.jboss.tools.openshift.express.internal.ui.utils.DialogChildToggleAdapter;
+import org.jboss.tools.openshift.express.internal.ui.utils.DialogChildVisibilityAdapter;
 import org.jboss.tools.openshift.express.internal.ui.utils.Logger;
 import org.jboss.tools.openshift.express.internal.ui.utils.TableViewerBuilder;
 import org.jboss.tools.openshift.express.internal.ui.utils.TableViewerBuilder.IColumnLabelProvider;
@@ -113,7 +113,7 @@ public class ApplicationConfigurationWizardPage extends AbstractOpenShiftWizardP
 	private Text applicationNameText;
 	private OpenShiftApplicationWizardModel wizardModel;
 	private Button advancedButton;
-	private DialogChildToggleAdapter advancedSectionVisibilityAdapter;
+	private DialogChildVisibilityAdapter advancedSectionVisibilityAdapter;
 
 	ApplicationConfigurationWizardPage(IWizard wizard, OpenShiftApplicationWizardModel wizardModel) {
 		super("New or existing OpenShift Application", "", "New or existing OpenShift Application, wizard", wizard);
@@ -556,7 +556,7 @@ public class ApplicationConfigurationWizardPage extends AbstractOpenShiftWizardP
 		ControlDecorationSupport.create(
 				sourceCodeUrlValidator, SWT.LEFT | SWT.TOP, null, new RequiredControlDecorationUpdater());
 
-		this.advancedSectionVisibilityAdapter = new DialogChildToggleAdapter(advancedComposite, false);
+		this.advancedSectionVisibilityAdapter = new DialogChildVisibilityAdapter(advancedComposite, false);
 		advancedButton.addSelectionListener(
 				onAdvancedClicked());
 

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationTemplateDetailViews.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationTemplateDetailViews.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
@@ -246,33 +247,36 @@ public class ApplicationTemplateDetailViews extends AbstractDetailViews {
 		private Link nameLink;
 		private CLabel openshiftMaintainedLabel;
 		private CLabel securityUpdatesLabel;
-		private Text summaryText;
+		// use styled text to have vertical scrollbars hidden/visible correctly
+		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=180027#c11
+		private StyledText summaryText;
 
 		@Override
 		public Composite createControls(Composite parent, DataBindingContext dbc) {
-			Composite container = setControl(super.createControls(parent, dbc));
+			Composite container = setControl(new Composite(parent, SWT.None));
 			GridLayoutFactory.fillDefaults()
-					.numColumns(4).margins(10, 10).spacing(10, 10).applyTo(container);
+					.margins(4,4).numColumns(4).spacing(6, 6).applyTo(container);
 
 			// nameLink
 			this.nameLink = new Link(container, SWT.None);
 			GridDataFactory.fillDefaults()
-					.align(SWT.LEFT, SWT.CENTER).applyTo(nameLink);
+					.indent(6, 0).align(SWT.LEFT, SWT.CENTER).applyTo(nameLink);
 
 			// icons
 			this.openshiftMaintainedLabel = new CLabel(container, SWT.None);
 			GridDataFactory.fillDefaults()
-					.align(SWT.FILL, SWT.FILL).applyTo(openshiftMaintainedLabel);
+					.indent(6, 0).align(SWT.FILL, SWT.FILL).applyTo(openshiftMaintainedLabel);
 			this.securityUpdatesLabel = new CLabel(container, SWT.None);
 			GridDataFactory.fillDefaults()
 					.align(SWT.FILL, SWT.FILL).applyTo(securityUpdatesLabel);
 			
 			// summaryText
-			this.summaryText = new Text(container, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
-			summaryText.setEditable(false);
+			this.summaryText = new StyledText(container, SWT.WRAP | SWT.V_SCROLL | SWT.READ_ONLY);
+			summaryText.setAlwaysShowScrollBars(false);
 			summaryText.setBackground(container.getBackground());
+			Rectangle containerSize = container.getClientArea();
 			GridDataFactory.fillDefaults()
-					.span(3,1).align(SWT.LEFT, SWT.FILL).grab(true, true).applyTo(summaryText);
+					.span(3, 1).indent(6,0).align(SWT.FILL, SWT.FILL).grab(true, true).hint(containerSize.x, SWT.DEFAULT).applyTo(summaryText);
 			return container;
 		}
 
@@ -291,14 +295,14 @@ public class ApplicationTemplateDetailViews extends AbstractDetailViews {
 			updateSecurityUpdatesIcon(template);
 			this.summaryText.setText(template.getDescription());
 		}
-
+		
 		private void updateOpenShiftMaintainedIcon(IQuickstartApplicationTemplate template) {
 			if (template.isOpenShiftMaintained()) {
-				setImageAndText(openshiftMaintainedLabel,
+				setImageAndTooltip(openshiftMaintainedLabel,
 						"OpenShift maintained",
 						OpenShiftImages.OPENSHIFT_MAINTAINED_IMG);
 			} else {
-				setImageAndText(openshiftMaintainedLabel,
+				setImageAndTooltip(openshiftMaintainedLabel,
 						"Community created",
 						OpenShiftImages.NOT_OPENSHIFT_MAINTAINED_IMG);
 			}
@@ -306,18 +310,18 @@ public class ApplicationTemplateDetailViews extends AbstractDetailViews {
 		
 		private void updateSecurityUpdatesIcon(IQuickstartApplicationTemplate template) {
 			if (template.isAutomaticSecurityUpdates()) {
-				setImageAndText(securityUpdatesLabel, 
+				setImageAndTooltip(securityUpdatesLabel, 
 						"automatic security updates",
 						OpenShiftImages.SECURITY_UPDATES_IMG);
 			} else {
-				setImageAndText(securityUpdatesLabel,
+				setImageAndTooltip(securityUpdatesLabel,
 						"no automatic security updates",
 						OpenShiftImages.NO_SECURITY_UPDATES_IMG);
 			}
 		}
 
-		private void setImageAndText(CLabel label, String text, Image image) {
-			label.setText(text);
+		private void setImageAndTooltip(CLabel label, String text, Image image) {
+			// label.setText(text);
 			label.setImage(image);
 			label.setToolTipText(text);
 		}


### PR DESCRIPTION
The details view in the application wizard was using a wrapping text
control to show the quickstart summary. To have this working correctly
you have to restrain the horizontal size via GridData widthHint and use
StyledText. StyledText shows/hides the vertical scrollbars
automatically. With Text one needs to measure available & required sizes
(container/Text) and show/hide them upon results & resizing.
