### PR TITLE
JBIDE-21701 - Enable port forwarding on a given pod and a given debug port

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
@@ -35,6 +35,7 @@ Export-Package: org.jboss.tools.openshift.core;x-friends:="org.jboss.tools.opens
  org.jboss.tools.openshift.core.server;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.core.util;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.internal.core;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
+ org.jboss.tools.openshift.internal.core.portforwarding;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.internal.core.preferences;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui",
  org.jboss.tools.openshift.internal.core.util;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.ui"
 Service-Component: META-INF/connectionFactory.xml

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtils.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package org.jboss.tools.openshift.internal.core.portforwarding;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.resources.IPortForwardable;
+import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
+import com.openshift.restclient.model.IPod;
+
+/**
+ * Utility class about port forwarding.
+ */
+public class PortForwardingUtils {
+
+	/** Internal registry of {@link IPod}'s port-forwarding. */
+	private static final Map<IPod, IPortForwardable> REGISTRY = new HashMap<IPod, IPortForwardable>();
+
+	/**
+	 * Checks if the given port is already used
+	 * 
+	 * @param port
+	 *            the port to check
+	 * @return <code>true</code> if the port is used, <code>false</code> if it
+	 *         is available.
+	 */
+	public static boolean isPortInUse(int port) {
+		if (port < 0 || port >= 65536) {
+			return false;
+		}
+		try {
+			new ServerSocket(port).close();
+			return false;
+		} catch (IOException e) {
+			// success
+		}
+		try (Socket socket = new Socket("localhost", port)) {
+			return true; // success
+		} catch (IOException e) {
+			return false;
+		}
+	}
+	
+	/**
+	 * Checks if any of the given ports is already used.
+	 * @param ports the ports to check
+	 * @return <code>true</code> if at least one port is used, <code>false</code> otherwise
+	 */
+	public static boolean hasPortInUse(final Collection<IPortForwardable.PortPair> ports) {
+		return ports.stream().filter(port -> PortForwardingUtils.isPortInUse(port.getLocalPort())).findAny()
+				.isPresent();
+	}
+
+	/**
+	 * Checks if the given {@link IPod} is already forwarding
+	 * <strong>all</strong> its ports.
+	 * 
+	 * @param pod
+	 *            the pod to check
+	 * @return <code>true</code> if port-forwarding is started,
+	 *         <code>false</code> otherwise.
+	 */
+	public static boolean isPortForwardingStarted(final IPod pod) {
+		final IPortForwardable capability = REGISTRY.get(pod);
+		return capability != null && capability.isForwarding();
+	}
+	
+	/**
+	 * Returns the {@link PortPair} for the given {@code pod}
+	 * @param pod the pod to analyze
+	 * @return an <strong>immutable</strong> {@link Set} of {@link PortPair} 
+	 */
+	public static Set<IPortForwardable.PortPair> getForwardablePorts(final IPod pod) {
+		final Set<IPortForwardable.PortPair> ports = new HashSet<>();
+		final IPortForwardable forwardable = REGISTRY.get(pod);
+		if (forwardable != null && forwardable.getPortPairs() != null) {
+			Stream.of(forwardable.getPortPairs()).forEach(portPair -> ports.add(portPair));
+		} else if (pod.getContainerPorts() != null) {
+			pod.getContainerPorts().stream().map(containerPort -> new IPortForwardable.PortPair(containerPort))
+					.forEach(portPair -> ports.add(portPair));
+		}
+		return Collections.unmodifiableSet(ports);
+	}
+
+	/**
+	 * Starts port-forwarding for the given {@code pod}
+	 * 
+	 * @param pod
+	 *            the pod on which port-forwarding is to be started
+	 * @param ports
+	 *            the ports to forward
+	 * @return the {@link IPortForwardable} referencing all ports that were
+	 *         forwarded, or <code>null</code> if port-forwarding was already
+	 *         started on the given pod.
+	 */
+	public static IPortForwardable startPortForwarding(final IPod pod, final Set<IPortForwardable.PortPair> ports) {
+		// skip if port-forwarding is already started
+		if (isPortForwardingStarted(pod)) {
+			return null;
+		}
+		final IPortForwardable portForwarding = pod
+				.accept(new CapabilityVisitor<IPortForwardable, IPortForwardable>() {
+
+					@Override
+					public IPortForwardable visit(final IPortForwardable portForwarding) {
+						portForwarding.forwardPorts(ports.toArray(new IPortForwardable.PortPair[] {}));
+						return portForwarding;
+					}
+				}, null);
+		if (portForwarding != null) {
+			REGISTRY.put(pod, portForwarding);
+		}
+		return portForwarding;
+	}
+
+	/**
+	 * Starts port-forwarding for the given {@code pod} for a <strong>single</strong> port.
+	 * 
+	 * @param pod
+	 *            the pod on which port-forwarding is to be started
+	 * @param port
+	 *            the port to forward
+	 * @return the {@link IPortForwardable} referencing all ports that were
+	 *         forwarded, or <code>null</code> if port-forwarding was already
+	 *         started on the given pod.
+	 */
+	public static IPortForwardable startPortForwarding(final IPod pod, final PortPair port) {
+		final HashSet<PortPair> ports = new HashSet<>();
+		ports.add(port);
+		return startPortForwarding(pod, ports);
+	}
+
+	/**
+	 * Stops all port-forwarding for the given {@code pod}
+	 * 
+	 * @param pod
+	 *            the pod on which port-forwarding is to be stopped
+	 * @param stream the MessageConsoleStream to use to print messages 
+	 * @return the {@link IPortForwardable} referencing all ports that were
+	 *         forwarded, or <code>null</code> if port-forwarding was not already
+	 *         started on the given pod.
+	 * @throws IOException when writing into the given {@code stream} fails
+	 */
+	public static IPortForwardable stopPortForwarding(final IPod pod, final OutputStream stream) throws IOException {
+		if (!PortForwardingUtils.isPortForwardingStarted(pod)) {
+			return null;
+		}
+		final IPortForwardable portForwarding = REGISTRY.remove(pod);
+		if (portForwarding != null) {
+			portForwarding.stop();
+		}
+		final List<PortPair> ports = Arrays.asList(portForwarding.getPortPairs());
+		for (int i = 0; i < 50 && PortForwardingUtils.hasPortInUse(ports); i++) {
+			if (i % 10 == 0) {
+				// report once a second;
+				if(stream != null) {
+					stream.write("Waiting for port-forwarding to stop...\n".getBytes());
+				}
+			}
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				break;
+			}
+		}
+		return portForwarding;
+	}
+}

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/portforwarding/package-info.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/portforwarding/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+/**
+ * Pods Port-forwarding capabilities
+ */
+package org.jboss.tools.openshift.internal.core.portforwarding;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
@@ -12,30 +12,24 @@ package org.jboss.tools.openshift.internal.ui.portforwading;
 
 
 import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.jdt.launching.SocketUtil;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleListener;
 import org.eclipse.ui.console.MessageConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.jboss.tools.common.databinding.ObservablePojo;
 import org.jboss.tools.openshift.internal.common.ui.console.ConsoleUtils;
