### PR TITLE
JBIDE-21797 - vagrant 1.8.x has different output to vagrant status --…

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/VagrantPoller.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/VagrantPoller.java
@@ -186,27 +186,33 @@ public class VagrantPoller implements IServerStatePoller2 {
 	}
 	
 	
-	private int parseOutput(String[] lines) {
+	protected int parseOutput(String[] lines) {
 		HashMap<String, VagrantStatus> status = new HashMap<String, VagrantStatus>();
 		if( lines != null && lines.length > 0 ) {
 			for( int i = 0; i < lines.length; i++ ) {
 				String[] csv = lines[i].split(",");
-				String timestamp = csv[0];
-				String vmId = csv[1];
-				if( vmId != null && !vmId.isEmpty() ) {
-					VagrantStatus vs = status.get(vmId);
-					if( vs == null ) {
-						vs = new VagrantStatus(vmId);
-						status.put(vmId, vs);
-					}
-					String k = csv[2];
-					String v = csv[3];
-					if( k != null ) {
-						vs.setProperty(k,v);
-					}
-				} else {
-					return IStatus.INFO;
-				}
+				if( csv.length >=2 ) { // avoid arrayindex errors
+					String timestamp = csv[0];
+					String vmId = csv[1];
+					if( vmId != null && !vmId.isEmpty() ) {
+						VagrantStatus vs = status.get(vmId);
+						if( vs == null ) {
+							vs = new VagrantStatus(vmId);
+							status.put(vmId, vs);
+						}
+						String k = csv[2];
+						String v = csv[3];
+						if( k != null ) {
+							vs.setProperty(k,v);
+						}
+					} //else {
+					  // The given line has no vm id, so it is not relevant here. 
+					  //}
+				} //else {
+				  // The given line isn't csv or doesn't have at least 2 items in the csv array
+				  // and so should be ignored
+				  //return IStatus.INFO;
+				  //}
 			}
 		}		
 		Collection<VagrantStatus> stats = status.values();

--- a/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
@@ -22,5 +22,6 @@ Require-Bundle: org.jboss.tools.common.core;bundle-version="3.7.0",
  org.eclipse.pde.core,
  org.jboss.tools.foundation.ui,
  org.jboss.tools.openshift.common.core,
- org.eclipse.debug.core
+ org.eclipse.debug.core,
+ org.jboss.ide.eclipse.as.core;bundle-version="3.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/AllTestsSuite.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/AllTestsSuite.java
@@ -13,6 +13,7 @@ package org.jboss.tools.openshift.cdk.server.test;
 import org.jboss.tools.openshift.cdk.server.test.internal.CDKDockerUtilityTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.CDKLaunchControllerTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.CDKOpenshiftUtilityTest;
+import org.jboss.tools.openshift.cdk.server.test.internal.VagrantPollerTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -21,7 +22,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
 	CDKDockerUtilityTest.class,
 	CDKOpenshiftUtilityTest.class,
-	CDKLaunchControllerTest.class
+	CDKLaunchControllerTest.class,
+	VagrantPollerTest.class
 })
 /**
  * @author Andre Dietisheim

--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/VagrantPollerTest.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/VagrantPollerTest.java
@@ -1,0 +1,62 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.openshift.cdk.server.test.internal;
+
+import org.eclipse.core.runtime.IStatus;
+import org.jboss.tools.openshift.cdk.server.core.internal.CDKConstants;
+import org.jboss.tools.openshift.cdk.server.core.internal.adapter.VagrantPoller;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class VagrantPollerTest extends TestCase {
+	
+	@Test
+	public void testOutputParsing() {
+		VagrantPollerSub sub = new VagrantPollerSub();
+
+		String[] output = vagrant18_out(CDKConstants.STATE_RUNNING);
+		assertEquals(IStatus.OK, sub.parseOutput2(output));
+		
+		output = vagrant18_out(CDKConstants.STATE_POWEROFF);
+		assertEquals(IStatus.ERROR, sub.parseOutput2(output));
+		
+		output = vagrant18_out(CDKConstants.STATE_SHUTOFF);
+		assertEquals(IStatus.ERROR, sub.parseOutput2(output));
+		
+		output = vagrant17_out(CDKConstants.STATE_RUNNING);
+		assertEquals(IStatus.OK, sub.parseOutput2(output));
+		output = vagrant17_out(CDKConstants.STATE_POWEROFF);
+		assertEquals(IStatus.ERROR, sub.parseOutput2(output));
+		output = vagrant17_out(CDKConstants.STATE_SHUTOFF);
+		assertEquals(IStatus.ERROR, sub.parseOutput2(output));
+		
+	}
+	
+	private String[] vagrant18_out(String state) {
+		return new String[]{"1457045944,cdk,state," + state, 
+				"1457045944,cdk,state-human-short," + state,
+				"1457045944,cdk,state-human-long,The blahblahtruncated",
+				"1457045944,,ui,info,Current machine states:\\n\\ncdk blahblah truncated\n"};
+	}
+	private String[] vagrant17_out(String state) {
+		return new String[]{"1457045944,cdk,state," + state, 
+				"1457045944,cdk,state-human-short," + state,
+				"1457045944,cdk,state-human-long,The blahblahtruncated\n"};
+	}
+	
+	
+	private class VagrantPollerSub extends VagrantPoller {
+		public int parseOutput2(String[] lines) {
+			return parseOutput(lines);
+		}
+	}
+}


### PR DESCRIPTION
…machine-readable, adds line with no vagrant id breaking our parse code expectations