### PR TITLE
JBIDE-21776 - Cannot deploy docker image to OpenShift with manually entered details

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
@@ -41,6 +41,8 @@ Require-Bundle: org.jboss.tools.openshift.common.ui;bundle-version="[3.0.0,4.0.0
  org.eclipse.core.variables,
  org.apache.commons.io;bundle-version="2.0.1",
  org.apache.httpcomponents.httpclient,
+ org.apache.httpcomponents.httpcore;bundle-version="4.3.3",
+ org.jboss.ide.eclipse.as.dmr;bundle-version="3.1.1",
  org.apache.commons.lang;bundle-version="2.6.0",
  org.apache.commons.collections;bundle-version="3.2.0",
  org.eclipse.ui.workbench.texteditor,
@@ -65,5 +67,6 @@ Export-Package: org.jboss.tools.openshift.internal.ui;x-friends:="org.jboss.tool
  org.jboss.tools.openshift.internal.ui.wizard.builder;x-friends:="org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.wizard.common;x-friends:="org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.wizard.deployimage;x-friends:="org.jboss.tools.openshift.test",
+ org.jboss.tools.openshift.internal.ui.wizard.deployimage.search;x-friends:="org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.wizard.importapp;x-friends:="org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.wizard.newapp;x-friends:="org.jboss.tools.openshift.test"

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/IDeployImagePageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/IDeployImagePageModel.java
@@ -81,11 +81,18 @@ public interface IDeployImagePageModel extends IConnectionAware<Connection>{
 	void setImage(String image);
 	
 	/**
-	 * 
-	 * @param image
-	 * @return true if the image exists in the docker registry
+	 * Checks if an image with the given name exists in the selected Docker daemon
+	 * @param imageName the full name of the image to search locally
+	 * @return true if the image exists in the select Docker's registry cache
 	 */
-	boolean imageExists(String image);
+	boolean imageExistsLocally(String imageName);
+
+	/**
+	 * Checks if an image with the given name exists in a remote registry
+	 * @param imageName the full name of the image to search remotely
+	 * @return true if the image exists in a remote registry
+	 */
+	boolean imageExistsRemotely(String imageName);
 	
 	/**
 	 * @return the list of names of all images for the current Docker connection.

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/search/DockerHubRegistry.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/search/DockerHubRegistry.java
@@ -1,0 +1,140 @@
+package org.jboss.tools.openshift.internal.ui.wizard.deployimage.search;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.eclipse.linuxtools.docker.core.IRepositoryTag;
+import org.jboss.dmr.ModelNode;
+import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
+
+/**
+ * The default implementation is the Docker Hub registry (running Docker
+ * registry version 0.6.3)
+ */
+@SuppressWarnings("restriction")
+public class DockerHubRegistry {
+
+	private static final String REGISTRY_LOCATION = "https://registry.hub.docker.com/"; //$NON-NLS-1$
+
+	/**
+	 * Searches for the tags of the given image on the Docker registry.
+	 * @param repoName the repository/name of the image to search
+	 * @return the list of tags for the given repository, or empty list if none was found
+	 */
+	public List<String> getTags(final String repoName) {
+		final HttpClient httpClient = HttpClientBuilder.create().build();
+		try {
+			// check that the registry supports the version 1 API
+			// see
+			// https://github.com/docker/docker-registry/blob/master/docker_registry/app.py
+			final HttpGet pingApiV1Request = new HttpGet(
+					URIBuilder.target(REGISTRY_LOCATION).path("v1").path("_ping").toString());
+			pingApiV1Request.setHeader("Accept", "application/json");
+			final HttpResponse pingApiV1Response = httpClient.execute(pingApiV1Request);
+			if (pingApiV1Response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+				throw new InvalidDockerRegistryException(REGISTRY_LOCATION);
+			}
+			// now perform the call to retrieve the list of tags for the given
+			// repo/name
+			final HttpGet getTagsRequest = new HttpGet(URIBuilder.target(REGISTRY_LOCATION).path("v1")
+					.path("repositories").path(repoName).path("tags").toString());
+			getTagsRequest.setHeader("Accept", "application/json");
+			final HttpResponse getTagsResponse = httpClient.execute(getTagsRequest);
+			if (getTagsResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+				return Collections.emptyList();
+			}
+			final ModelNode tags = ModelNode.fromJSONStream(getTagsResponse.getEntity().getContent());
+			return tags.asList().stream().map(node -> node.get("name").asString()).collect(Collectors.toList());
+		} catch (final IOException e) {
+			OpenShiftUIActivator.getDefault().getLogger().logError("Failed to retrieve the tags for image named '" + repoName + "'", e);
+		}
+		return Collections.emptyList();
+	}
+	
+	/**
+	 * URI Builder
+	 */
+	private static class URIBuilder {
+		
+		private final StringBuilder uri; 
+		private URIBuilder(final String target) {
+			this.uri = new StringBuilder(target);
+		}
+		public static URIBuilder target(final String target) {
+			return new URIBuilder(target);
+		}
+		
+		/**
+		 * Appends the given {@code path} to the current URI. 
+		 * @param path the path to append
+		 * @return this {@link URIBuilder}, for fluent chaining with other paths.
+		 */
+		public URIBuilder path(final String path) {
+			if(path.charAt(0) != '/') {
+				this.uri.append('/');
+			}
+			this.uri.append(path);
+			return this;
+		}
+		
+		@Override
+		public String toString() {
+			return this.uri.toString();
+		}
+		
+	}
+	
+	/**
+	 * Repository tag retrieved from Docker Registry version 0.6.3
+	 *
+	 */
+	@Deprecated
+	public class RepositoryTag implements IRepositoryTag {
+
+		private String layer;
+
+		private String name;
+
+		/**
+		 * @return the layer
+		 */
+		@Override
+		public String getLayer() {
+			return layer;
+		}
+
+		/**
+		 * @param layer
+		 *            the layer to set
+		 */
+		public void setLayer(String layer) {
+			this.layer = layer;
+		}
+
+		/**
+		 * @return the name
+		 */
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		/**
+		 * @param name
+		 *            the name to set
+		 */
+		public void setName(String name) {
+			this.name = name;
+		}
+
+	}
+
+
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/search/InvalidDockerRegistryException.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/search/InvalidDockerRegistryException.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package org.jboss.tools.openshift.internal.ui.wizard.deployimage.search;
+
+import com.openshift.restclient.OpenShiftException;
+
+/**
+ * Custom {@link OpenShiftException} raised when the Docker Registry that is accessed is not compatible with the Docker Registry v1 API.
+ */
+public class InvalidDockerRegistryException extends OpenShiftException {
+	
+	/** Generated Serial Version UID */
+	private static final long serialVersionUID = -3167694006460745225L;
+	
+	/** The URI of the Registry that was accessed. */
+	private final String registryURI;
+	
+	/**
+	 * Constructor
+	 * @param registryURI the URI of the Registry that was accessed.
+	 */
+	public InvalidDockerRegistryException(final String registryURI) {
+		super("Docker Registry at '{}' is incompatible with API v1", registryURI);
+		this.registryURI = registryURI;
+	}
+	
+	/**
+	 * @return the URI of the Registry that was accessed.
+	 */
+	public String getRegistryURI() {
+		return registryURI;
+	}
+
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/search/package-info.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/search/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+/**
+ * 
+ */
+package org.jboss.tools.openshift.internal.ui.wizard.deployimage.search;

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/DeployImageWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/DeployImageWizardModelTest.java
@@ -33,25 +33,25 @@ public class DeployImageWizardModelTest {
 	
 	
 	@Test
-	public void testImageExists() {
-		assertFalse(model.imageExists(null));
-		assertFalse(model.imageExists(" "));
+	public void testImageExistsLocally() {
+		assertFalse(model.imageExistsLocally(null));
+		assertFalse(model.imageExistsLocally(" "));
 		
 		//no tag
-		model.imageExists("foo/bar");
+		model.imageExistsLocally("foo/bar");
 		verify(dockerConnection).hasImage("foo/bar", "latest");
 		
 		//has tag
-		model.imageExists("foo/bar:asf34fs");
+		model.imageExistsLocally("foo/bar:asf34fs");
 		verify(dockerConnection).hasImage("foo/bar", "asf34fs");
 		
 		//has registry+port and tag
-		model.imageExists("host:1234/foo/bar:asf34fs");
+		model.imageExistsLocally("host:1234/foo/bar:asf34fs");
 		verify(dockerConnection).hasImage("host:1234/foo/bar", "asf34fs");
 		
 		//
 		model.setDockerConnection(null);
-		assertFalse(model.imageExists("foo/bar"));
+		assertFalse(model.imageExistsLocally("foo/bar"));
 		
 	}
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/deployimage/search/DockerHubRegistryTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/deployimage/search/DockerHubRegistryTest.java
@@ -1,0 +1,23 @@
+package org.jboss.tools.openshift.test.ui.wizard.deployimage.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.linuxtools.docker.core.DockerException;
+import org.jboss.tools.openshift.internal.ui.wizard.deployimage.search.DockerHubRegistry;
+import org.junit.Test;
+
+public class DockerHubRegistryTest {
+
+	@Test
+	public void shouldFindImageTags() throws InterruptedException, ExecutionException, DockerException {
+		// given
+		final DockerHubRegistry dockerHubRegistrySearch = new DockerHubRegistry();
+		// when
+		final List<String> tags = dockerHubRegistrySearch.getTags("jboss/wildfly");
+		// then
+		assertThat(tags).contains("8.2.0.Final", "9.0.2.Final", "latest");
+	}
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/deployimage/search/package-info.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/deployimage/search/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+/**
+ * 
+ */
+package org.jboss.tools.openshift.test.ui.wizard.deployimage.search;


### PR DESCRIPTION
Validating that an image with the given name exists in the selected Docker daemon's cache
 or in the registry when the user clicks on "Next", in order to keep the as-you-type
 validation as fast as possible (ie, only validate that the name matches a regex)