### PR TITLE
JBIDE-21830 Server Adapter wizard: route selected by default is wrong

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServiceViewModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServiceViewModel.java
@@ -124,7 +124,9 @@ public class ServiceViewModel extends ObservablePojo {
 			this.routes.clear();
 			List<IRoute> newRoutes = routeMap.get(this.service.getProject());
 			if(newRoutes != null) {
-				this.routes.addAll(newRoutes);
+				newRoutes.stream()
+					.filter((route)->service.getName().equals(route.getServiceName()))
+					.forEach((route)->this.routes.add(route));
 			}
 			routeToReset = this.route;
 			firePropertyChange(PROPERTY_ROUTES, oldRoutes, this.routes);


### PR DESCRIPTION
Routes are mapped by project. Routes for the selected service can be filtered by the service name.