### PR TITLE
JBIDE-21840 Checkbox to save password in Secure Storage is not checked when password is stored

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/BasicAuthenticationDetailView.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/BasicAuthenticationDetailView.java
@@ -57,12 +57,11 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 	private IObservableValue rememberPasswordObservable;
 	private IValueChangeListener changeListener;
 	private IConnectionAuthenticationProvider connectionAuthProvider;
-	private Button chkRememberToken;
+	private Button rememberPasswordCheckbox;
+	private Binding rememberPasswordBinding;
 	
-	public BasicAuthenticationDetailView(IValueChangeListener changeListener, Object context, IObservableValue rememberPasswordObservable, Button chkRememberToken) {
+	public BasicAuthenticationDetailView(IValueChangeListener changeListener, Object context) {
 		this.changeListener = changeListener;
-		this.rememberPasswordObservable = rememberPasswordObservable;
-		this.chkRememberToken = chkRememberToken;
 	}
 	
 	@Override
@@ -91,6 +90,12 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 				.align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(passwordText);
 		this.passwordObservable = new WritableValue(null, String.class);
 
+		this.rememberPasswordObservable = new WritableValue(Boolean.FALSE, Boolean.class);
+		this.rememberPasswordCheckbox = new Button(composite, SWT.CHECK);
+		rememberPasswordCheckbox.setText("&Save password (could trigger secure storage login)");
+		GridDataFactory.fillDefaults()
+			.align(SWT.FILL, SWT.CENTER).span(2, 1).grab(true, false).applyTo(rememberPasswordCheckbox);
+		
 		return composite;
 	}
 
@@ -103,8 +108,10 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 	@Override
 	public void onVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		bindWidgetsToInternalModel(dbc);
-		chkRememberToken.setText("&Save password (could trigger secure storage login)");
-		UIUtils.setVisibleAndExclude(true, chkRememberToken);
+		this.rememberPasswordBinding = ValueBindingBuilder
+				.bind(WidgetProperties.selection().observe(rememberPasswordCheckbox))
+				.to(rememberPasswordObservable)
+				.in(dbc);
 	}
 	
 	@Override
@@ -123,7 +130,7 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 	@Override
 	public void onInVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		disposeBindings();
-		UIUtils.setVisibleAndExclude(false, chkRememberToken);
+		DataBindingUtils.dispose(rememberPasswordBinding);
 	}
 
 	private void bindWidgetsToInternalModel(DataBindingContext dbc) {
@@ -192,8 +199,6 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 					connection.setPassword((String) passwordObservable.getValue());
 					connection.setRememberPassword(
 							BooleanUtils.toBoolean((Boolean) rememberPasswordObservable.getValue()));
-//					connection.setRememberToken(
-//							BooleanUtils.toBoolean((Boolean) rememberPasswordObservable.getValue()));
 				}
 			});
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/BasicAuthenticationDetailView.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/BasicAuthenticationDetailView.java
@@ -22,8 +22,10 @@ import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
@@ -37,6 +39,7 @@ import org.jboss.tools.openshift.internal.common.ui.databinding.RequiredStringVa
 import org.jboss.tools.openshift.internal.common.ui.databinding.TrimmingStringConverter;
 import org.jboss.tools.openshift.internal.common.ui.detailviews.BaseDetailsView;
 import org.jboss.tools.openshift.internal.common.ui.utils.DataBindingUtils;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 
 import com.openshift.restclient.authorization.IAuthorizationContext;
 
@@ -101,6 +104,7 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 	public void onVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		bindWidgetsToInternalModel(dbc);
 		chkRememberToken.setText("&Save password (could trigger secure storage login)");
+		UIUtils.setVisibleAndExclude(true, chkRememberToken);
 	}
 	
 	@Override
@@ -119,6 +123,7 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 	@Override
 	public void onInVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		disposeBindings();
