### PR TITLE
JBIDE-21482 New Application Wizard: OpenShift project is resetted to 1st entry when I get back

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -364,7 +364,22 @@ public class NewApplicationWizardModel
 	}
 	
 	private void setProjectItems(List<ObservableTreeItem> projects) {
-		update(useLocalTemplate, null, projects, serverTemplate, localTemplateFilename);
+		update(useLocalTemplate, findProject(projects, this.project), projects, serverTemplate, localTemplateFilename);
+	}
+
+	private IProject findProject(List<ObservableTreeItem> projects, IProject project) {
+		if(project == null || projects == null || projects.isEmpty()) {
+			return null;
+		}
+		for (ObservableTreeItem item: projects) {
+			if(item.getModel() instanceof IProject) {
+				IProject p = (IProject)item.getModel();
+				if(p.getName().equals(project.getName())) {
+					return p;
+				}
+			}
+		}
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
When the list of projects is updated, currently selected project is used to find project by name and replace the selected project, before it was reset to null.