### PR TITLE
[JBIDE-19584] Hide 'New Connection' menu from OpenShiftException nodes in OS Explorer

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.common.ui/plugin.xml
@@ -190,11 +190,22 @@
                 id="org.jboss.tools.openshift.express.ui.command.newconnection"
                 mnemonic="N">
 				<visibleWhen>
-					<or>
-						<with variable="activePartId">
-							<equals value="org.jboss.tools.openshift.express.ui.explorer.expressConsoleView" />
-						</with>
-					</or>
+				<and>
+					<with variable="selection">
+						<and>
+							<count value="?" /><!-- 1 or none-->
+							<iterate ifEmpty="true" operator="and">
+								<not>
+									<instanceof
+										value="com.openshift.restclient.OpenShiftException" />
+								</not>
+							</iterate>
+						</and>
+					</with>
+					<with variable="activePartId">
+						<equals value="org.jboss.tools.openshift.express.ui.explorer.expressConsoleView" />
+					</with>
+				</and>
 				</visibleWhen>
 			</command>
 		</menuContribution>

--- a/plugins/org.jboss.tools.openshift.ui/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.ui/plugin.xml
@@ -63,6 +63,9 @@
             <instanceof
                   value="com.openshift.restclient.model.IResource">
             </instanceof>
+            <instanceof
+                  value="com.openshift.restclient.OpenShiftException">
+            </instanceof>
          </or>
 						</iterate>
 					</and>


### PR DESCRIPTION
I don't know how we can get the parent Connection node from the error node, from the ISelection, 
so I didn't add the Refresh menu

At least hiding the new Connection menu from error nodes should be enough for now

Signed-off-by: Fred Bricon <fbricon@gmail.com>