### PR TITLE
[JBIDE-20974] Fix project combo regression in deploy image

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/connection/ConnectionWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/connection/ConnectionWizardModel.java
@@ -37,9 +37,8 @@ public class ConnectionWizardModel implements IConnectionAware<IConnection> {
 	}
 
 	@Override
-	public IConnection setConnection(IConnection connection) {
+	public void setConnection(IConnection connection) {
 		this.connection = connection;
-		return connection;
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/wizard/IConnectionAware.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/wizard/IConnectionAware.java
@@ -23,7 +23,7 @@ public interface IConnectionAware<C extends IConnection> {
 
 	public boolean hasConnection();
 	
-	public C setConnection(C connection);
+	public void setConnection(C connection);
 	
 	/**
 	 * A context that is useful to connection editors

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
@@ -398,8 +398,8 @@ public abstract class ExpressApplicationWizard extends Wizard implements IWorkbe
 	}
 
 	@Override
-	public ExpressConnection setConnection(ExpressConnection connection) {
-		return model.setConnection(connection);
+	public void setConnection(ExpressConnection connection) {
+		model.setConnection(connection);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
@@ -541,9 +541,8 @@ class OpenShiftApplicationWizardModel extends ObservablePojo implements IOpenShi
 	}
 
 	@Override
-	public ExpressConnection setConnection(ExpressConnection connection) {
+	public void setConnection(ExpressConnection connection) {
 		setProperty(PROP_CONNECTION, connection);
-		return connection;
 	}
 	
 	@Override

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeployImageHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeployImageHandler.java
@@ -45,8 +45,7 @@ public class DeployImageHandler extends AbstractHandler {
 		}else{
 			final IProject project = UIUtils.getFirstElement(selection, IProject.class);
 			if(project != null) {
-				model.setProject(project);
-				model.setConnection(ConnectionsRegistryUtil.getConnectionFor(project));
+				model.initModel(ConnectionsRegistryUtil.getConnectionFor(project), project);
 			}else {
 				final Connection osConnection = UIUtils.getFirstElement(selection, Connection.class);
 				if(osConnection != null){

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
@@ -228,7 +228,9 @@ public class DeployImagePage extends AbstractOpenShiftWizardPage {
 		
 		StructuredViewer cmboProject = new ComboViewer(parent);
 		GridDataFactory.fillDefaults()
-			.align(SWT.FILL, SWT.CENTER).grab(true, false)
+			.align(SWT.FILL, SWT.CENTER)
+			.grab(true, false)
+			.hint(SWT.DEFAULT, 30)
 			.applyTo(cmboProject.getControl());
 		
 		final OpenShiftExplorerLabelProvider labelProvider = new OpenShiftExplorerLabelProvider();

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/importapp/ImportApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/importapp/ImportApplicationWizard.java
@@ -142,8 +142,8 @@ public class ImportApplicationWizard extends Wizard implements IWorkbenchWizard,
 	}
 
 	@Override
-	public Connection setConnection(Connection connection) {
-		return model.setConnection(connection);
+	public void setConnection(Connection connection) {
+		model.setConnection(connection);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/importapp/ImportApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/importapp/ImportApplicationWizardModel.java
@@ -169,10 +169,9 @@ public class ImportApplicationWizardModel
 	}
 
 	@Override
-	public Connection setConnection(Connection connection) {
+	public void setConnection(Connection connection) {
 		firePropertyChange(PROPERTY_CONNECTION, this.connection, this.connection = connection);
 		setBuildConfigsTreeRoot(connection);
-		return this.connection;
 	}
 
 	private void setBuildConfigsTreeRoot(Connection connection) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
@@ -188,8 +188,8 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 	}
 
 	@Override
-	public Connection setConnection(Connection connection) {
-		return model.setConnection(connection);
+	public void setConnection(Connection connection) {
+		model.setConnection(connection);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -262,15 +262,14 @@ public class NewApplicationWizardModel
 	}
 
 	@Override
-	public Connection setConnection(Connection connection) {
+	public void setConnection(Connection connection) {
 		if (ObjectUtils.equals(connection, this.connection)) {
-			return this.connection;
+			return;
 		}
 
 		setResourceFactory(connection);
 		reset();
 		firePropertyChange(PROPERTY_CONNECTION, this.connection, this.connection = connection);
-		return connection;
 	}
 
 	private void reset() {


### PR DESCRIPTION
* Fixes regression in populating the project combo
* An issue using ConnectionAware with BeanProperties where setConnction wasnt found
* The project combo height when there are initially no entries