### PR TITLE
JBIDE-21069 Application wizard: long project display names mess up project selection

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/explorer/OpenShiftExplorerLabelProvider.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/explorer/OpenShiftExplorerLabelProvider.java
@@ -43,7 +43,25 @@ import com.openshift.restclient.model.template.ITemplate;
  * @author Andre Dietisheim
  */
 public class OpenShiftExplorerLabelProvider extends BaseExplorerLabelProvider { 
+	//Limit for label length = baseText.length + qualifiedText.length
+	private static final int DEFAULT_LABEL_LIMIT = 60;
 
+	private int labelLimit;
+
+	public OpenShiftExplorerLabelProvider() {
+		setLabelLimit(DEFAULT_LABEL_LIMIT);
+	}
+
+	/**
+	 * Set limit of label length in characters. 
+	 * @param limit
+	 */
+	public void setLabelLimit(int limit) {
+		if(limit <= 0) {
+			throw new IllegalArgumentException("Label limit cannot be less than 1: " + limit);
+		}
+		labelLimit = limit;
+	}
 	
 	@Override
 	public String getText(Object element) {
@@ -51,7 +69,9 @@ public class OpenShiftExplorerLabelProvider extends BaseExplorerLabelProvider {
 			IProject project = (IProject) element;
 			String name = project.getName();
 			if(org.apache.commons.lang.StringUtils.isNotEmpty(project.getDisplayName())) {
-				name = project.getDisplayName() + " (" + name + ")";
+				String[] parts = new String[]{project.getDisplayName(), name};
+				applyEllipses(parts);
+				name = parts[0] + " (" + parts[1] + ")";
 			}
 			return name;
 		}
@@ -186,7 +206,7 @@ public class OpenShiftExplorerLabelProvider extends BaseExplorerLabelProvider {
 		}, null);
 		return style(template.getName(), tags);
 	}
