### PR TITLE
[JBIDE-21626] Fix deploy docker image

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
@@ -44,5 +44,7 @@ Require-Bundle: org.apache.httpcomponents.httpclient;bundle-version="4.3.6",
  org.eclipse.jetty.util;bundle-version="9.2.13",
  org.eclipse.jetty.io;bundle-version="9.2.13",
  org.eclipse.jetty.websocket.common;bundle-version="9.2.13",
- org.eclipse.jetty.websocket.api;bundle-version="9.2.13"
+ org.eclipse.jetty.websocket.api;bundle-version="9.2.13",
+ org.eclipse.jetty.client;bundle-version="9.2.13",
+ org.eclipse.jetty.http;bundle-version="9.2.13"
 Bundle-Activator: org.jboss.tools.openshift.client.internal.OpenShiftClientActivator

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeployImageHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeployImageHandler.java
@@ -55,7 +55,7 @@ public class DeployImageHandler extends AbstractHandler {
 		}
 
 		
-		WizardUtils.openWizardDialog(600, 1500, new DeployImageWizard(model), HandlerUtil.getActiveShell(event));
+		WizardUtils.openWizardDialog(600, 1500, new DeployImageWizard(model), HandlerUtil.getActiveWorkbenchWindow(event).getShell());
 		return null;
 	}
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
@@ -59,6 +59,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.jboss.tools.common.ui.WizardUtils;
+import org.jboss.tools.common.ui.databinding.ParametrizableWizardPageSupport;
 import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.internal.common.ui.connection.ConnectionColumLabelProvider;
@@ -92,6 +93,11 @@ public class DeployImagePage extends AbstractOpenShiftWizardPage {
 	protected DeployImagePage(IWizard wizard, IDeployImagePageModel model) {
 		super("Deploy an Image", PAGE_DESCRIPTION, "Deployment Config Settings Page", wizard);
 		this.model = model;
+	}
+	
+	@Override
+	protected void setupWizardPageSupport(DataBindingContext dbc) {
+		ParametrizableWizardPageSupport.create(IStatus.ERROR |  IStatus.CANCEL, this, dbc);
 	}
 
 	/**

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicesAndRoutingPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicesAndRoutingPage.java
@@ -16,6 +16,11 @@ import java.util.List;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
+import org.eclipse.core.databinding.observable.list.IObservableList;
+import org.eclipse.core.databinding.validation.MultiValidator;
+import org.eclipse.core.databinding.validation.ValidationStatus;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.databinding.viewers.ObservableListContentProvider;
 import org.eclipse.jface.databinding.viewers.ViewerProperties;
@@ -116,8 +121,19 @@ public class ServicesAndRoutingPage extends AbstractOpenShiftWizardPage  {
 				.to(BeanProperties.value(IServiceAndRoutingPageModel.PROPERTY_SELECTED_SERVICE_PORT).observe(model))
 				.in(dbc);
 		portsViewer.setContentProvider(new ObservableListContentProvider());
-		portsViewer.setInput(BeanProperties.list(
-				IServiceAndRoutingPageModel.PROPERTY_SERVICE_PORTS).observe(model));
+		IObservableList portsObservable = BeanProperties.list(
+				IServiceAndRoutingPageModel.PROPERTY_SERVICE_PORTS).observe(model);
+		portsViewer.setInput(portsObservable);
+		dbc.addValidationStatusProvider(new MultiValidator() {
+			
+			@Override
+			protected IStatus validate() {
+				if(portsObservable.isEmpty()) {
+					return ValidationStatus.error("At least 1 port is required when generating the service for the deployed image");
+				}
+				return Status.OK_STATUS;
+			}
+		});
 	
 		Button btnAdd = new Button(container, SWT.PUSH);
 		GridDataFactory.fillDefaults()

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/DeployImageWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/DeployImageWizardModelTest.java
@@ -10,30 +10,57 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.test.ui.models;
 
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
 
 import org.eclipse.linuxtools.docker.core.IDockerConnection;
 import org.jboss.tools.openshift.internal.ui.wizard.deployimage.DeployImageWizardModel;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import com.openshift.restclient.capability.resources.IImageStreamImportCapability;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IProject;
+import com.openshift.restclient.model.IStatus;
+import com.openshift.restclient.model.image.IImageStreamImport;
+
+@RunWith(MockitoJUnitRunner.class)
 public class DeployImageWizardModelTest {
 
 	private DeployImageWizardModel model;
 	private IDockerConnection dockerConnection;
+	@Mock
+	private IProject project;
+	@Mock
+	private IImageStreamImportCapability cap;
+	@Mock
+	private IImageStreamImport streamImport;
+	@Mock
+	private IStatus status;
 	
 	@Before
 	public void setUp() {
 		model = new DeployImageWizardModel();
 		dockerConnection = mock(IDockerConnection.class);
 		model.setDockerConnection(dockerConnection);
+
+		model.setProject(project);
+		when(project.supports(IImageStreamImportCapability.class)).thenReturn(true);
+		when(project.getCapability(IImageStreamImportCapability.class)).thenReturn(cap);
+		
+		when(status.getStatus()).thenReturn("Success");
+		when(cap.importImageMetadata(any(DockerImageURI.class))).thenReturn(streamImport);
+		when(streamImport.getImageStatus()).thenReturn(Arrays.asList(status));
 	}
-	
 	
 	@Test
 	public void testImageExistsLocally() {
+		model.setProject(null);
 		assertFalse(model.imageExistsLocally(null));
 		assertFalse(model.imageExistsLocally(" "));
 		
@@ -54,4 +81,5 @@ public class DeployImageWizardModelTest {
 		assertFalse(model.imageExistsLocally("foo/bar"));
 		
 	}
+
 }


### PR DESCRIPTION
The PR fixes deploying a docker image by:

* pulling metadata from a docker connection or via openshift imagestreamimport
* allows create of 'deploy image' resources without image metadata. deployment is dependent upon server being able to access image

cc @fbricon @adietish 