### PR TITLE
JBIDE-20998 Application wizard: Validation error description in Resource Labels page is cut off

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/LabelKeyValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/LabelKeyValidator.java
@@ -77,11 +77,11 @@ public class LabelKeyValidator extends LabelValueValidator {
 	@Override
 	public IStatus validate(Object paramObject) {
 		if(!(paramObject instanceof String)) {
-			return ValidationStatus.error(getValueIsNotAStringMessage());
+			return ValidationStatus.cancel(getValueIsNotAStringMessage());
 		}
 		String value = (String) paramObject;
 		if(StringUtils.isEmpty(value)) {
-			return ValidationStatus.error(NLS.bind("{0} is required", type));
+			return ValidationStatus.cancel(NLS.bind("{0} is required", type));
 		}
 		if(readonlykeys.contains(value)) {
 			return ValidationStatus.error("Adding a label with a key that is the same as a readonly label is not allowed");

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/LabelValueValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/LabelValueValidator.java
@@ -70,7 +70,7 @@ public class LabelValueValidator implements IValidator {
 		}
 		String value = (String) paramObject;
 		if(StringUtils.isBlank(value))
-			return ValidationStatus.error(NLS.bind("{0} is required.", type));
+			return ValidationStatus.cancel(NLS.bind("{0} is required.", type));
 		if(value.length() > LABEL_MAXLENGTH) {
 			return getSizeConstraintError();
 		}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/LabelKeyValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/LabelKeyValidatorTest.java
@@ -34,7 +34,7 @@ public class LabelKeyValidatorTest {
 	
 	@Test
 	public void nullValueShouldBeInvalid() {
-		assertFailure(null);
+		assertCancel(null);
 	}
 	
 	@Test
@@ -49,12 +49,12 @@ public class LabelKeyValidatorTest {
 	
 	@Test
 	public void emptyValueShouldBeInvalid() {
-		assertFailure("");
+		assertCancel("");
 	}
 
 	@Test
 	public void blankValueShouldBeInvalid() {
-		assertFailure("  ");
+		assertCancel("  ");
 	}
 
 	@Test

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/LabelValueValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/LabelValueValidatorTest.java
@@ -25,12 +25,12 @@ public class LabelValueValidatorTest extends AbstractValidatorTest{
 
 	@Test
 	public void emptyValueShouldBeInvalid() {
-		assertFailure("");
+		assertCancel("");
 	}
 
 	@Test
 	public void blankValueShouldBeInvalid() {
-		assertFailure("  ");
+		assertCancel("  ");
 	}
 
 	@Test


### PR DESCRIPTION
Empty value may return status CANCEL instead of ERROR.