+import org.jboss.tools.openshift.internal.core.portforwarding.PortForwardingUtils;
 
-import com.openshift.restclient.capability.CapabilityVisitor;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.model.IPod;
-import com.openshift.restclient.model.IPort;
 
 /**
  * @author jeff.cantrill
@@ -47,29 +41,18 @@ public class PortForwardingWizardModel extends ObservablePojo {
 	public static final String PROPERTY_PORT_FORWARDING_ALLOWED = "portForwardingAllowed";
 	public static final String PROPERTY_FREE_PORT_SEARCH_ALLOWED = "freePortSearchAllowed";
 	public static final String PROPERTY_USE_FREE_PORTS = "useFreePorts";
-	private static final Map<IPod, IPortForwardable> REGISTRY = new HashMap<IPod, IPortForwardable>();
 
 	private Boolean useFreePorts = Boolean.FALSE;
 	private final IPod pod;
 	private final ConsoleListener consoleListener = new ConsoleListener();
-	private Set<IPortForwardable.PortPair> ports = new HashSet<IPortForwardable.PortPair>();
+	private final Set<IPortForwardable.PortPair> ports;
 	
 	private boolean isPortForwardingAllowed = false;
 
 	public PortForwardingWizardModel(final IPod pod) {
 		this.pod = pod;
-		IPortForwardable forwardable = REGISTRY.get(pod);
-		if(forwardable != null && forwardable.getPortPairs() != null && forwardable.getPortPairs().length > 0) {
-			for(IPortForwardable.PortPair p : forwardable.getPortPairs()) {
-				ports.add(p);
-			}
-		}else {
-			for (IPort port : pod.getContainerPorts()) {
-				ports.add(new IPortForwardable.PortPair(port));
-			}
-		}
-		ports = Collections.unmodifiableSet(ports);
-		useFreePorts = computeUsingFreePorts();
+		this.ports = PortForwardingUtils.getForwardablePorts(pod);
+		this.useFreePorts = computeUsingFreePorts();
 		updatePortForwardingAllowed();
 	}
 
@@ -79,7 +62,7 @@ public class PortForwardingWizardModel extends ObservablePojo {
 
 	
 	public boolean getPortForwarding() {
-		return isPortForwarding(pod);
+		return PortForwardingUtils.isPortForwardingStarted(pod);
 	}
 
 	/**
@@ -94,101 +77,68 @@ public class PortForwardingWizardModel extends ObservablePojo {
 		return isPortForwardingAllowed();
 	}
 
+	/**
+	 * @return boolean flag to indicate if port-forwarding is allowed.
+	 * @see PROPERTY_PORT_FORWARDING_ALLOWED
+	 */
 	public boolean isPortForwardingAllowed() {
-		return isPortForwardingAllowed;
+		return this.isPortForwardingAllowed;
 	}
 
