### PR TITLE
[JBIDE-21429] Initial support for LiveReload

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -12,6 +12,7 @@ package org.jboss.tools.openshift.core.server;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -36,11 +37,14 @@ import org.osgi.service.prefs.BackingStoreException;
 
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IService;
+import com.openshift.restclient.model.route.IRoute;
 
 /**
  * @author Andre Dietisheim
  */
 public class OpenShiftServerUtils {
+
+	private static final String LIVERELOAD_PORT_KEY = "port";//Key to the port # of the host the LiveReload server need to proxy
 
 	public static final String SERVER_PROJECT_QUALIFIER = "org.jboss.tools.openshift.core"; //$NON-NLS-1$
 
@@ -61,7 +65,7 @@ public class OpenShiftServerUtils {
 		if (service == null) {
 			return null;
 		}
-		
+
 		return new StringBuilder(service.getName())
 				.append(" at OpenShift 3 (")
 				.append(UrlUtils.cutPort(UrlUtils.cutScheme(connection.getHost())))
@@ -74,15 +78,34 @@ public class OpenShiftServerUtils {
 		String deployProjectName = ProjectUtils.getName(deployProject);
 		updateServer(serverName, host, connectionUrl, deployProjectName, OpenShiftResourceUniqueId.get(service), sourcePath, podPath, server);
 	}
-	
+
 	private static String getHost(IService service) {
+		if (service == null) {
+			return null;
+		}
+
 		String host = null;
-		if (service != null) {
+
+		com.openshift.restclient.model.IProject project = service.getProject();
+		if (project != null) {
+
+			//TODO Ideally, we should use a route selected during the Server creation, in case there are several
+			//Until then, we'll fall back on always choosing the 1st route to open a browser
+			IRoute route = getRoute(project.getResources(ResourceKind.ROUTE));
+			if (route != null) {
+				host = route.getURL();
+			}
+		}
+		if (host == null) {
 			host = service.getPortalIP();
 		}
 		return host;
 	}
-	
+
+	private static IRoute getRoute(List<IRoute> routes) {
+		return routes == null || routes.isEmpty()? null : routes.get(0);
+	}
+
 	/**
 	 * Fills the given settings into the given server adapter working copy.
 	 * <b>IMPORTANT:</b> If the server adapter name is matching an existing server adapter, then
@@ -109,7 +132,7 @@ public class OpenShiftServerUtils {
 
 		server.setName(serverName);
 		server.setHost(UrlUtils.getHost(host));
-		
+
 		server.setAttribute(ATTR_CONNECTIONURL, connectionUrl);
 		server.setAttribute(ATTR_DEPLOYPROJECT, deployProjectName);
 		server.setAttribute(ATTR_SOURCE_PATH, sourcePath);
@@ -121,7 +144,9 @@ public class OpenShiftServerUtils {
 		server.setAttribute(IDeployableServer.SERVER_MODE, OpenShiftServer.OPENSHIFT3_MODE_ID);
 		((ServerWorkingCopy) server).setAutoPublishSetting(Server.AUTO_PUBLISH_DISABLE);
 		server.setAttribute(IJBossToolingConstants.IGNORE_LAUNCH_COMMANDS, String.valueOf(Boolean.TRUE));
-		server.setAttribute(IJBossToolingConstants.WEB_PORT, 80);
+		int webPort = 80;//TODO should we determine the webPort from the route?
+		server.setAttribute(IJBossToolingConstants.WEB_PORT, webPort);
+		server.setAttribute(LIVERELOAD_PORT_KEY, webPort);//So that we can open via LiveReload
 		server.setAttribute(IJBossToolingConstants.WEB_PORT_DETECT, Boolean.FALSE.toString());
 		server.setAttribute(IDeployableServer.DEPLOY_DIRECTORY_TYPE, IDeployableServer.DEPLOY_CUSTOM);
 		server.setAttribute(IDeployableServer.ZIP_DEPLOYMENTS_PREF, true);

--- a/plugins/org.jboss.tools.openshift.ui/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.ui/plugin.xml
@@ -643,6 +643,13 @@
 			type="org.eclipse.ui.views.properties.IPropertySource">
 		</adapter>
 	</factory>
+	<factory
+		adaptableType="org.eclipse.wst.server.core.IServer"
+		class="org.jboss.tools.openshift.internal.ui.server.OpenShiftServerAdapterFactory">
+		<adapter
+			type="org.eclipse.wst.server.ui.IServerModule">
+		</adapter>
+	</factory>
 	</extension>
 
 	<!-- definitions -->

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerAdapterFactory.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerAdapterFactory.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.ui.server;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdapterFactory;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IModuleType;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.ui.IServerModule;
+import org.jboss.tools.openshift.core.server.OpenShiftServer;
+
+public class OpenShiftServerAdapterFactory implements IAdapterFactory {
+
+	@Override
+	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+		if (adaptableObject instanceof IServer && IServerModule.class.equals(adapterType)) {
+			IServer server = (IServer)adaptableObject;
+			OpenShiftServer oss = (OpenShiftServer)server.loadAdapter(OpenShiftServer.class, new NullProgressMonitor());
+			if (oss != null) {
+				return (T) new OpenShiftServerModuleAdapter(server);
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?>[] getAdapterList() {
+		return new Class<?>[] {IServerModule.class};
+	}
+
+	private static class OpenShiftServerModuleAdapter implements IServerModule {
+
+		private IServer server;
+		private RootModule module;
+
+		private OpenShiftServerModuleAdapter(IServer server) {
+			this.server = server;
+			module = new RootModule(server.toString(), "");//TODO we need to be able to determine the context root
+		}
+
+		@Override
+		public IServer getServer() {
+			return server;
+		}
+
+		@Override
+		public IModule[] getModule() {
+			return new IModule[]{module};
+		}
+
+	}
+
+	//TODO we're not supposed to implement IModule. That'll do until we find a better way to integrate with LiveReload
+	private static class RootModule implements IModule {
+
+		private String id;
+
+		private RootModule(String id, String contextRoot) {
+			this.id = id;
+		}
+
+		@Override
+		public String getId() {
+			return id;
+		}
+
+		@Override
+		public String getName() {
+			return "";
+		}
+
+		@Override
+		public IModuleType getModuleType() {
+			return null;
+		}
+
+		@Override
+		public IProject getProject() {
+			return null;
+		}
+
+		@Override
+		public boolean isExternal() {
+			return false;
+		}
+
+		@Override
+		public boolean exists() {
+			return true;
+		}
+
+		@Override
+		public Object getAdapter(Class adapter) {
+			return null;
+		}
+
+		@Override
+		public Object loadAdapter(Class adapter, IProgressMonitor monitor) {
+			return null;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This initial support is pretty hacky. The LiveReload command requires IServerModules (that wraps an IServer and an IModule) to determine the host to proxy and the url to open
Current implementation of OpenShift server adapter doesn't contain any IModule, so we provide a stub IModule implementation, even though IModules should be created via IModuleFactories and never be implemented directly.

Signed-off-by: Fred Bricon <fbricon@gmail.com>