### PR TITLE
JBIDE-21802 - Content assist for image names in "Deploy Docker Image" wizard

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
@@ -335,16 +335,11 @@ public class DeployImagePage extends AbstractOpenShiftWizardPage {
 		return new IContentProposalProvider() {
 
 			@Override
-			public IContentProposal[] getProposals(final String contents,
+			public IContentProposal[] getProposals(final String input,
 					final int position) {
-				final List<IContentProposal> proposals = new ArrayList<>();
-				for (String imageName : model.getImageNames()) {
-					if (imageName.contains(contents)) {
-						proposals.add(new ContentProposal(imageName, imageName,
-								null, position));
-					}
-				}
-				return proposals.toArray(new IContentProposal[0]);
+				return model.getImageNames().stream().filter(name -> name.contains(input))
+						.map(n -> new ContentProposal(n, n, null, position))
+						.toArray(size -> new IContentProposal[size]);
 			}
 		};
 	}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizardModel.java
@@ -466,7 +466,9 @@ public class DeployImageWizardModel
 	public void setDockerConnection(IDockerConnection dockerConnection) {
 		firePropertyChange(PROPERTY_DOCKER_CONNECTION, this.dockerConnection, this.dockerConnection = dockerConnection);
 		this.imageNames.clear();
-		this.imageNames.addAll(dockerConnection.getImages().stream().flatMap(image -> image.repoTags().stream()).sorted().collect(Collectors.toList()));
+		this.imageNames.addAll(dockerConnection.getImages().stream()
+				.filter(image -> !image.isDangling() && !image.isIntermediateImage())
+				.flatMap(image -> image.repoTags().stream()).sorted().collect(Collectors.toList()));
 	}
 
 	@Override


### PR DESCRIPTION
Ignoring dnagling and intermediate images in the content assist proposals.
Using Lambda Expression instead of old for-loop based.