### PR TITLE
JBIDE-21443 NullPointerException when trying to import a BuildConfig as a new application from OpenShift 3

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/importapp/ImportApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/importapp/ImportApplicationWizardModel.java
@@ -34,8 +34,6 @@ public class ImportApplicationWizardModel
 	extends ObservableUIPojo 
 	implements IBuildConfigPageModel, IGitCloningPageModel {
 
-	private static final Pattern PROJECT_NAME_PATTERN = Pattern.compile("([^/]+[^(\\.git)/])(/|\\.git)?$");
-
 	private Connection connection;
 	private ConnectionTreeItem connectionItem;
 	private Object selectedItem;
@@ -141,10 +139,21 @@ public class ImportApplicationWizardModel
 	public static String extractProjectNameFromURI(String uri) {
 		String projectName = null;
 		if (uri != null) {
-			Matcher matcher = PROJECT_NAME_PATTERN.matcher(uri);
-			if (matcher.find()
-					&& matcher.group(1) != null) {
-				projectName = matcher.group(1);
+			uri = uri.trim();
+			while(uri.endsWith("/")) {
+				//Trailing slashes do not matter.
+				uri = uri.substring(0, uri.length() - 1);
+			}
+			if(uri.endsWith(".git")) {
+				uri = uri.substring(0, uri.length() - 4);
+				if(uri.endsWith("/")) { 
+					// '/' before .git is error
+					return null;
+				}
+			}
+			int b = uri.lastIndexOf("/");
+			if(b >= 0) {
+				projectName = uri.substring(b + 1);
 			}
 		}
 		return projectName;

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/application/ImportApplicationWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/application/ImportApplicationWizardModelTest.java
@@ -27,6 +27,12 @@ public class ImportApplicationWizardModelTest {
 		assertEquals("bar", ImportApplicationWizardModel.extractProjectNameFromURI("http://foo/bar.git"));
 		assertEquals("bar", ImportApplicationWizardModel.extractProjectNameFromURI("http://foo/bar/"));
 		assertEquals("ba.r", ImportApplicationWizardModel.extractProjectNameFromURI("http://foo/ba.r"));
+
+		assertEquals("quickstart", ImportApplicationWizardModel.extractProjectNameFromURI("https://github.com/akram/quickstart"));
+		assertEquals("quickstart", ImportApplicationWizardModel.extractProjectNameFromURI("https://github.com/akram/quickstart.git"));
+		assertEquals("quickstart", ImportApplicationWizardModel.extractProjectNameFromURI("https://github.com/akram/quickstart/"));
+		assertEquals("quickstart", ImportApplicationWizardModel.extractProjectNameFromURI("https://github.com/akram/quickstart.git/"));
+
 	}
 
 }


### PR DESCRIPTION
I could not come up with a reasonable regex to solve the problem.
Actually, a piece of intricate regex looks like so much of compiled byte code put into the source.
I suggest good old String.endsWith and String.lastIndexOf for extracting project name of uri.
Tests should take care of project name being not null with good uri.