### PR TITLE
JBIDE-21301 Preferences: path to OC binary is not shown on OpenShift 3 page if binary is on $PATH

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
@@ -30,6 +30,7 @@ Export-Package: org.jboss.tools.openshift.core;x-friends:="org.jboss.tools.opens
  org.jboss.tools.openshift.core.preferences;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.core.server;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.internal.core;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
+ org.jboss.tools.openshift.internal.core.preferences;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.internal.core.util;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui"
 Service-Component: META-INF/connectionFactory.xml
 

--- a/plugins/org.jboss.tools.openshift.core/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.core/plugin.xml
@@ -86,6 +86,11 @@
 			sourcePathComputerId="org.eclipse.jst.server.generic.core.sourcePathComputer"/>
 	</extension>
 
+   <extension point="org.eclipse.core.runtime.preferences">
+      <initializer class="org.jboss.tools.openshift.internal.core.preferences.OpenShiftCorePreferenceInitializer"/>
+   </extension>
+
+
 	<!-- UI integration: credentials pompt -->
    	<extension-point id="org.jboss.tools.openshift.core.credentialsPrompterUI" 
    		name="CredentialsPrompterUI" 

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/preferences/OCBinaryName.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/preferences/OCBinaryName.java
@@ -1,0 +1,54 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.openshift.internal.core.preferences;
+
+import org.apache.commons.lang.SystemUtils;
+import org.eclipse.core.runtime.Platform;
+import org.jboss.tools.openshift.internal.common.core.util.CommandLocationBinary;
+
+public enum OCBinaryName {
+
+	WINDOWS("oc.exe", new String[] { "exe" }), 
+	OTHER("oc", new String[] {});
+	
+	private String name;
+	private String[] extensions;
+	private CommandLocationBinary locationBinary;
+	private OCBinaryName(String name, String[] extensions) {
+		this.name = name;
+		this.extensions = extensions;
+	}
+
+	public String getName() {
+		return name;
+	};
+
+	public String[] getExtensions() {
+		return extensions;
+	};
+
+	public String getLocation() {
+		if( locationBinary == null ) {
+			locationBinary = new CommandLocationBinary("oc");
+			locationBinary.addPlatformLocation(Platform.OS_LINUX, "/usr/bin/oc");
+			locationBinary.setDefaultPlatform(Platform.OS_LINUX);
+		}
+		return locationBinary.findLocation();
+	}
+	
+	public static OCBinaryName getInstance() {
+		if (SystemUtils.IS_OS_WINDOWS) {
+			return WINDOWS;
+		} else {
+			return OTHER;
+		}
+	}
+}

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/preferences/OpenShiftCorePreferenceInitializer.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/preferences/OpenShiftCorePreferenceInitializer.java
@@ -1,0 +1,32 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.openshift.internal.core.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.jboss.tools.openshift.core.preferences.IOpenShiftCoreConstants;
+import org.jboss.tools.openshift.internal.core.OpenShiftCoreActivator;
+
+public class OpenShiftCorePreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		IEclipsePreferences defaultPreferences = ((IScopeContext)DefaultScope.INSTANCE).getNode(OpenShiftCoreActivator.PLUGIN_ID);
+		
+		String location = OCBinaryName.getInstance().getLocation();
+		if(location != null && location.length() > 0) {
+			defaultPreferences.put(IOpenShiftCoreConstants.OPENSHIFT_CLI_LOC, location);
+		}
+	}
+
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/AbstractOpenShiftCliHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/AbstractOpenShiftCliHandler.java
@@ -29,7 +29,7 @@ import org.eclipse.swt.widgets.Link;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.jboss.tools.openshift.core.preferences.OpenShiftCorePreferences;
-import org.jboss.tools.openshift.internal.ui.preferences.OpenShiftPreferencePage.OCBinaryName;
+import org.jboss.tools.openshift.internal.core.preferences.OCBinaryName;
 
 import com.openshift.restclient.capability.resources.IPortForwardable;
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/preferences/OpenShiftPreferencePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/preferences/OpenShiftPreferencePage.java
@@ -14,7 +14,6 @@ import java.io.File;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
@@ -29,7 +28,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.jboss.tools.foundation.ui.util.BrowserUtility;
 import org.jboss.tools.openshift.core.preferences.IOpenShiftCoreConstants;
-import org.jboss.tools.openshift.internal.common.core.util.CommandLocationBinary;
+import org.jboss.tools.openshift.internal.core.preferences.OCBinaryName;
 import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 
 /**
@@ -40,45 +39,6 @@ public class OpenShiftPreferencePage extends FieldEditorPreferencePage implement
 
 	private static final String DOWNLOAD_INSTRUCTIONS_URL = 
 			"https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc#download-from-github";
-	
-	public enum OCBinaryName {
-
-		WINDOWS("oc.exe", new String[] { "exe" }), 
-		OTHER("oc", new String[] {});
-		
-		private String name;
-		private String[] extensions;
-		private CommandLocationBinary locationBinary;
-		private OCBinaryName(String name, String[] extensions) {
-			this.name = name;
-			this.extensions = extensions;
-		}
-
-		public String getName() {
-			return name;
-		};
-
-		public String[] getExtensions() {
-			return extensions;
-		};
-
-		public String getLocation() {
-			if( locationBinary == null ) {
-				locationBinary = new CommandLocationBinary("oc");
-				locationBinary.addPlatformLocation(Platform.OS_LINUX, "/usr/bin/oc");
-				locationBinary.setDefaultPlatform(Platform.OS_LINUX);
-			}
-			return locationBinary.findLocation();
-		}
-		
-		public static OCBinaryName getInstance() {
-			if (SystemUtils.IS_OS_WINDOWS) {
-				return WINDOWS;
-			} else {
-				return OTHER;
-			}
-		}
-	}
 	
 	private FileFieldEditor cliLocationEditor;
 	private OCBinaryName ocBinary;


### PR DESCRIPTION
OpenShiftCorePreferenceInitializer is implemented. It sets the default preference value at the first access to the preference, which can be either at preference page or any other code that needs it.
Definition of OCBinaryName is moved as is from OpenShiftPreferencePage into OpenShiftCorePreferenceInitializer. It remains visible from OpenShiftPreferencePage.