### PR TITLE
[JBIDE-21846] fix deploy image name validator when set by setting the  image

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ServiceNameValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ServiceNameValidator.java
@@ -22,7 +22,7 @@ import org.eclipse.osgi.util.NLS;
  * 
  * @author Jeff Cantrill
  */
-public class DeployImageNameValidator implements IValidator {
+public class ServiceNameValidator implements IValidator {
 
 	private static final String CHAR_FMT = "[a-z0-9]";
 	private static final String EXT_CHAR_FMT = "[-a-z0-9]";
@@ -35,7 +35,7 @@ public class DeployImageNameValidator implements IValidator {
 	private final IStatus FAILED;
 	private final IStatus EMPTY_CANCEL;
 	
-	public DeployImageNameValidator() {
+	public ServiceNameValidator() {
 		FAILED = ValidationStatus.error(failureMessage);
 		EMPTY_CANCEL = ValidationStatus.cancel("Please provide a valid resource name.");
 	}
@@ -45,7 +45,7 @@ public class DeployImageNameValidator implements IValidator {
 		if(paramObject != null && !(paramObject instanceof String))
 			return ValidationStatus.cancel("Name is not an instance of a string");
 		String value= (String) paramObject;
-		if(StringUtils.isEmpty(value))
+		if(StringUtils.isBlank(value))
 			return EMPTY_CANCEL;
 		if(value.length() > MAXLENGTH) {
 			return ValidationStatus.error(NLS.bind("Maximum name length is {0} characters", MAXLENGTH));

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
@@ -11,14 +11,13 @@
 package org.jboss.tools.openshift.internal.ui.wizard.deployimage;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.core.databinding.Binding;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.validation.IValidator;
+import org.eclipse.core.databinding.validation.MultiValidator;
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -73,7 +72,7 @@ import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 import org.jboss.tools.openshift.internal.ui.explorer.OpenShiftExplorerLabelProvider;
 import org.jboss.tools.openshift.internal.ui.treeitem.ObservableTreeItem2ModelConverter;
 import org.jboss.tools.openshift.internal.ui.treeitem.ObservableTreeItemLabelProvider;
-import org.jboss.tools.openshift.internal.ui.validator.DeployImageNameValidator;
+import org.jboss.tools.openshift.internal.ui.validator.ServiceNameValidator;
 import org.jboss.tools.openshift.internal.ui.validator.DockerImageValidator;
 import org.jboss.tools.openshift.internal.ui.wizard.project.ManageProjectsWizard;
 
@@ -433,11 +432,25 @@ public class DeployImagePage extends AbstractOpenShiftWizardPage {
 				WidgetProperties.text(SWT.Modify).observe(resourceNameText);
 		final Binding nameBinding = ValueBindingBuilder
 				.bind(resourceNameTextObservable)
-				.validatingAfterConvert(new DeployImageNameValidator())
 				.to(BeanProperties.value(IDeployImagePageModel.PROPERTY_NAME).observe(model))
 				.in(dbc);
+		dbc.addValidationStatusProvider(new DeployImageNameValidator(resourceNameTextObservable));
 		ControlDecorationSupport.create(
 				nameBinding, SWT.LEFT | SWT.TOP, null, new RequiredControlDecorationUpdater(true));
+		
+	}
+	
+	private static class DeployImageNameValidator extends MultiValidator{
+		
+		private ServiceNameValidator validator = new ServiceNameValidator();
+		final private IObservableValue observable;
+		DeployImageNameValidator(IObservableValue observable){
+			this.observable = observable;
+		}
+		@Override
+		protected IStatus validate() {
+			return validator.validate(observable.getValue());
+		}
 		
 	}
 

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/AbstractValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/AbstractValidatorTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.ui.validator;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.core.databinding.validation.IValidator;
+import org.eclipse.core.databinding.validation.ValidationStatus;
+import org.eclipse.core.runtime.IStatus;
+
+/**
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public abstract class AbstractValidatorTest {
+
+	private static final IStatus PASS = ValidationStatus.ok();
+	private IValidator validator;
+	
+	protected AbstractValidatorTest(IValidator validator) {
+		this.validator = validator;
+	}
+	protected IValidator getValidator() {
+		return this.validator;
+	}
+	
+	protected void assertFailure(Object value) {
+		IStatus act = getValidator().validate(value);
+		assertEquals(String.format("Exp. to receive ERROR status but got %s", getStatus(act.getSeverity())),IStatus.ERROR, act.getSeverity());
+	}
+
+	protected void assertCancel(Object value) {
+		IStatus act = getValidator().validate(value);
+		assertEquals(String.format("Exp. to receive CANCEL status but got %s", getStatus(act.getSeverity())),IStatus.CANCEL, act.getSeverity());
+	}
+
+	protected void assertPass(Object value) {
+		assertEquals(PASS, getValidator().validate(value));
+	}
+	
+	protected String getStatus(int severity) {
+		String status = null;
+		switch(severity) {
+		case IStatus.OK:
+			status = "OK";
+			break;
+		case IStatus.CANCEL:
+			status = "CANCEL";
+			break;
+		case IStatus.ERROR:
+			status = "ERROR";
+			break;
+		case IStatus.WARNING:
+			status = "WARNING";
+			break;
+		case IStatus.INFO:
+			status = "INFO";
+			break;
+		}
+		return status;
+	}
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/LabelValueValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/LabelValueValidatorTest.java
@@ -8,23 +8,14 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.test.ui.validator;
 
-import static org.junit.Assert.*;
-
-import org.eclipse.core.databinding.validation.IValidator;
-import org.eclipse.core.databinding.validation.ValidationStatus;
-import org.eclipse.core.runtime.IStatus;
 import org.jboss.tools.openshift.internal.ui.validator.LabelKeyValidator;
 import org.jboss.tools.openshift.internal.ui.validator.LabelValueValidator;
 import org.junit.Test;
 
-public class LabelValueValidatorTest {
+public class LabelValueValidatorTest extends AbstractValidatorTest{
 	
-	private static final IStatus PASS = ValidationStatus.ok();
-	
-	private LabelValueValidator validator = new LabelValueValidator();
-	
-	protected IValidator getValidator() {
-		return validator;
+	public LabelValueValidatorTest() {
+		super(new LabelValueValidator());
 	}
 
 	@Test
@@ -63,42 +54,6 @@ public class LabelValueValidatorTest {
 	@Test
 	public void valueWithDotsDashesAndUnderScoresShouldBeValid() {
 		assertPass("abcd.efg_k-123");
-	}
-
-	protected void assertFailure(String value) {
-		IStatus act = getValidator().validate(value);
-		assertEquals(String.format("Expected to receive ERROR status but got %s", getStatus(act.getSeverity())),IStatus.ERROR, act.getSeverity());
-	}
-
-	protected void assertCancel(String value) {
-		IStatus act = getValidator().validate(value);
-		assertEquals(String.format("CANCEL to receive ERROR status but got %s", getStatus(act.getSeverity())),IStatus.CANCEL, act.getSeverity());
-	}
-
-	protected void assertPass(String value) {
-		assertEquals(PASS, getValidator().validate(value));
-	}
-	
-	protected String getStatus(int severity) {
-		String status = null;
-		switch(severity) {
-		case IStatus.OK:
-			status = "OK";
-			break;
-		case IStatus.CANCEL:
-			status = "CANCEL";
-			break;
-		case IStatus.ERROR:
-			status = "ERROR";
-			break;
-		case IStatus.WARNING:
-			status = "WARNING";
-			break;
-		case IStatus.INFO:
-			status = "INFO";
-			break;
-		}
-		return status;
 	}
 
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ProjectNameValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ProjectNameValidatorTest.java
@@ -12,20 +12,16 @@ package org.jboss.tools.openshift.test.ui.validator;
 
 import java.util.Arrays;
 
-import org.eclipse.core.databinding.validation.IValidator;
 import org.jboss.tools.openshift.internal.ui.validator.ProjectNameValidator;
 import org.junit.Test;
 
 /**
  * @author jeff.cantrill
  */
-public class ProjectNameValidatorTest extends LabelValueValidatorTest {
+public class ProjectNameValidatorTest extends AbstractValidatorTest {
 
-	private ProjectNameValidator validator = new ProjectNameValidator("default message", Arrays.asList("nope","back off"));
-
-	@Override
-	protected IValidator getValidator() {
-		return validator;
+	public ProjectNameValidatorTest() {
+		super(new ProjectNameValidator("default message", Arrays.asList("nope","back off")));
 	}
 
 	@Test
@@ -58,24 +54,20 @@ public class ProjectNameValidatorTest extends LabelValueValidatorTest {
 		assertPass("projectname");
 	}
 
-	@Override
 	public void emptyValueShouldBeInvalid() {
 		assertCancel("");
 	}
 
-	@Override
 	public void valueWithSlashesShouldBeInValid() {
 		// Should be invalid, as opposed to regular LabelValueValidator behavior
 		assertFailure("abcd.efg/a23");
 	}
 
-	@Override
 	public void valueWithDotsDashesAndUnderScoresShouldBeValid() {
 		// Should be invalid, as opposed to regular LabelValueValidator behavior
 		assertFailure("abcd.efg_k-123");
 	}
 
-	@Override
 	public void nullValueShouldBeInvalid() {
 		assertFailure(null);
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ServiceNameValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ServiceNameValidatorTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.ui.validator;
+
+import org.jboss.tools.openshift.internal.ui.validator.ServiceNameValidator;
+import org.junit.Test;
+
+/**
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public class ServiceNameValidatorTest extends AbstractValidatorTest {
+	
+	public ServiceNameValidatorTest() {
+		super(new ServiceNameValidator());
+	}
+	
+	@Test
+	public void testShouldReturnPassIfConforms() {
+		assertPass("spring");
+		assertPass("spring09");
+		assertPass("spring-09");
+		assertPass("spring-09-09");
+	}
+
+	@Test
+	public void testShouldReturnFalseIfBeginsWithCapital() {
+		assertFailure("Spring");
+	}
+
+	@Test
+	public void testShouldReturnFalseIfDoesntBeginWithAlpha() {
+		assertFailure("99spring");
+		assertFailure("$$spring");
+	}
+
+	@Test
+	public void testShouldReturnFalseIfDoesntEndWithAlphanumeric() {
+		assertFailure("spring-");
+		assertFailure("spring-$");
+	}
+
+	@Test
+	public void testShouldReturnFalseForGreaterThanMax() {
+		assertFailure("spring-boot-helloworld-ui");
+	}
+
+	@Test
+	public void testShouldReturnPForEqualToMax() {
+		assertPass("spring-boot-helloworld-u");
+	}
+	
+	@Test
+	public void testShouldReturnFalseForNonString() {
+		assertCancel(Boolean.FALSE);
+	}
+
+	@Test
+	public void testShouldReturnFalseForNull() {
+		assertCancel(null);
+	}
+
+	@Test
+	public void testShouldReturnFalseForEmptyString() {
+		assertCancel("");
+	}
+
+	@Test
+	public void testShouldReturnFalseForBlankString() {
+		assertCancel(" ");
+	}
+
+}


### PR DESCRIPTION
This PR
* Renames deployimagename validator to servicenamevalidator
* Adds validation tests
* Fixes name validation when model#setName is called by model#setImage