-	
+
 	private StyledString getStyledText(IProject project) {
 		if(org.apache.commons.lang.StringUtils.isNotBlank(project.getDisplayName())) {
 			return style(project.getDisplayName(), project.getName());
@@ -195,6 +215,10 @@ public class OpenShiftExplorerLabelProvider extends BaseExplorerLabelProvider {
 	}
 
 	private StyledString style(String baseText, String qualifiedText) {
+		String[] parts = new String[]{baseText, qualifiedText};
+		applyEllipses(parts);
+		baseText = parts[0];
+		qualifiedText = parts[1];
 		StyledString value = new StyledString(baseText);
 		if(org.apache.commons.lang.StringUtils.isNotBlank(qualifiedText)) {
 			value.append(" ")
@@ -204,4 +228,7 @@ public class OpenShiftExplorerLabelProvider extends BaseExplorerLabelProvider {
 		return value;
 	}
 
+	private void applyEllipses(String[] parts) {
+		StringUtils.shorten(parts, labelLimit);
+	}
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/core/util/StringUtilsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/core/util/StringUtilsTest.java
@@ -43,4 +43,22 @@ public class StringUtilsTest {
 		assertEquals("http://foo.bar", StringUtils.removeTrailingSlashes("http://foo.bar/"));
 		assertEquals("a", StringUtils.removeTrailingSlashes("a//"));
 	}
+
+	@Test
+	public void testShortenParts(){
+		String[] parts = new String[]{"I am 18 chars long", "7 chars", "?"};
+		StringUtils.shorten(parts, 12);
+		assertEquals("I a...ng", parts[0]);
+		assertEquals("...", parts[1]);
+		assertEquals("?", parts[2]);
+	}
+
+	@Test
+	public void testShortenPartsWithNull(){
+		String[] parts = new String[]{"I am 18 chars long", null, "7 chars"};
+		StringUtils.shorten(parts, 12);
+		assertEquals("I a...ng", parts[0]);
+		assertEquals("7...", parts[2]);
+		assertNull(parts[1]);
+	}
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/explorer/OpenShiftExplorerLabelProviderTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/explorer/OpenShiftExplorerLabelProviderTest.java
@@ -83,7 +83,7 @@ public class OpenShiftExplorerLabelProviderTest {
 	@Test
 	public void getStyledTextForAReplicationController(){
 		IReplicationController rc = givenAResource(IReplicationController.class, ResourceKind.REPLICATION_CONTROLLER);
-		Map<String, String> selector = new HashMap<String, String>();
+		Map<String, String> selector = new HashMap<>();
 		selector.put("foo", "bar");
 		when(rc.getReplicaSelector()).thenReturn(selector);
 		
@@ -102,10 +102,21 @@ public class OpenShiftExplorerLabelProviderTest {
 	}
 
 	@Test
+	public void getStyledTextForAPodWithLongNames() {
+		provider.setLabelLimit(10);
+		IPod pod = givenAResource(IPod.class, ResourceKind.POD);
+
+		String status = "Chilling";
+		when(pod.getStatus()).thenReturn(status);
+		String exp = "s...e C...g";
+		assertEquals(exp, provider.getStyledText(pod).getString());
+	}
+	
+	@Test
 	public void getStyledTextForAPodWithoutLabels(){
 		IPod pod = givenAResource(IPod.class, ResourceKind.POD);
 		when(pod.getIP()).thenReturn("172.17.2.226");
-		Map<String, String> labels = new HashMap<String, String>();
+		Map<String, String> labels = new HashMap<>();
 		when(pod.getLabels()).thenReturn(labels);
 		
 		assertEquals(pod.getName(), provider.getStyledText(pod).getString());
@@ -117,7 +128,7 @@ public class OpenShiftExplorerLabelProviderTest {
 		when(service.getPortalIP()).thenReturn("172.17.2.226");
 		when(service.getPort()).thenReturn(5432);
 		when(service.getTargetPort()).thenReturn("3306");
-		Map<String, String> labels = new HashMap<String, String>();
+		Map<String, String> labels = new HashMap<>();
 		labels.put("foo", "bar");
 		when(service.getSelector()).thenReturn(labels);
 		
@@ -135,12 +146,23 @@ public class OpenShiftExplorerLabelProviderTest {
 	@Test
 	public void getStyledTextForADeploymentConfig(){
 		IDeploymentConfig config = givenAResource(IDeploymentConfig.class, ResourceKind.DEPLOYMENT_CONFIG);
-		Map<String, String> selector = new HashMap<String, String>();
+		Map<String, String> selector = new HashMap<>();
 		selector.put("name", "foo");
 		selector.put("deployment", "bar");
 		when(config.getReplicaSelector()).thenReturn(selector );
 		
 		assertEquals(config.getName() + " selector: deployment=bar,name=foo", provider.getStyledText(config).getString());
+	}
+	
+	@Test
+	public void getStyledTextForADeploymentConfigWithLongNames(){
+		provider.setLabelLimit(120);
+		IDeploymentConfig config = givenAResource(IDeploymentConfig.class, ResourceKind.DEPLOYMENT_CONFIG);
+		Map<String, String> selector = new HashMap<>();
+		selector.put("name", "foo01234567890123456789012345678901234567890123456789");
+		selector.put("deployment", "bar01234567890123456789012345678901234567890123456789");
+		when(config.getReplicaSelector()).thenReturn(selector );
+		assertEquals("someName selector: deployment=bar0123456789012345678901234567890...=foo01234567890123456789012345678901234567890123456789", provider.getStyledText(config).getString());
 	}
 	
 	@Test


### PR DESCRIPTION
Length of label text returned by OpenShiftExplorerLabelProvider is limited.
This provider is used not only in explorer but in many viewers in wizards.
It is not user friendly to display the entire value if its length is unreasonably large.
In this solution, ellipses are applied if length exceeds 120 symbols.