### PR TITLE
JBIDE-21949 - Allow user to turn on/off showing console when output changes

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
@@ -147,7 +147,7 @@ public class RSync {
 			try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(syncStream));) {
 				String line;
 					while ((line = bufferedReader.readLine()) != null) {
-						consoleWriter.writeToShell(RSync.this.server.getId(), new String[]{line});
+						consoleWriter.writeToShell(RSync.this.server.getId(), new String[]{line}, false);
 					}
 			}
 			} catch(IOException e)  {


### PR DESCRIPTION
Using the new method in IServerConsoleWriter to avoid activating the console
when new content is written. The console is only opened when it is created,
ie, at the first 'rsync' operation.