### PR TITLE
JBIDE-21116 - openshift server adapter doesn't need or benefit from 

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/server/OpenShiftServerExtendedProperties.java
+++ b/plugins/org.jboss.tools.openshift.express.core/src/org/jboss/tools/openshift/express/internal/core/server/OpenShiftServerExtendedProperties.java
@@ -24,6 +24,10 @@ public class OpenShiftServerExtendedProperties extends ServerExtendedProperties 
 		super(adaptable);
 	}
 	
+	public boolean allowConvenienceEnhancements() {
+		return false;
+	}
+	
 	public boolean hasWelcomePage() {
 		return true;
 	}


### PR DESCRIPTION
JBIDE-21116 - openshift server adapter doesn't need or benefit from xml / fileset enhancements