### PR TITLE
JBIDE-21816 Table is not refreshed properly in SWT_GTK3

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/GTK3Utils.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/GTK3Utils.java
@@ -14,6 +14,7 @@ package org.jboss.tools.openshift.internal.common.ui.utils;
 import java.lang.reflect.Field;
 
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.viewers.TableViewer;
 
 /**
  * @author Snjezana Peco
@@ -55,5 +56,26 @@ public class GTK3Utils {
 		return !"0".equals(gtk3); //$NON-NLS-1$
 	}
 
+	/**
+	 * This method is a workaround for an issue in GTK3.
+	 * It does nothing in an environment other than GTK3.
+	 * 
+	 * In GTK3 table viewer in some cases (e.g. if it is invisible,
+	 * on the next wizard page, and has vertical scroll) is not updated
+	 * after its content is changed even with refresh(true).
+	 * This method makes it to update in a radical way. It will 
+	 * take effect if invoked after tree of widgets including 
+	 * the table gets visible (e.g. on wizard page activated).
+	 * @param viewer
+	 */
+	public static void refreshTableViewer(TableViewer viewer) {
+		if(isRunning() && viewer != null && viewer.getControl() != null && !viewer.getControl().isDisposed()) {
+			Object input = viewer.getInput();
+			if(input != null) {
+				viewer.setInput(null);
+				viewer.setInput(input);
+			}
+		}
+	}
 	
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeploymentConfigPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeploymentConfigPage.java
@@ -12,7 +12,6 @@ package org.jboss.tools.openshift.internal.ui.wizard.deployimage;
 
 
 import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.databinding.DataBindingContext;
@@ -41,6 +40,7 @@ import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Table;
 import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
 import org.jboss.tools.openshift.internal.common.ui.databinding.IsNotNull2BooleanConverter;
+import org.jboss.tools.openshift.internal.common.ui.utils.GTK3Utils;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder;
 import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder.IColumnLabelProvider;
@@ -385,4 +385,10 @@ public class DeploymentConfigPage extends AbstractOpenShiftWizardPage {
 		return dataViewer;
 	}
 	
+	@Override
+	protected void onPageActivated(DataBindingContext dbc) {
+		GTK3Utils.refreshTableViewer(envViewer);
+		GTK3Utils.refreshTableViewer(dataViewer);
+	}
+
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicesAndRoutingPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicesAndRoutingPage.java
@@ -39,6 +39,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
 import org.jboss.tools.openshift.internal.common.ui.databinding.IsNotNull2BooleanConverter;
+import org.jboss.tools.openshift.internal.common.ui.utils.GTK3Utils;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder;
 import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder.IColumnLabelProvider;
@@ -285,4 +286,8 @@ public class ServicesAndRoutingPage extends AbstractOpenShiftWizardPage  {
 		};
 	}
 
+	@Override
+	protected void onPageActivated(DataBindingContext dbc) {
+		GTK3Utils.refreshTableViewer(portsViewer);
+	}
 }


### PR DESCRIPTION
The fix is done for Deploy Image to Openshift wizard.
Utility method that can be used in other wizards that
are affected by the same problem is put to GTK3Utils.refreshTableViewer(TableViewer).