### PR TITLE
JBIDE-20751 Wizard closing dialog shown upon canceling a creation of a project in process of creating a new OpenShift 3 application

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
@@ -381,7 +381,7 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 							int result = new OkCancelButtonWizardDialog(getShell(), manageProjectsWizard).open();
 							// reload projects to reflect changes that happened in projects wizard
 							if (manageProjectsWizard.hasChanged()) {
-								loadResources(templatesViewer, model);
+								loadResources(templatesViewer, model, false);
 							}
 							if(Dialog.OK == result) {
 								IProject selectedProject = manageProjectsWizard.getSelectedProject();
@@ -738,17 +738,18 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 
 			@Override
 			public void handleValueChange(ValueChangeEvent event) {
-				loadResources(templatesViewer, model);
+				loadResources(templatesViewer, model, getPreviousPage() == null);
 				templatesViewer.expandAll();
 			}
 		};
 	}
 
-	private void loadResources(final TreeViewer templatesViewer, final ITemplateListPageModel model) {
+	private void loadResources(final TreeViewer templatesViewer, final ITemplateListPageModel model, final boolean closeOnCancel) {
 		if (!model.hasConnection()) {
 			return;
 		}
 		try {
+			final boolean[] closeAfter = new boolean[]{false}; 
 			Job jobs = new JobChainBuilder(
 					new AbstractDelegatingMonitorJob("Loading projects, templates...") {
 
@@ -767,7 +768,7 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 								NewProjectWizard newProjectWizard = new NewProjectWizard(connection, projects);
 								if (Dialog.CANCEL ==
 										WizardUtils.openWizardDialog(newProjectWizard, getShell())) {
-									WizardUtils.close(getWizard());
+									closeAfter[0] = closeOnCancel;
 									return Status.CANCEL_STATUS;
 								} else {
 									model.loadResources();
@@ -785,6 +786,13 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 						}
 					}).build();
 			WizardUtils.runInWizard(jobs, getContainer());
+			if(closeAfter[0]) {
+				Display.getDefault().asyncExec(new Runnable() {
+					public void run() {
+						WizardUtils.close(getWizard());
+					}
+				});
+			}
 		} catch (InvocationTargetException | InterruptedException e) {
 			// intentionnally swallowed
 		}
@@ -792,7 +800,7 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 
 	@Override
 	protected void onPageActivated(final DataBindingContext dbc) {
-		loadResources(templatesViewer, model);
+		loadResources(templatesViewer, model, getPreviousPage() == null);
 		// fix GTK3 combo boxes too small
 		// https://issues.jboss.org/browse/JBIDE-16877,
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=431425


### PR DESCRIPTION
It was the original idea to close New Application wizard entirely
if user cancelled creation of required project. There was bug in it, it is fixed.

Logic for when wizard should be closed or not is enhanced to consider these 3 cases:

1. File-> New -> OpenShift Application or JBoss Central -> OpenShift Application started;
user selects connection and after Next, Select Template page is opened
and dialog New Project is opened automatically (when project list is empty).
In this case, New Application wizard should not be closed on project creation cancel
because user has the option to push Back and select another connection.

2. Context menu on connection New -> Application is started;
dialog New Project is opened automatically (when project list is empty).
In this case New Application wizard should be closed on project creation cancel.

3. New Project dialog is started through Manage Projects link.
In this case, no matter how New Application wizard is started,
it should not be closed if project creation is cancelled.