### PR TITLE
JBIDE-21868 - Performance issue on Deploy Docker Image wizard

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeployImageHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeployImageHandler.java
@@ -41,7 +41,7 @@ public class DeployImageHandler extends AbstractHandler {
 			IDockerConnection dockerConnection = image.getConnection();
 			model.setOriginatedFromDockerExplorer(true);
 			model.setDockerConnection(dockerConnection);
-			model.setImage(image.repo());
+			model.setImageName(image.repo());
 		}else{
 			final IProject project = UIUtils.getFirstElement(selection, IProject.class);
 			if(project != null) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/DeployImageJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/DeployImageJob.java
@@ -75,7 +75,7 @@ public class DeployImageJob extends AbstractDelegatingMonitorJob implements IRes
 		try {
 			final Connection connection = parameters.getConnection();
 			final IResourceFactory factory = connection.getResourceFactory();
-			final String name = parameters.getName();
+			final String name = parameters.getResourceName();
 			Map<String, IResource> resources = generateResources(factory, name);
 			
 			//validate 
@@ -89,7 +89,7 @@ public class DeployImageJob extends AbstractDelegatingMonitorJob implements IRes
 		}catch(Exception e) {
 			return new Status(IStatus.ERROR, 
 					OpenShiftUIActivator.PLUGIN_ID, 
-					NLS.bind("Unable to create resources to deploy image {0}", parameters.getImage()),
+					NLS.bind("Unable to create resources to deploy image {0}", parameters.getImageName()),
 					e);
 		}
 		return Status.OK_STATUS;
@@ -115,7 +115,7 @@ public class DeployImageJob extends AbstractDelegatingMonitorJob implements IRes
 
 	private Map<String, IResource> generateResources(final IResourceFactory factory, final String name) {
 		final IProject project = parameters.getProject();
-		DockerImageURI sourceImage = new DockerImageURI(parameters.getImage());
+		DockerImageURI sourceImage = new DockerImageURI(parameters.getImageName());
 		
 		Map<String, IResource> resources = new HashMap<String, IResource>(4);
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizard.java
@@ -67,7 +67,7 @@ public class DeployImageWizard extends AbstractOpenShiftWizard<IDeployImageParam
 						@Override
 						public void run() {
 							final String message = NLS.bind(
-									"Results of deploying image \"{0}\".",  getModel().getName());
+									"Results of deploying image \"{0}\".",  getModel().getResourceName());
 							new ResourceSummaryDialog(
 									getShell(), 
 									deployJob.getResources(),

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeploymentConfigPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeploymentConfigPage.java
@@ -225,7 +225,7 @@ public class DeploymentConfigPage extends AbstractOpenShiftWizardPage {
 				IDeploymentConfigPageModel.PROPERTY_VOLUMES).observe(model));
 		
 		Label lblNotice = new Label(sectionContainer, SWT.WRAP);
-		lblNotice.setText(NLS.bind("NOTICE: This image might use an EmptyDir volume. Data in EmptyDir volumes is not persisted across deployments.", model.getName()));
+		lblNotice.setText(NLS.bind("NOTICE: This image might use an EmptyDir volume. Data in EmptyDir volumes is not persisted across deployments.", model.getResourceName()));
 		GridDataFactory.fillDefaults()
 			.align(SWT.FILL, SWT.FILL)
 			.span(2,2)

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/IDeployImagePageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/IDeployImagePageModel.java
@@ -31,8 +31,8 @@ public interface IDeployImagePageModel extends IConnectionAware<Connection>{
 	static final String PROPERTY_DOCKER_CONNECTION = "dockerConnection";
 	static final String PROPERTY_PROJECTS = "projects";
 	static final String PROPERTY_PROJECT = "project";
-	static final String PROPERTY_NAME = "name";
-	static final String PROPERTY_IMAGE = "image";
+	static final String PROPERTY_RESOURCE_NAME = "resourceName";
+	static final String PROPERTY_IMAGE_NAME = "imageName";
 	
 	/**
 	 * 
@@ -67,35 +67,40 @@ public interface IDeployImagePageModel extends IConnectionAware<Connection>{
 	void setProject(IProject project);
 	
 	/**
-	 * The name to be used for the deployed resources
-	 * @return
+	 * @return the name to be used for the deployed resources
 	 */
-	String getName();
-	void setName(String name);
+	String getResourceName();
 	
 	/**
-	 * The docker image to use
-	 * @return
+	 * Sets the name to be used for the deployed resources
+	 * @param resourceName the name to be used for the deployed resources
 	 */
-	String getImage();
-	void setImage(String image);
+	void setResourceName(String resourceName);
 	
 	/**
-	 * Checks if an image with the given name exists in the selected Docker daemon
-	 * @param imageName the full name of the image to search locally
-	 * @return true if the image exists in the select Docker's registry cache
+	 * @return the name of the Docker Image to use
 	 */
-	boolean imageExistsLocally(String imageName);
-
+	String getImageName();
+	
 	/**
-	 * Checks if an image with the given name exists in a remote registry
-	 * @param imageName the full name of the image to search remotely
-	 * @return true if the image exists in a remote registry
+	 * Sets the name of the Docker Image to use
+	 * @param imageName the name of the Docker Image to use
 	 */
-	boolean imageExistsRemotely(String imageName);
+	void setImageName(String imageName);
 	
 	/**
 	 * @return the list of names of all images for the current Docker connection.
 	 */
 	List<String> getImageNames();
+	
+	/**
+	 * Initializes the container info from the selected Docker Image.
+	 * 
+	 * <p>
+	 * <strong>Note:</strong> This operation can be consuming since it may
+	 * involve remote calls to retrive the Docker Image metadata.
+	 * 
+	 * @return <code>true</code> if the initialization succeeded, <code>false</code> otherwise.
+	 */
+	boolean initializeContainerInfo();
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/IDeploymentConfigPageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/IDeploymentConfigPageModel.java
@@ -32,7 +32,7 @@ public interface IDeploymentConfigPageModel {
 
 	String PROPERTY_REPLICAS = "replicas";
 	
-	String getName();
+	String getResourceName();
 
 	List<EnvironmentVariable> getEnvironmentVariables();
 	void setEnvironmentVariables(List<EnvironmentVariable> envVars);

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/PortSpecAdapter.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/PortSpecAdapter.java
@@ -55,5 +55,41 @@ public class PortSpecAdapter implements IPort{
 	public String getProtocol() {
 		return protocol;
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + port;
+		result = prime * result + ((protocol == null) ? 0 : protocol.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PortSpecAdapter other = (PortSpecAdapter) obj;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (port != other.port)
+			return false;
+		if (protocol == null) {
+			if (other.protocol != null)
+				return false;
+		} else if (!protocol.equals(other.protocol))
+			return false;
+		return true;
+	}
+	
+	
 	
 }

--- a/tests/org.jboss.tools.openshift.test/.classpath
+++ b/tests/org.jboss.tools.openshift.test/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
@@ -26,5 +26,6 @@ Require-Bundle: org.jboss.tools.openshift.client;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.linuxtools.docker.core,
  org.jboss.tools.common.ui;bundle-version="3.7.1",
  org.eclipse.core.databinding;bundle-version="1.5.0",
- org.eclipse.core.expressions;bundle-version="3.5.0"
+ org.eclipse.core.expressions;bundle-version="3.5.0",
+ org.apache.commons.io;bundle-version="2.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.openshift.test/resources/jboss_infinispan-server_ImageStreamImport.json
+++ b/tests/org.jboss.tools.openshift.test/resources/jboss_infinispan-server_ImageStreamImport.json
@@ -1,0 +1,112 @@
+{ "image" : { "dockerImageLayers" : [ { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:196355c4b639d30f63444b2b00b2a5f24cfc8b274cefd2428294c06da0e0ba5d",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:833495e2e417afdb64c6dbf8d393c927025471cd0787c3f45aae2f2097b41be7",
+            "size" : 0
+          },
+          { "name" : "sha256:70c1882a134d1458ea37a86aab02de52900a6b62ca7e586a6bafc0e8a7679ebe",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:24e5c2759a019c32e893f46044ab65b2ace121a75029f75a133b0fefbdbccbf2",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:c141cdef0ee7288df9ab123fa2326fa493864ccc03b85724372ca0257f1d458b",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          },
+          { "name" : "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+            "size" : 0
+          }
+        ],
+      "dockerImageMetadata" : { "Architecture" : "amd64",
+          "Config" : { "Cmd" : [ "/opt/jboss/infinispan-server/bin/standalone.sh",
+                  "-b",
+                  "0.0.0.0"
+                ],
+              "Env" : [ "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                  "JAVA_HOME=/usr/lib/jvm/java",
+                  "INFINISPAN_SERVER_HOME=/opt/jboss/infinispan-server",
+                  "INFINISPAN_VERSION=8.2.0.Final"
+                ],
+              "Hostname" : "0bc4c5093a7b",
+              "Image" : "sha256:372b2032fbbb34aa7b92c381dd76451a96480d98ec2faaa659a22fb0db6fc70a",
+              "Labels" : { "build-date" : "2016-03-04",
+                  "license" : "GPLv2",
+                  "name" : "CentOS Base Image",
+                  "vendor" : "CentOS"
+                },
+              "User" : "jboss",
+              "WorkingDir" : "/opt/jboss"
+            },
+          "Container" : "18b5908c5510742f941fa6cffd50ef58412d6aea4bd5d84876b573e4e4bffa22",
+          "ContainerConfig" : { "Cmd" : [ "/bin/sh",
+                  "-c",
+                  "#(nop) CMD [\"/opt/jboss/infinispan-server/bin/standalone.sh\" \"-b\" \"0.0.0.0\"]"
+                ],
+              "Env" : [ "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                  "JAVA_HOME=/usr/lib/jvm/java",
+                  "INFINISPAN_SERVER_HOME=/opt/jboss/infinispan-server",
+                  "INFINISPAN_VERSION=8.2.0.Final"
+                ],
+              "Hostname" : "0bc4c5093a7b",
+              "Image" : "sha256:372b2032fbbb34aa7b92c381dd76451a96480d98ec2faaa659a22fb0db6fc70a",
+              "Labels" : { "build-date" : "2016-03-04",
+                  "license" : "GPLv2",
+                  "name" : "CentOS Base Image",
+                  "vendor" : "CentOS"
+                },
+              "User" : "jboss",
+              "WorkingDir" : "/opt/jboss"
+            },
+          "Created" : "2016-03-09T11:50:07Z",
+          "DockerVersion" : "1.10.2",
+          "Id" : "141205cf24586e16b48d42d93cd03d57dd8307e9cd4f1ef77ab1e4320a1f097b",
+          "Parent" : "8bb456f5ee9806279f4eb94916ef97db8974796489d7713a1bf071003ab6cf1e",
+          "apiVersion" : "1.0",
+          "kind" : "DockerImage"
+        },
+      "dockerImageMetadataVersion" : "1.0",
+      "dockerImageReference" : "jboss/infinispan-server@sha256:8613bec96ddf9d4c67d3f2a927a3802d3209431e989f965dcb290198dbe0656f",
+      "metadata" : { "name" : "sha256:8613bec96ddf9d4c67d3f2a927a3802d3209431e989f965dcb290198dbe0656f" }
+    },
+  "status" : { "status" : "Success" },
+  "tag" : "latest"
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/DeployImageWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/DeployImageWizardModelTest.java
@@ -10,18 +10,24 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.test.ui.models;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.linuxtools.docker.core.IDockerConnection;
+import org.eclipse.linuxtools.docker.core.IDockerImageInfo;
+import org.jboss.tools.openshift.internal.ui.wizard.common.EnvironmentVariable;
 import org.jboss.tools.openshift.internal.ui.wizard.deployimage.DeployImageWizardModel;
-import org.junit.Before;
+import org.jboss.tools.openshift.internal.ui.wizard.deployimage.PortSpecAdapter;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
 
 import com.openshift.restclient.capability.resources.IImageStreamImportCapability;
 import com.openshift.restclient.images.DockerImageURI;
@@ -29,57 +35,76 @@ import com.openshift.restclient.model.IProject;
 import com.openshift.restclient.model.IStatus;
 import com.openshift.restclient.model.image.IImageStreamImport;
 
-@RunWith(MockitoJUnitRunner.class)
+/**
+ * Testing the {@link DeployImageWizardModel} class
+ */
 public class DeployImageWizardModelTest {
 
-	private DeployImageWizardModel model;
-	private IDockerConnection dockerConnection;
-	@Mock
-	private IProject project;
-	@Mock
-	private IImageStreamImportCapability cap;
-	@Mock
-	private IImageStreamImport streamImport;
-	@Mock
-	private IStatus status;
-	
-	@Before
-	public void setUp() {
-		model = new DeployImageWizardModel();
-		dockerConnection = mock(IDockerConnection.class);
+	@Test
+	public void shouldInitializeContainerInfoFromLocalDockerImage() {
+		// given
+		final DeployImageWizardModel model = new DeployImageWizardModel();
+		final IDockerConnection dockerConnection = mock(IDockerConnection.class);
+		final IProject project = Mockito.mock(IProject.class);
 		model.setDockerConnection(dockerConnection);
-
 		model.setProject(project);
+		// assume Docker image is on local
+		final IDockerImageInfo dockerImageInfo = Mockito.mock(IDockerImageInfo.class, Mockito.RETURNS_DEEP_STUBS);
+		when(dockerConnection.hasImage("jboss/wildfly", "latest")).thenReturn(true);
+		when(dockerConnection.getImageInfo("jboss/wildfly:latest")).thenReturn(dockerImageInfo);
+		when(dockerImageInfo.containerConfig().env()).thenReturn(Arrays.asList("foo1=bar1", "foo2=bar2"));
+		when(dockerImageInfo.containerConfig().exposedPorts())
+				.thenReturn(new HashSet<>(Arrays.asList("8080/tcp", "9990/tcp")));
+		when(dockerImageInfo.containerConfig().volumes()).thenReturn(Collections.emptySet());
+
+		// when
+		model.setImageName("jboss/wildfly:latest");
+		final boolean result = model.initializeContainerInfo();
+		// then
+		assertThat(result).isTrue();
+		assertThat(model.getEnvironmentVariables()).contains(new EnvironmentVariable("foo1", "bar1"),
+				new EnvironmentVariable("foo2", "bar2"));
+		assertThat(model.getPortSpecs()).contains(new PortSpecAdapter("8080/tcp"), new PortSpecAdapter("9990/tcp"));
+
+	}
+
+	@Test
+	public void shouldInitializeContainerInfoFromRemoteDockerImage() throws IOException {
+		// given
+		final DeployImageWizardModel model = new DeployImageWizardModel();
+		final IDockerConnection dockerConnection = mock(IDockerConnection.class);
+		model.setDockerConnection(dockerConnection);
+		final IProject project = Mockito.mock(IProject.class);
+		model.setProject(project);
+		// no Docker image on local
+		when(dockerConnection.hasImage("jboss/infinispan-server", "latest")).thenReturn(false);
+
+		final IImageStreamImportCapability cap = Mockito.mock(IImageStreamImportCapability.class);
 		when(project.supports(IImageStreamImportCapability.class)).thenReturn(true);
 		when(project.getCapability(IImageStreamImportCapability.class)).thenReturn(cap);
-		
+		final IStatus status = Mockito.mock(IStatus.class);
+		final IImageStreamImport streamImport = Mockito.mock(IImageStreamImport.class);
+		final DockerImageURI dockerImageURI = new DockerImageURI("jboss/infinispan-server:latest");
 		when(status.getStatus()).thenReturn("Success");
-		when(cap.importImageMetadata(any(DockerImageURI.class))).thenReturn(streamImport);
+		when(cap.importImageMetadata(dockerImageURI)).thenReturn(streamImport);
+		when(streamImport.getImageJsonFor(dockerImageURI))
+				.thenReturn(getImageStreamImport("jboss_infinispan-server_ImageStreamImport.json"));
 		when(streamImport.getImageStatus()).thenReturn(Arrays.asList(status));
-	}
-	
-	@Test
-	public void testImageExistsLocally() {
-		model.setProject(null);
-		assertFalse(model.imageExistsLocally(null));
-		assertFalse(model.imageExistsLocally(" "));
-		
-		//no tag
-		model.imageExistsLocally("foo/bar");
-		verify(dockerConnection).hasImage("foo/bar", "latest");
-		
-		//has tag
-		model.imageExistsLocally("foo/bar:asf34fs");
-		verify(dockerConnection).hasImage("foo/bar", "asf34fs");
-		
-		//has registry+port and tag
-		model.imageExistsLocally("host:1234/foo/bar:asf34fs");
-		verify(dockerConnection).hasImage("host:1234/foo/bar", "asf34fs");
-		
-		//
-		model.setDockerConnection(null);
-		assertFalse(model.imageExistsLocally("foo/bar"));
-		
+		// when
+		model.setImageName("jboss/infinispan-server:latest");
+		final boolean result = model.initializeContainerInfo();
+		// then
+		assertThat(result).isTrue();
+		assertThat(model.getEnvironmentVariables()).contains(new EnvironmentVariable("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"),
+				new EnvironmentVariable("JAVA_HOME", "/usr/lib/jvm/java"),
+				new EnvironmentVariable("INFINISPAN_SERVER_HOME", "/opt/jboss/infinispan-server"),
+				new EnvironmentVariable("INFINISPAN_VERSION", "8.2.0.Final"));
+		assertThat(model.getPortSpecs()).isEmpty();;
 	}
 
+	private String getImageStreamImport(final String filename) throws IOException {
+		final InputStream imageStreamImport = Thread.currentThread().getContextClassLoader()
+				.getResourceAsStream(filename);
+		return IOUtils.toString(imageStreamImport);
+	}
 }


### PR DESCRIPTION
Moving the code that pull image metadata (sometimes using the
 imagestream capabilities) when the user inputs the Image Name
 to the page validation phase, when the user clicks on the
 'Next >' button.

Also renamed some fields to reflect their type and UI name:
- image -> imageName
- name -> resourceName

This also seems to fix JBIDE-21815