### PR TITLE
JBIDE-19162 add openshift v3 feature + test feature to category.xml

### DIFF
--- a/site/category.xml
+++ b/site/category.xml
@@ -17,6 +17,12 @@
 	<feature url="features/org.jboss.tools.openshift.express.test.feature_0.0.0.jar" id="org.jboss.tools.openshift.express.test.feature" version="0.0.0">
 		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
 	</feature>
+	<feature url="features/org.jboss.tools.openshift.feature_0.0.0.jar" id="org.jboss.tools.openshift.feature" version="0.0.0">
+		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
+	</feature>
+	<feature url="features/org.jboss.tools.openshift.test.feature_0.0.0.jar" id="org.jboss.tools.openshift.test.feature" version="0.0.0">
+		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
+	</feature>
 	<!-- Sources -->
 	<feature url="features/org.jboss.tools.openshift.egit.integration.feature.source_0.0.0.jar" id="org.jboss.tools.openshift.egit.integration.feature.source" version="0.0.0">
 		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
@@ -28,6 +34,12 @@
 		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
 	</feature>
 	<feature url="features/org.jboss.tools.openshift.express.test.feature.source_0.0.0.jar" id="org.jboss.tools.openshift.express.test.feature.source" version="0.0.0">
+		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
+	</feature>
+	<feature url="features/org.jboss.tools.openshift.feature.source_0.0.0.jar" id="org.jboss.tools.openshift.feature.source" version="0.0.0">
+		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
+	</feature>
+	<feature url="features/org.jboss.tools.openshift.test.feature.source_0.0.0.jar" id="org.jboss.tools.openshift.test.feature.source" version="0.0.0">
 		<category name="JBoss Tools OpenShift Nightly Build Update Site" />
 	</feature>
 </site>


### PR DESCRIPTION
PR #536 did not add features to `category.xml` thus nothing in the actual generated site.

Note: this does not make it available in main jboss tools updatesite yet so that step is still needed.