### PR TITLE
JBIDE-20167 Openshift Tooling Usage Tracking.

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/internal/common/core/UsageStats.java
+++ b/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/internal/common/core/UsageStats.java
@@ -76,32 +76,32 @@ public class UsageStats {
 	}
 
 	public void newV2Connection(String host) {
-		UsageReporter.getInstance().countEvent(
+		UsageReporter.getInstance().trackEvent(
 				newConnectionV2.event(getHostType(host)));
 	}
 
 	public void newV2Application(String host, boolean success) {
-		UsageReporter.getInstance().countEvent(
+		UsageReporter.getInstance().trackEvent(
 				newApplicationV2.event(getHostType(host), success ? SUCCESS : FAILURE));
 	}
 
 	public void importV2Application(String host, boolean success) {
-		UsageReporter.getInstance().countEvent(
+		UsageReporter.getInstance().trackEvent(
 				importApplicationV2.event(getHostType(host), success ? SUCCESS : FAILURE));
 	}
 
 	public void newV3Connection(String host) {
-		UsageReporter.getInstance().countEvent(
+		UsageReporter.getInstance().trackEvent(
 				newConnectionV3.event(getHostType(host)));
 	}
 
 	public void newV3Application(String host, boolean success) {
-		UsageReporter.getInstance().countEvent(
+		UsageReporter.getInstance().trackEvent(
 				newApplicationV3.event(getHostType(host), success ? SUCCESS : FAILURE));
 	}
 
 	public void importV3Application(String host, boolean success) {
-		UsageReporter.getInstance().countEvent(
+		UsageReporter.getInstance().trackEvent(
 				importApplicationV3.event(getHostType(host), success ? SUCCESS : FAILURE));
 	}
 


### PR DESCRIPTION
Replaced countEvent() by trackEvent(). So we will send all events right away instead of counting them for 24 hours.