### PR TITLE
JBIDE-21072 - Application wizard: Server templates tree is not rendered

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
@@ -136,6 +136,14 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 			.grab(true, false)
 			.applyTo(tabContainer);
 
+		tabContainer.addListener(SWT.Selection, new Listener() {
+
+			@Override
+			public void handleEvent(Event event) {
+				parent.layout(true, false);
+			}
+		});
+
 		IObservableValue useLocalTemplateObservable = 
 				BeanProperties.value(ITemplateListPageModel.PROPERTY_USE_LOCAL_TEMPLATE).observe(model);
 		ValueBindingBuilder


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-21072
Application wizard: Server templates tree is not rendered