### PR TITLE
JBIDE-21760 NPE is thrown on addition of a first pod-service mapping in Deploy docker image wizard

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicePortDialog.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicePortDialog.java
@@ -151,12 +151,12 @@ public class ServicePortDialog extends AbstractOpenShiftWizardPage {
 				return ERROR;
 			}
 			String newPort = (String) value;
-			if(!podPort.equals(newPort)) {
+			if(!newPort.equals(podPort)) {
 				if(newPort.length() > MAXLENGTH || !REGEXP.matcher(newPort).matches()) {
 					return ERROR;
 				}
 				for (IServicePort port : ports) {
-					if(port.getTargetPort().equals(newPort)) {
+					if(newPort.equals(port.getTargetPort())) {
 						return ERROR;
 					}
 				}


### PR DESCRIPTION
IServicePort.getTargetPort() returns null.
The fix reverts podPort.equals(newPort) to newPort.equals(podPort) because newPort is checked above for null.
@jcantrill, could you please check if it is allowed for IServicePort.getTargetPort() to return null.