+		UIUtils.setVisibleAndExclude(false, chkRememberToken);
 	}
 
 	private void bindWidgetsToInternalModel(DataBindingContext dbc) {
@@ -187,8 +192,8 @@ public class BasicAuthenticationDetailView extends BaseDetailsView implements IC
 					connection.setPassword((String) passwordObservable.getValue());
 					connection.setRememberPassword(
 							BooleanUtils.toBoolean((Boolean) rememberPasswordObservable.getValue()));
-					connection.setRememberToken(
-							BooleanUtils.toBoolean((Boolean) rememberPasswordObservable.getValue()));
+//					connection.setRememberToken(
+//							BooleanUtils.toBoolean((Boolean) rememberPasswordObservable.getValue()));
 				}
 			});
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/ConnectionEditor.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/ConnectionEditor.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
@@ -43,6 +44,7 @@ import org.jboss.tools.openshift.internal.common.ui.databinding.RequiredControlD
 import org.jboss.tools.openshift.internal.common.ui.detailviews.AbstractStackedDetailViews;
 import org.jboss.tools.openshift.internal.common.ui.detailviews.AbstractStackedDetailViews.IDetailView;
 import org.jboss.tools.openshift.internal.common.ui.utils.DataBindingUtils;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 
 import com.openshift.restclient.authorization.IAuthorizationContext;
 
