### PR TITLE
JBIDE-21122 Port Forwarding: Start All button should be disabled if port forwarding is already active

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
@@ -41,6 +41,7 @@ public class PortForwardingWizardModel extends ObservablePojo {
 
 	public static final String PROPERTY_FORWARDABLE_PORTS = "forwardablePorts";
 	public static final String PROPERTY_PORT_FORWARDING = "portForwarding";
+	public static final String PROPERTY_PORT_FORWARDING_ALLOWED = "portForwardingAllowed";
 	public static final String PROPERTY_USE_FREE_PORTS = "useFreePorts";
 	private static final Map<IPod, IPortForwardable> REGISTRY = new HashMap<IPod, IPortForwardable>();
 
@@ -73,6 +74,10 @@ public class PortForwardingWizardModel extends ObservablePojo {
 		return isPortForwarding(pod);
 	}
 
+	public boolean isPortForwardingAllowed() {
+		return !getForwardablePorts().isEmpty() && !isPortForwarding(pod);
+	}
+
 	public Collection<IPortForwardable.PortPair> getForwardablePorts(){
 		return ports;
 	}
@@ -94,13 +99,13 @@ public class PortForwardingWizardModel extends ObservablePojo {
 				cap.forwardPorts(ports.toArray(new IPortForwardable.PortPair []{}));
 				stream.println("done.");
 				ConsoleUtils.displayConsoleView(console);
-				firePropertyChange(PROPERTY_PORT_FORWARDING, false, getPortForwarding());
 				return cap;
 			}
 		}, null);
 		if(portForwardable != null) {
 			REGISTRY.put(pod, portForwardable);
 		}
+		firePropertyChange(PROPERTY_PORT_FORWARDING, false, getPortForwarding());
 	}
 	
 	private boolean isPortForwarding(IPod pod) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardPage.java
@@ -114,36 +114,18 @@ public class PortForwardingWizardPage extends AbstractOpenShiftWizardPage {
 		IObservableValue portForwardingStartedObservable = BeanProperties.value(
 				PortForwardingWizardModel.PROPERTY_PORT_FORWARDING).observe(wizardModel);
 
-		IObservableValue forwardablePortsModelObservable =
-				BeanProperties.value(PortForwardingWizardModel.PROPERTY_FORWARDABLE_PORTS).observe(wizardModel);
+		IObservableValue portForwardingAllowedObservable = BeanProperties.value(
+				PortForwardingWizardModel.PROPERTY_PORT_FORWARDING_ALLOWED).observe(wizardModel);
 
 		ValueBindingBuilder.bind(WidgetProperties.enabled().observe(startButton))
-			.notUpdating(portForwardingStartedObservable).converting(new InvertingBooleanConverter()).in(dbc);
+			.notUpdating(portForwardingAllowedObservable).in(dbc);
 
 		
-		Converter collectionToBooleanConverter = new Converter(Collection.class, Boolean.class) {
-			
-			@Override
-			public Object convert(Object fromObject) {
-				if(fromObject instanceof Collection<?>) {
-					return !((Collection<?>) fromObject).isEmpty();
-				}
-				return Boolean.FALSE;
-			}
-			
-		};
-		ValueBindingBuilder.bind(WidgetProperties.enabled().observe(startButton))
-			.notUpdating(forwardablePortsModelObservable).converting(collectionToBooleanConverter).in(dbc);
-
 		ValueBindingBuilder.bind(WidgetProperties.enabled().observe(stopButton))
 				.notUpdating(portForwardingStartedObservable).in(dbc);
 		
 		ValueBindingBuilder.bind(WidgetProperties.enabled().observe(findFreesPortButton))
-				.notUpdating(portForwardingStartedObservable).converting(new InvertingBooleanConverter()).in(dbc);
-
-		ValueBindingBuilder.bind(WidgetProperties.enabled().observe(findFreesPortButton))
-		.notUpdating(forwardablePortsModelObservable).converting(collectionToBooleanConverter).in(dbc);
-
+				.notUpdating(portForwardingAllowedObservable).in(dbc);
 
 	}
 


### PR DESCRIPTION
1. It seems that 2 independent binds to model for startButton (as well as for findFreesPortButton) does not work as planned.
I added a new property to model "portForwardingAllowed" that computes value as needed for startButton and findFreesPortButton and bound them to it. Maybe it is not the only way to solve the problem, but I find it appealing to have one simple property that implements the entire logic inside the model.

2. Since getPortForwarding() is based on REGISTRY, and computed in startPortForwarding() portForwardable object is added to REGISTRY _after_ call pod.accept(), firing property change inside visit() seems has no effect, so that I copied firing to the end of startPortForwarding().