### PR TITLE
JBIDE-21808 - outdated "import package" declaration in "org.jboss.tools.openshift.test"

### DIFF
--- a/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
@@ -23,10 +23,7 @@ Require-Bundle: org.jboss.tools.openshift.client;bundle-version="[3.0.0,4.0.0)",
  org.apache.commons.logging;bundle-version="1.1.1",
  org.assertj.core;bundle-version="2.1.0",
  org.apache.commons.collections,
- org.eclipse.linuxtools.docker.core
+ org.eclipse.linuxtools.docker.core,
+ org.jboss.tools.common.ui;bundle-version="3.7.1",
+ org.eclipse.core.databinding;bundle-version="1.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.openshift.client,
- org.eclipse.core.databinding.validation,
- org.jboss.tools.common.ui,
- org.jboss.tools.common.ui.databinding,
- org.jboss.tools.openshift.internal.common.ui


### PR DESCRIPTION
replaced import-packages directive with additional entries in the required-bundles