@@ -64,11 +66,14 @@ public class ConnectionEditor extends BaseConnectionEditor {
 	private DetailViewModel detailViewModel = new DetailViewModel();
 
 	private Button rememberTokenCheckbox;
+	private Button rememberPasswordCheckbox;
 	private ComboViewer authTypeViewer;
 	private IObservableValue rememberTokenObservable;
+	private IObservableValue rememberPasswordObservable;
 	private IObservableValue detailViewObservable;
 	private IObservableValue authSchemeObservable;
 	private Binding rememberTokenBinding;
+	private Binding rememberPasswordBinding;
 	private Binding selectedAuthTypeBinding;
 	
 	private class DetailViewModel extends ObservablePojo{
@@ -123,7 +128,9 @@ public class ConnectionEditor extends BaseConnectionEditor {
 
 		//remember token
 		this.rememberTokenObservable = new WritableValue(Boolean.FALSE, Boolean.class);
+		this.rememberPasswordObservable = new WritableValue(Boolean.FALSE, Boolean.class);
 		this.rememberTokenCheckbox = new Button(parent, SWT.CHECK); //parent is reset further down
+		this.rememberPasswordCheckbox = new Button(parent, SWT.CHECK); //parent is reset further down
 
 		this.detailViewObservable = 
 				BeanProperties.value(PROPERTY_SELECTED_DETAIL_VIEW, IConnectionEditorDetailView.class).observe(detailViewModel);
@@ -134,7 +141,7 @@ public class ConnectionEditor extends BaseConnectionEditor {
 		detailViews.put(IAuthorizationContext.AUTHSCHEME_OAUTH, 
 				new OAuthDetailView(wizardPage.getWizard(), pageModel, changeListener, pageModel.getContext(), rememberTokenObservable, rememberTokenCheckbox, authSchemeObservable));
 		detailViews.put(IAuthorizationContext.AUTHSCHEME_BASIC, 
-				new BasicAuthenticationDetailView(changeListener, pageModel.getContext(), rememberTokenObservable, rememberTokenCheckbox));
+				new BasicAuthenticationDetailView(changeListener, pageModel.getContext(), rememberPasswordObservable, rememberPasswordCheckbox));
 
 		// auth type
 		Label authTypeLabel = new Label(composite, SWT.NONE);
@@ -169,6 +176,12 @@ public class ConnectionEditor extends BaseConnectionEditor {
 		this.rememberTokenCheckbox.setParent(composite);
 		GridDataFactory.fillDefaults()
 				.align(SWT.FILL, SWT.CENTER).span(2, 1).grab(true, false).applyTo(rememberTokenCheckbox);
+		this.rememberPasswordCheckbox.setParent(composite);
+		GridDataFactory.fillDefaults()
+				.align(SWT.FILL, SWT.CENTER).span(2, 1).grab(true, false).applyTo(rememberPasswordCheckbox);
+		
+		UIUtils.setVisibleAndExclude(false, rememberTokenCheckbox);
+		UIUtils.setVisibleAndExclude(false, rememberPasswordCheckbox);
 		
 		return composite;
 	}
@@ -202,6 +215,10 @@ public class ConnectionEditor extends BaseConnectionEditor {
 				.bind(WidgetProperties.selection().observe(rememberTokenCheckbox))
 				.to(rememberTokenObservable)
 				.in(dbc);
+		this.rememberPasswordBinding = ValueBindingBuilder
+				.bind(WidgetProperties.selection().observe(rememberPasswordCheckbox))
+				.to(rememberPasswordObservable)
+				.in(dbc);
 
 	}
 
@@ -213,6 +230,7 @@ public class ConnectionEditor extends BaseConnectionEditor {
 
 	private void disposeBindings() {
 		DataBindingUtils.dispose(rememberTokenBinding);
+		DataBindingUtils.dispose(rememberPasswordBinding);
 		DataBindingUtils.dispose(selectedAuthTypeBinding);
 		for (IDetailView view : stackedViews.getDetailViews()) {
 			view.dispose();

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/OAuthDetailView.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/OAuthDetailView.java
@@ -74,6 +74,7 @@ import org.jboss.tools.openshift.internal.common.ui.databinding.TrimmingStringCo
 import org.jboss.tools.openshift.internal.common.ui.detailviews.BaseDetailsView;
 import org.jboss.tools.openshift.internal.common.ui.utils.DataBindingUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.StyledTextUtils;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 
 import com.openshift.restclient.ClientFactory;
@@ -145,11 +146,13 @@ public class OAuthDetailView extends BaseDetailsView implements IConnectionEdito
 	public void onVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		bindWidgetsToInternalModel(dbc);
 		rememberTokenCheckbox.setText("&Save token (could trigger secure storage login)");
+		UIUtils.setVisibleAndExclude(true, rememberTokenCheckbox);
 	}
 	
 	@Override
 	public void onInVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		dispose();
+		UIUtils.setVisibleAndExclude(false, rememberTokenCheckbox);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/OAuthDetailView.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/OAuthDetailView.java
@@ -98,20 +98,24 @@ public class OAuthDetailView extends BaseDetailsView implements IConnectionEdito
 	private IAuthorizationDetails authDetails;
 	private ConnectionWizardPageModel pageModel;
 	private Button rememberTokenCheckbox;
+	private Binding rememberTokenBinding;
 
 	private IWizard wizard;
 
 	public OAuthDetailView(IWizard wizard, ConnectionWizardPageModel pageModel, IValueChangeListener changeListener, Object context, 
-			IObservableValue rememberTokenObservable, Button rememberTokenCheckbox, IObservableValue authSchemeObservable) {
+			IObservableValue authSchemeObservable) {
 		this.wizard = wizard;
 		this.pageModel = pageModel;
-		this.rememberTokenObservable = rememberTokenObservable;
+		this.rememberTokenObservable = new WritableValue(Boolean.FALSE, Boolean.class);
 		this.authSchemeObservable = authSchemeObservable;
 		this.changeListener = changeListener;
-		this.rememberTokenCheckbox = rememberTokenCheckbox;
 		if (context instanceof IAuthorizationDetails) {
 			this.authDetails = (IAuthorizationDetails) context;
 		}
+	}
+
+	IObservableValue getRememberTokenObservable() {
+		return rememberTokenObservable;
 	}
 	
 	@Override
@@ -139,20 +143,27 @@ public class OAuthDetailView extends BaseDetailsView implements IConnectionEdito
 			.align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(tokenText);
 		this.tokenObservable = new WritableValue(null, String.class);
 
+		this.rememberTokenCheckbox = new Button(composite, SWT.CHECK);
+		rememberTokenCheckbox.setText("&Save token (could trigger secure storage login)");
+		GridDataFactory.fillDefaults()
+		.align(SWT.FILL, SWT.CENTER).span(2, 1).grab(true, false).applyTo(rememberTokenCheckbox);
+
 		return composite;
 	}
 	
 	@Override
 	public void onVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		bindWidgetsToInternalModel(dbc);
-		rememberTokenCheckbox.setText("&Save token (could trigger secure storage login)");
-		UIUtils.setVisibleAndExclude(true, rememberTokenCheckbox);
+		this.rememberTokenBinding = ValueBindingBuilder
+				.bind(WidgetProperties.selection().observe(rememberTokenCheckbox))
+				.to(rememberTokenObservable)
+				.in(dbc);
 	}
 	
 	@Override
 	public void onInVisible(IObservableValue detailsViewModel, DataBindingContext dbc) {
 		dispose();
-		UIUtils.setVisibleAndExclude(false, rememberTokenCheckbox);
+		DataBindingUtils.dispose(rememberTokenBinding);
 	}
 
 	@Override


### PR DESCRIPTION
Two separate checkboxes are done for Basic and Auth, bound to rememberPassword and rememberToken. Checkboxes are hidden when protocol is changed.