### PR TITLE
[JBIDE-21349] Browse for Workspace source folder

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.common.core/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.jboss.tools.common.core;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.equinox.common,
  org.eclipse.equinox.security;bundle-version="1.2.0",
  org.apache.commons.io;bundle-version="[2.0.1,3.0.0)",
- org.apache.commons.lang;bundle-version="[2.6.0,3.0.0)"
+ org.apache.commons.lang;bundle-version="[2.6.0,3.0.0)",
+ org.eclipse.core.variables
 Export-Package: org.jboss.tools.openshift.common.core;
   x-friends:="org.jboss.tools.openshift.common.ui,
    org.jboss.tools.openshift.core,

--- a/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/common/core/OpenShiftCoreException.java
+++ b/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/common/core/OpenShiftCoreException.java
@@ -27,4 +27,7 @@ public class OpenShiftCoreException extends RuntimeException {
 		super(MessageFormat.format(message, arguments), cause);	
 	}
 	
+	public OpenShiftCoreException(Throwable cause) {
+		super(cause);	
+	}
 }

--- a/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/common/core/utils/VariablesHelper.java
+++ b/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/common/core/utils/VariablesHelper.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.common.core.utils;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.variables.VariablesPlugin;
+import org.jboss.tools.openshift.common.core.OpenShiftCoreException;
+import org.jboss.tools.openshift.internal.common.core.OpenShiftCommonCoreActivator;
+
+/**
+ * Utility class to handle variables and variable substitution in Strings.
+ * 
+ */
+public class VariablesHelper {
+
+	public static final String VARIABLE_PREFIX = "${";
+	public static final String VARIABLE_SUFFIX = "}";
+	public static final String WORKSPACE_LOC = "workspace_loc";
+	public static final String WORKSPACE_PREFIX = VARIABLE_PREFIX+WORKSPACE_LOC+":";
+	
+	private VariablesHelper() {}
+	
+	/**
+	 * @return true if the value contains <code>${</code>
+	 */
+	public static boolean containsVariables(String value) {
+		return StringUtils.isNotBlank(value) && value.indexOf(VARIABLE_PREFIX) < value.indexOf(VARIABLE_SUFFIX);
+	}
+	
+	public static String addWorkspacePrefix(String value) {
+		if (StringUtils.isBlank(value) || value.startsWith(WORKSPACE_PREFIX)) {
+			return value;
+		}
+		return VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(WORKSPACE_LOC, value);
+	}
+	
+	public static String getWorkspacePath(String value) {
+		if (StringUtils.isBlank(value) || !(value.startsWith(WORKSPACE_PREFIX) && value.endsWith(VARIABLE_SUFFIX))) {
+			return value;
+		}
+		String path = value.substring(WORKSPACE_PREFIX.length(), value.length()-1);
+		return path;
+	}
+	
+	public static String replaceVariables(String value) {
+		return replaceVariables(value, false);
+	}
+	
+	public static String replaceVariables(String value, boolean ignoreErrors) {
+		if (containsVariables(value)) {
+			try {
+				return VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(value);
+			} catch (CoreException e) {
+				if (ignoreErrors) {
+					OpenShiftCommonCoreActivator.log("Could not interpolate "+value, e);
+				} else {
+					throw new OpenShiftCoreException(e);
+				}
+			}
+		}
+		return value;
+	}
+}

--- a/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
@@ -22,7 +22,8 @@ Require-Bundle: org.jboss.tools.openshift.client;bundle-version="[3.0.0,4.0.0)",
  org.apache.httpcomponents.httpclient;bundle-version="4.3.6",
  org.apache.httpcomponents.httpcore;bundle-version="4.3.3",
  org.apache.commons.codec;bundle-version="1.6.0",
- org.apache.commons.lang;bundle-version="2.6.0"
+ org.apache.commons.lang;bundle-version="2.6.0",
+ org.eclipse.core.variables
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.openshift.core;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -28,6 +28,7 @@ import org.jboss.tools.openshift.common.core.server.ServerUtils;
 import org.jboss.tools.openshift.common.core.utils.ProjectUtils;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
 import org.jboss.tools.openshift.common.core.utils.UrlUtils;
+import org.jboss.tools.openshift.common.core.utils.VariablesHelper;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.util.OpenShiftResourceUniqueId;
 import org.jboss.tools.openshift.internal.core.OpenShiftCoreActivator;