-	void updatePortForwardingAllowed() {
-		boolean newValue = !getForwardablePorts().isEmpty() && !isPortForwarding(pod) && !hasPortInUse();
-		firePropertyChange(PROPERTY_PORT_FORWARDING_ALLOWED, isPortForwardingAllowed, isPortForwardingAllowed = newValue);
+	private void updatePortForwardingAllowed() {
+		boolean newValue = !getForwardablePorts().isEmpty() && !PortForwardingUtils.isPortForwardingStarted(pod) && !PortForwardingUtils.hasPortInUse(this.ports);
+		firePropertyChange(PROPERTY_PORT_FORWARDING_ALLOWED, this.isPortForwardingAllowed, this.isPortForwardingAllowed = newValue);
 	}
 
 	public boolean isFreePortSearchAllowed() {
-		return !getForwardablePorts().isEmpty() && !isPortForwarding(pod);
-	}
-
-	private boolean hasPortInUse() {
-		for (IPortForwardable.PortPair port : ports) {
-			if(isPortInUse(port.getLocalPort())) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	public static boolean isPortInUse(int port) {
-		if(port < 0 || port >= 65536) {
-			return false;
-		}
-		try {
-			new ServerSocket(port).close();
-			return false;
-		} catch (IOException e) {
-			//success
-		}
-		try (Socket socket = new Socket("localhost", port)) {
-			return true; //success
-		} catch (IOException e) {
-			return false;
-		}
+		return !getForwardablePorts().isEmpty() && !PortForwardingUtils.isPortForwardingStarted(pod);
 	}
 
 	public Collection<IPortForwardable.PortPair> getForwardablePorts(){
 		return ports;
 	}
 
+	/**
+	 * Starts the port-forwarding for the current pod.
+	 */
 	public void startPortForwarding() {
-		if(isPortForwarding(pod)) return;
-		IPortForwardable portForwardable = pod.accept(new CapabilityVisitor<IPortForwardable, IPortForwardable>() {
-
-			@Override
-			public IPortForwardable visit(final IPortForwardable cap) {
-				final MessageConsole console = ConsoleUtils.findMessageConsole(getMessageConsoleName());
-				consoleListener.setCapability(cap);
-				ConsoleUtils.registerConsoleListener(consoleListener);
-				MessageConsoleStream stream = console.newMessageStream();
-				stream.println("Starting port-forwarding...");
-				for (IPortForwardable.PortPair port : ports) {
-					stream.println(NLS.bind("{0} {1} -> {2}", new Object [] {port.getName(), port.getLocalPort(), port.getRemotePort()}));
-				}
-				cap.forwardPorts(ports.toArray(new IPortForwardable.PortPair []{}));
-				stream.println("done.");
-				ConsoleUtils.displayConsoleView(console);
-				return cap;
-			}
-		}, null);
-		if(portForwardable != null) {
-			REGISTRY.put(pod, portForwardable);
-		}
+		final MessageConsole console = ConsoleUtils.findMessageConsole(getMessageConsoleName());
+		MessageConsoleStream stream = console.newMessageStream();
+		ConsoleUtils.registerConsoleListener(consoleListener);
+		ConsoleUtils.displayConsoleView(console);
+		stream.println("Starting port-forwarding...");
+		final IPortForwardable portForwardable = PortForwardingUtils.startPortForwarding(this.pod, this.ports);
+		Stream.of(portForwardable.getPortPairs()).forEach(port -> stream.println(NLS.bind("{0} {1} -> {2}",
+				new Object[] { port.getName(), port.getLocalPort(), port.getRemotePort() })));
+		stream.println("done.");
 		firePropertyChange(PROPERTY_PORT_FORWARDING, false, getPortForwarding());
 		updatePortForwardingAllowed();
 	}
 	
-	private boolean isPortForwarding(IPod pod) {
-		IPortForwardable capability = REGISTRY.get(pod);
-		return capability != null && capability.isForwarding();
-	} 
 	
 	private class ConsoleListener implements IConsoleListener{
-		private IPortForwardable cap;
 		
-		public void setCapability(IPortForwardable cap) {
-			this.cap = cap;
-		}
+		/**
+		 * Stops the port-forwarding is the port-forwarding console was removed, does nothing otherwise.
+		 *
+		 * @param consoles the consoles that were removed.
+		 */
+		//TODO: shouldn't we replace this with a ProcessConsole to have a big-stop-red button ? #UX
 		@Override
 		public void consolesRemoved(IConsole[] consoles) {
 			final String messageConsoleName = getMessageConsoleName();
-			for (IConsole console : consoles) {
-				if(console.getName().equals(messageConsoleName)) {
-					try {
-						cap.stop();
-						REGISTRY.remove(pod);
-						return;
-					}finally {
-						ConsoleUtils.deregisterConsoleListener(this);
-					}
+			if (Stream.of(consoles).filter(console -> console.getName().equals(messageConsoleName)).findAny()
+					.isPresent()) {
+				try {
+					PortForwardingUtils.stopPortForwarding(pod, null);
+				} catch (IOException e) {
+					// ignore here: the IOException could be thrown when writing
+					// in the console but 'null' is passed here, so there's no
+					// risk of such an Exception.
+				} finally {
+					ConsoleUtils.deregisterConsoleListener(this);
 				}
-			}
+			}			
 		}
 		
 		@Override
@@ -200,56 +150,33 @@ public class PortForwardingWizardModel extends ObservablePojo {
 		return NLS.bind("Port forwarding to pod {0} ({1})", pod.getName(), pod.getNamespace());
 	}
 
-	public void stopPortForwarding() {
-		if(!isPortForwarding(pod)) return;
-		IPortForwardable cap = REGISTRY.remove(pod);
-		MessageConsoleStream stream = null;
-		try {
-			final MessageConsole console = ConsoleUtils.findMessageConsole(getMessageConsoleName());
-			stream = console.newMessageStream();
+	/**
+	 * Stops the port-forwarding for the current pod.
+	 * @throws IOException 
+	 */
+	public void stopPortForwarding() throws IOException {
+		if (!PortForwardingUtils.isPortForwardingStarted(pod)) {
+			return;
+		}
+		final MessageConsole console = ConsoleUtils.findMessageConsole(getMessageConsoleName());
+		try (final MessageConsoleStream stream = console.newMessageStream()) {
 			stream.println("Stopping port-forwarding...");
-			cap.stop();
-			waitForStoppingProcessComplete(stream);
-
-			for (IPortForwardable.PortPair port : ports) {
-				stream.println(NLS.bind("{0} {1} -> {2}", new Object [] {port.getName(), port.getLocalPort(), port.getRemotePort()}));
+			final IPortForwardable cap = PortForwardingUtils.stopPortForwarding(pod, stream);
+			if (cap != null) {
+				Stream.of(cap.getPortPairs()).forEach(port -> stream.println(NLS.bind("{0} {1} -> {2}",
+						new Object[] { port.getName(), port.getLocalPort(), port.getRemotePort() })));
 			}
-			if(!hasPortInUse()) {
+			if (!PortForwardingUtils.hasPortInUse(this.ports)) {
 				stream.println("done.");
 			} else {
-				stream.println("Ports remain in use yet. Stopping ports is requested and eventually will be completed.");
+				stream.println(
+						"Ports remain in use yet. Stopping ports is requested and eventually will be completed.");
 			}
 			ConsoleUtils.displayConsoleView(console);
 			firePropertyChange(PROPERTY_PORT_FORWARDING, true, getPortForwarding());
 			updatePortForwardingAllowed();
-		}finally {
-			if(stream != null) {
-				try {
-					stream.close();
-				} catch (IOException e) {
-					// ignore
-				}
-			}
-			ConsoleUtils.deregisterConsoleListener(consoleListener);					
-		}
-	}
-
-	/**
-	 * Wait up to 5 seconds until the forcibly destroyed process really dies.
-	 * 
-	 * @param stream
-	 */
-	private void waitForStoppingProcessComplete(MessageConsoleStream stream) {
-		for (int i = 0; i < 50 && hasPortInUse(); i++) {
-			if(i % 10 == 0) {
-				//report once a second;
-				stream.println("Waiting for port-forwarding to stop...");
-			}
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {
-				break;
-			}
+		} finally {
+			ConsoleUtils.deregisterConsoleListener(consoleListener);
 		}
 	}
 
@@ -296,7 +223,7 @@ public class PortForwardingWizardModel extends ObservablePojo {
 	 * A slim chance that some free port coincided with the default one is neglected.
 	 */
 	private boolean computeUsingFreePorts() {
-		if(ports.isEmpty() || !isPortForwarding(pod)) {
+		if(ports.isEmpty() || !PortForwardingUtils.isPortForwardingStarted(pod)) {
 			return false;
 		}
 		for (IPortForwardable.PortPair port : ports) {

--- a/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
@@ -27,5 +27,7 @@ Require-Bundle: org.jboss.tools.openshift.client;bundle-version="[3.0.0,4.0.0)",
  org.jboss.tools.common.ui;bundle-version="3.7.1",
  org.eclipse.core.databinding;bundle-version="1.5.0",
  org.eclipse.core.expressions;bundle-version="3.5.0",
- org.apache.commons.io;bundle-version="2.2.0"
+ org.apache.commons.io;bundle-version="2.2.0",
+ org.eclipse.jdt.launching;bundle-version="3.8.0",
+ org.eclipse.jdt.launching.macosx;bundle-version="3.3.0";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtilsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtilsTest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+package org.jboss.tools.openshift.internal.core.portforwarding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.launching.SocketUtil;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.resources.IPortForwardable;
+import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
+import com.openshift.restclient.model.IPod;
+import com.openshift.restclient.model.IPort;
+
+/**
+ * Testing the {@link PortForwardingUtils} class.
+ */
+public class PortForwardingUtilsTest {
+
+	@Test
+	public void shouldCheckThatPortIsInUse() throws IOException {
+		// given
+		try (final ServerSocket serverSocket = new ServerSocket(SocketUtil.findFreePort())) {
+			// when
+			final int port = serverSocket.getLocalPort();
+			final boolean portInUse = PortForwardingUtils.isPortInUse(port);
+			// then
+			assertThat(portInUse).isTrue();
+		}
+	}
+
+	@Test
+	public void shouldCheckThatPortIsNotInUse() throws IOException {
+		// given
+		final int port = SocketUtil.findFreePort();
+		// when
+		final boolean portInUse = PortForwardingUtils.isPortInUse(port);
+		// then
+		assertThat(portInUse).isFalse();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shouldStartPortForwardingOnSinglePort() {
+		// given
+		final IPod pod = Mockito.mock(IPod.class);
+		final PortPair port = Mockito.mock(PortPair.class);
+		final IPortForwardable portForwardable = Mockito.mock(IPortForwardable.class);
+		Mockito.when(pod.accept(Mockito.any(CapabilityVisitor.class), Mockito.any(IPortForwardable.class)))
+				.thenReturn(portForwardable);
+		Mockito.when(portForwardable.isForwarding()).thenReturn(true);
+		// when
+		final IPortForwardable startPortForwarding = PortForwardingUtils.startPortForwarding(pod, port);
+		// then
+		assertThat(startPortForwarding).isNotNull().isEqualTo(portForwardable);
+		assertThat(PortForwardingUtils.isPortForwardingStarted(pod)).isTrue();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shouldStopPortForwarding() throws IOException {
+		// given
+		final IPod pod = Mockito.mock(IPod.class);
+		final PortPair port = Mockito.mock(PortPair.class);
+		final IPortForwardable portForwardable = Mockito.mock(IPortForwardable.class);
+		Mockito.when(pod.accept(Mockito.any(CapabilityVisitor.class), Mockito.any(IPortForwardable.class)))
+				.thenReturn(portForwardable);
+		Mockito.when(portForwardable.isForwarding()).thenReturn(true);
+		PortForwardingUtils.startPortForwarding(pod, port);
+		// when
+		final IPortForwardable stopPortForwarding = PortForwardingUtils.stopPortForwarding(pod, null);
+		// then
+		assertThat(stopPortForwarding).isNotNull().isEqualTo(portForwardable);
+		assertThat(PortForwardingUtils.isPortForwardingStarted(pod)).isFalse();
+		Mockito.verify(portForwardable, Mockito.times(1)).stop();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shouldGetForwardablePortsOnStartedState() {
+		// given
+		final IPod pod = Mockito.mock(IPod.class);
+		final PortPair port = Mockito.mock(PortPair.class);
+		final IPortForwardable portForwardable = Mockito.mock(IPortForwardable.class);
+		Mockito.when(portForwardable.getPortPairs()).thenReturn(new PortPair[]{port});
+		Mockito.when(pod.accept(Mockito.any(CapabilityVisitor.class), Mockito.any(IPortForwardable.class)))
+				.thenReturn(portForwardable);
+		PortForwardingUtils.startPortForwarding(pod, port);
+		// when
+		final Set<PortPair> forwardablePorts = PortForwardingUtils.getForwardablePorts(pod);
+		// then
+		assertThat(forwardablePorts).isNotNull().containsExactly(port);
+	}
+
+	@Test
+	public void shouldGetForwardablePortsOnStartedStopped() {
+		// given
+		final IPod pod = Mockito.mock(IPod.class);
+		final IPort port = Mockito.mock(IPort.class);
+		final IPortForwardable portForwardable = Mockito.mock(IPortForwardable.class);
+		Mockito.when(pod.getContainerPorts()).thenReturn(toSet(port));
+		// when
+		final Set<PortPair> forwardablePorts = PortForwardingUtils.getForwardablePorts(pod);
+		// then
+		assertThat(forwardablePorts).isNotNull().hasSize(1);
+	}
+	
+	/**
+	 * Adds the given {@code element} in a new {@link Set}
+	 * @param element the element to add
+	 * @return the new {@link Set} containing the given {@code element}.
+	 */
+	static <T> Set<T> toSet(final T element) {
+		return Stream.of(element).collect(Collectors.toSet());
+	}
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/package-info.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat - Initial Contribution
+ *******************************************************************************/
+
+/**
+ * 
+ */
+package org.jboss.tools.openshift.internal.core.portforwarding;


### PR DESCRIPTION
Refactored the PortForwardingWizardModel to move all the port-forwarding
 core functionnalities in a new PortforwardingUtils class
 in plugins/org.jboss.tools.openshift.core.
Refactored the PortForwardingWizardPage to use local variables instead
 of fields for the widgets.