### PR TITLE
JBIDE-21083 'Untrusted SSL Certificate' shell keeps extending when help is turned on and off again

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/CreationLogDialog.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/CreationLogDialog.java
@@ -51,6 +51,7 @@ public class CreationLogDialog extends TitleAreaDialog {
 		super(parentShell);
 		this.logEntries = logEntries;
 		this.links = new ArrayList<Link>();
+		setHelpAvailable(false);
 	}
 	
 	@Override
@@ -64,7 +65,6 @@ public class CreationLogDialog extends TitleAreaDialog {
 		parent.getShell().setText("Embedded Cartridges");
 		setTitle("Please make note of the credentials and url that were reported\nwhen your cartridges were embedded / application was created. ");
 		setTitleImage(ExpressImages.OPENSHIFT_LOGO_WHITE_MEDIUM_IMG);
-		setDialogHelpAvailable(false);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/details/ApplicationDetailsDialog.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/details/ApplicationDetailsDialog.java
@@ -47,6 +47,7 @@ public class ApplicationDetailsDialog extends TitleAreaDialog {
 	public ApplicationDetailsDialog(IApplication application, Shell parentShell) {
 		super(parentShell);
 		this.application = application;
+		setHelpAvailable(false);
 	}
 
 	@Override
@@ -120,7 +121,6 @@ public class ApplicationDetailsDialog extends TitleAreaDialog {
 		parent.getShell().setText("Application Details");
 		setTitle(NLS.bind("Details of Application {0}", application.getName()));
 		setTitleImage(ExpressImages.OPENSHIFT_LOGO_WHITE_MEDIUM_IMG);
-		setDialogHelpAvailable(false);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/connection/SSLCertificateCallback.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/connection/SSLCertificateCallback.java
@@ -94,6 +94,7 @@ public class SSLCertificateCallback implements ISSLCertificateCallback {
 		private SSLCertificateDialog(Shell parentShell, X509Certificate[] certificateChain) {
 			super(parentShell);
 			this.certificateChain = certificateChain;
+			setHelpAvailable(false);
 		}
 
 		@Override
@@ -107,7 +108,6 @@ public class SSLCertificateCallback implements ISSLCertificateCallback {
 			parent.getShell().setText("Untrusted SSL Certificate");
 			setTitle("Do you accept the following untrusted SSL certificate?");
 			setTitleImage(ExpressImages.OPENSHIFT_LOGO_WHITE_MEDIUM_IMG);
-			setDialogHelpAvailable(false);
 		}
 
 		@Override

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dialog/ResourceSummaryDialog.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dialog/ResourceSummaryDialog.java
@@ -57,6 +57,7 @@ public class ResourceSummaryDialog  extends TitleAreaDialog {
 		this.message = message;
 		this.labelProvider = labelProvider;
 		this.contentProvider = contetProvider;
+		setHelpAvailable(false);
 	}
 	
 	@Override
@@ -123,7 +124,6 @@ public class ResourceSummaryDialog  extends TitleAreaDialog {
 		parent.getShell().setText(dialogTitle);
 		setTitle(message);
 		setTitleImage(OpenShiftCommonImages.OPENSHIFT_LOGO_WHITE_MEDIUM_IMG);
-		setDialogHelpAvailable(false);
 	}
 	
 	@Override


### PR DESCRIPTION
Fixed wrong usage of TrayDialog.setDialogHelpAvailable(boolean)

Currently, this pull request depends on https://github.com/jbosstools/jbosstools-openshift/pull/871 which includes fix for org.jboss.tools.openshift.internal.ui.wizard.connection.SSLCertificateCallback.SSLCertificateDialog to avoid merge conflicts.