@@ -225,7 +226,12 @@ public class OpenShiftServerUtils {
 	
 	public static String getSourcePath(IServerAttributes attributes) {
 		// TODO: implement override project settings with server settings
-		return getProjectAttribute(ATTR_SOURCE_PATH, null, getDeployProject(attributes));
+		String rawSourcePath = getProjectAttribute(ATTR_SOURCE_PATH, null, getDeployProject(attributes));
+		if (org.apache.commons.lang.StringUtils.isBlank(rawSourcePath)) {
+			return rawSourcePath;
+		}
+		String path = VariablesHelper.replaceVariables(rawSourcePath);
+		return path;
 	}
 
 	public static boolean isOverridesProject(IServerAttributes server) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorModel.java
@@ -50,19 +50,19 @@ public class OpenShiftServerEditorModel extends ServerSettingsViewModel {
 
 	@Override
 	protected org.eclipse.core.resources.IProject getProjectOrDefault(org.eclipse.core.resources.IProject project, List<org.eclipse.core.resources.IProject> projects) {
-		// dont default to 1st element
+		// don't default to 1st element
 		return project;
 	}
 
 	@Override
 	protected IService getServiceOrDefault(IService service, List<ObservableTreeItem> services) {
-		// dont default to 1st element
+		// don't default to 1st element
 		return service;
 	}
 
 	@Override
 	protected List<ObservableTreeItem> loadServices(Connection connection) {
-		// dont load
+		// don't load
 		return Collections.emptyList();
 	}	
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsViewModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsViewModel.java
@@ -21,6 +21,7 @@ import org.eclipse.wst.server.core.IServerWorkingCopy;
 import org.jboss.tools.openshift.common.core.connection.ConnectionURL;
 import org.jboss.tools.openshift.common.core.utils.ProjectUtils;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
+import org.jboss.tools.openshift.common.core.utils.VariablesHelper;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.server.OpenShiftServerUtils;
 import org.jboss.tools.openshift.internal.common.core.util.CollectionUtils;
@@ -87,7 +88,8 @@ public class ServerSettingsViewModel extends ServiceViewModel {
 	protected void updateSourcePath(String sourcePath, org.eclipse.core.resources.IProject deployProject) {
 		if (StringUtils.isEmpty(sourcePath)
 				&& ProjectUtils.isAccessible(deployProject)) {
-			sourcePath = deployProject.getLocation().toString();
+			String projectPath = deployProject.getFullPath().toString();
+			sourcePath = VariablesHelper.addWorkspacePrefix(projectPath);
 		}
 		firePropertyChange(PROPERTY_SOURCE_PATH, this.sourcePath, this.sourcePath = sourcePath);
 	}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -27,8 +27,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.osgi.util.NLS;
+import org.jboss.tools.openshift.common.core.utils.VariablesHelper;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.egit.core.EGitUtils;
 import org.jboss.tools.openshift.internal.ui.treeitem.ObservableTreeItem;
@@ -99,13 +99,13 @@ public class NewApplicationWizardModel
 			return null;
 		}
 		ITemplate uploadedTemplate = null;
+		filename = VariablesHelper.replaceVariables(filename);
 		try {
-			filename = VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(filename);
 			if (!Files.isRegularFile(Paths.get(filename))) {
 				return null;
 			}
 			uploadedTemplate = resourceFactory.create(createInputStream(filename));
-		} catch (FileNotFoundException | CoreException e) {
+		} catch (FileNotFoundException e) {
 			throw new OpenShiftException(e, NLS.bind("Could not find the file \"{0}\" to upload", filename));
 		} catch (ResourceFactoryException | ClassCastException e) {
 			throw e;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
@@ -40,7 +40,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.jface.databinding.fieldassist.ControlDecorationSupport;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
@@ -95,6 +94,7 @@ import org.jboss.tools.common.ui.WizardUtils;
 import org.jboss.tools.common.ui.databinding.ParametrizableWizardPageSupport;
 import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
 import org.jboss.tools.openshift.common.core.utils.ProjectUtils;
+import org.jboss.tools.openshift.common.core.utils.VariablesHelper;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.egit.core.EGitUtils;
 import org.jboss.tools.openshift.egit.ui.util.EGitUIUtils;
@@ -459,8 +459,8 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 			public void widgetSelected(SelectionEvent e) {
 				ElementTreeSelectionDialog dialog = createFileDialog(model.getLocalTemplateFileName());
 				if (dialog.open() == IDialogConstants.OK_ID && dialog.getFirstResult() instanceof IFile) {
-					String path = ((IFile)dialog.getFirstResult()).getFullPath().toPortableString();
-					String file = VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression("workspace_loc", path);
+					String path = ((IFile)dialog.getFirstResult()).getFullPath().toString();
+					String file = VariablesHelper.addWorkspacePrefix(path);
 					setLocalTemplate(file);
 				}
 			}
@@ -534,7 +534,7 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 
 	private boolean isFile(String path) {
 		return StringUtils.isNotBlank(path) &&
-				Files.isRegularFile(Paths.get(substituteVariables(path)));
+				Files.isRegularFile(Paths.get(VariablesHelper.replaceVariables(path)));
 	}
 
 	private IObservableValue createServerTemplateControls(TabFolder tabFolder, IObservableValue uploadTemplate, DataBindingContext dbc) {
@@ -925,14 +925,6 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 		UIUtils.setVisibleAndExclude(showLink, gitLabel);
 	}
 
-	private String substituteVariables(String string) {
-		try {
-			return VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(string);
-		} catch (CoreException ex) {
-			throw new RuntimeException(ex);
-		}
-	}
-	
 	@Override
 	protected void setupWizardPageSupport(DataBindingContext dbc) {
 		ParametrizableWizardPageSupport.create(

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/core/util/VariablesHelperTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/core/util/VariablesHelperTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.common.core.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.jboss.tools.openshift.common.core.OpenShiftCoreException;
+import org.jboss.tools.openshift.common.core.utils.VariablesHelper;
+import org.junit.Test;
+
+public class VariablesHelperTest {
+
+	@Test
+	public void testContainsVariables() {
+		assertFalse(VariablesHelper.containsVariables(null));
+		assertFalse(VariablesHelper.containsVariables("  "));
+		assertFalse(VariablesHelper.containsVariables("}foo${"));
+		assertFalse(VariablesHelper.containsVariables("}foo${"));
+		assertTrue(VariablesHelper.containsVariables("${foo}"));
+	}
+	
+	@Test
+	public void testAddWorkspacePrefix() {
+		String value = "foo";
+		assertEquals(VariablesHelper.WORKSPACE_PREFIX+value+VariablesHelper.VARIABLE_SUFFIX, VariablesHelper.addWorkspacePrefix(value));
+		value = null;
+		assertNull(VariablesHelper.addWorkspacePrefix(value));
+		value = " ";
+		assertEquals(value, VariablesHelper.addWorkspacePrefix(value));
+		value = VariablesHelper.WORKSPACE_PREFIX+"bar"+VariablesHelper.VARIABLE_SUFFIX;
+		assertEquals(value, VariablesHelper.addWorkspacePrefix(value));
+	}
+	
+	@Test
+	public void testGetWorkspacePath() {
+		String value = "foo";
+		assertEquals(value, VariablesHelper.getWorkspacePath(value));
+		String varValue = VariablesHelper.addWorkspacePrefix(value);
+		assertEquals(value, VariablesHelper.getWorkspacePath(varValue));
+	}
+	
+	
+	@Test
+	public void testReplaceVariables() throws Exception {
+		String name = "foo";
+		String value = VariablesHelper.addWorkspacePrefix(name);
+		try {
+			VariablesHelper.replaceVariables(value);
+			fail("missing resource should fail to resolve");
+		} catch (OpenShiftCoreException e) {
+		}
+		IProject bar = getOrcreateProject(name);
+		assertEquals(bar.getLocation().toString(), VariablesHelper.replaceVariables(value));
+	}
+	
+	private IProject getOrcreateProject(String projectName) throws Exception {
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		if (project.exists()) {
+			return project;
+		}
+		IProjectDescription desc = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+		project.create(desc, null);
+		project.open(null);
+		return project;
+	}
+}


### PR DESCRIPTION
Workspace based paths now use the workspace_loc variable.

Opening the filesystem browser converts a workspace relative path to an absolute one
Opening the workspace browser converts an absolute relative path to a workspace relative one
If a filesystem path that doesn't match anything in the workspace is used to open the workspace browser, it falls back on selecting the selected project's path


Signed-off-by: Fred Bricon <fbricon@gmail.com>