### PR TITLE
JBIDE-18082 Application wizard, Connection wizard: Last used connection from explorer is not preselected

### DIFF
--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
@@ -36,6 +36,7 @@ import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.common.ui.DelegatingProgressMonitor;
 import org.jboss.tools.common.ui.JobUtils;
 import org.jboss.tools.common.ui.WizardUtils;
+import org.jboss.tools.openshift.common.core.connection.ConnectionsRegistrySingleton;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
 import org.jboss.tools.openshift.common.ui.wizard.NewApplicationWorkbenchWizard;
 import org.jboss.tools.openshift.express.internal.core.connection.ExpressConnection;
@@ -415,6 +416,9 @@ public abstract class ExpressApplicationWizard extends Wizard implements IWorkbe
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		updateModel(selection, getModel());
+		if(getModel().getConnection() != null) {
+			ConnectionsRegistrySingleton.getInstance().setRecent(getModel().getConnection());
+		}
 	}
 
 	private void updateModel(IStructuredSelection selection, IOpenShiftApplicationWizardModel model) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWizard;
 import org.jboss.tools.common.ui.JobUtils;
+import org.jboss.tools.openshift.common.core.connection.ConnectionsRegistrySingleton;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.connection.ConnectionsRegistryUtil;
 import org.jboss.tools.openshift.internal.common.core.UsageStats;
@@ -78,9 +79,13 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 		} else {
 			IResource resource = UIUtils.getFirstElement(selection, IResource.class);
 			if (resource != null) {
-				model.setConnection(ConnectionsRegistryUtil.safeGetConnectionFor(resource));
+				connection = ConnectionsRegistryUtil.safeGetConnectionFor(resource);
+				model.setConnection(connection);
 				model.setProject(resource.getProject());
 			} 
+		}
+		if(connection != null) {
+			ConnectionsRegistrySingleton.getInstance().setRecent(connection);
 		}
 	}
 


### PR DESCRIPTION
At initializing New Application wizard, current connection is
set to connection registry as recent.