### PR TITLE
JBIDE-20028 Import wizard: cloning and import operation is executed in modal (wizard) dialog, blocks me from doing anything.

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/ImportApplicationHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/ImportApplicationHandler.java
@@ -27,7 +27,7 @@ public class ImportApplicationHandler extends AbstractHandler {
 	public Object execute(final ExecutionEvent event) throws ExecutionException {
 		WizardUtils.openWizardDialog(
 				new ImportApplicationWizard(),
-				HandlerUtil.getActiveShell(event));
+				HandlerUtil.getActiveShell(event), false);
 		return Status.OK_STATUS;
 	}
 }


### PR DESCRIPTION
ImportApplicationHandler is made to open a non-modal wizard dialog.
However, it should be taken into account that new/import application wizards do operations
that lock workspace resources. While the operation is going, it is ok for user just to navigate
and browse resources, but a change/create/remove action may be put to wait for the wizard's operation,
and Eclipse will be locked till its end.