### PR TITLE
JBIDE-21847 Start port forwarding button is disabled after starting and stopping it

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtils.java
@@ -172,7 +172,24 @@ public class PortForwardingUtils {
 			portForwarding.stop();
 		}
 		final List<PortPair> ports = Arrays.asList(portForwarding.getPortPairs());
-		for (int i = 0; i < 50 && PortForwardingUtils.hasPortInUse(ports); i++) {
+		waitForPortsToGetFree(ports, 5, stream);
+		return portForwarding;
+	}
+
+	/**
+	 * Polls the given ports for given time.
+	 * Returns true if all ports get free, returns false otherwise.
+	 * @param ports
+	 * @param stream
+	 * @return
+	 * @throws IOException
+	 */
+	public static boolean waitForPortsToGetFree(Collection<PortPair> ports, int pollingTimeSeconds, OutputStream stream) throws IOException {
+		int pollCount = pollingTimeSeconds * 10; //One poll per 100 ms.
+		for (int i = 0; i < pollCount; i++) {
+			if(!PortForwardingUtils.hasPortInUse(ports)) {
+				return true;
+			}
 			if (i % 10 == 0) {
 				// report once a second;
 				if(stream != null) {
@@ -185,6 +202,6 @@ public class PortForwardingUtils {
 				break;
 			}
 		}
-		return portForwarding;
+		return false;
 	}
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
@@ -12,6 +12,7 @@ package org.jboss.tools.openshift.internal.ui.portforwading;
 
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -177,6 +178,19 @@ public class PortForwardingWizardModel extends ObservablePojo {
 			updatePortForwardingAllowed();
 		} finally {
 			ConsoleUtils.deregisterConsoleListener(consoleListener);
+		}
+	}
+
+	boolean waitForPortsToGetFree(int timeSeconds) {
+		try {
+			boolean result = (timeSeconds == 0) 
+				? !PortForwardingUtils.hasPortInUse(ports)
+				: PortForwardingUtils.waitForPortsToGetFree(ports, timeSeconds, System.out);
+			updatePortForwardingAllowed();
+			return result;
+		} catch (IOException e) {
+			//Ignore, with System.out it cannot happen
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Since in some environments wait for ports to get free fails
in the thread that calls stop forwarding, one more job is started
after giving UI a break, since manual testing always found ports get
free as soon as job was completed and UI refreshed.