### PR TITLE
JBIDE-21701 - Enable port forwarding on a given pod and a given debug port

### DIFF
--- a/tests/org.jboss.tools.openshift.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.test/pom.xml
@@ -12,4 +12,5 @@
 	     then change this to packaging=eclipse-test-plugin to make Tycho RUN the tests rather than just 
 	     compiling sources -->
 	<packaging>eclipse-test-plugin</packaging>
+	
 </project>

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtilsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtilsTest.java
@@ -84,6 +84,7 @@ public class PortForwardingUtilsTest {
 		Mockito.when(pod.accept(Mockito.any(CapabilityVisitor.class), Mockito.any(IPortForwardable.class)))
 				.thenReturn(portForwardable);
 		Mockito.when(portForwardable.isForwarding()).thenReturn(true);
+		Mockito.when(portForwardable.getPortPairs()).thenReturn(new PortPair[]{port});
 		PortForwardingUtils.startPortForwarding(pod, port);
 		// when
 		final IPortForwardable stopPortForwarding = PortForwardingUtils.stopPortForwarding(pod, null);


### PR DESCRIPTION
Fix build failures on Tycho/Linux by removing unnecessary optional dependencies (here: org.eclipse.jdt.launching.macosx)