### PR TITLE
JBIDE-21981 - Error during rsync

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
@@ -45,6 +45,7 @@ import org.jboss.tools.openshift.internal.core.server.debug.IDebugListener;
 import org.jboss.tools.openshift.internal.core.server.debug.OpenShiftDebugUtils;
 
 import com.openshift.restclient.OpenShiftException;
+import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
 import com.openshift.restclient.model.IDeploymentConfig;
@@ -216,7 +217,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 	 * @param remotePort
 	 * @return the local debug port or -1 if port forwarding did not start or was cancelled.
 	 */
-	private int mapPortForwarding(DebuggingContext debuggingContext, IProgressMonitor monitor) {
+	private int mapPortForwarding(final DebuggingContext debuggingContext, final IProgressMonitor monitor) {
 		
 		monitor.subTask("Enabling port forwarding");
 		IPod pod = debuggingContext.getPod();
@@ -244,7 +245,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 			monitor.worked(1);
 		}
 		
-		PortForwardingUtils.startPortForwarding(pod, ports);
+		PortForwardingUtils.startPortForwarding(pod, ports, OpenShiftBinaryOption.SKIP_TLS_VERIFY);
 		
 		if (PortForwardingUtils.isPortForwardingStarted(pod)) {
 			int p = debugPort.get().getLocalPort();

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtilsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/internal/core/portforwarding/PortForwardingUtilsTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -83,7 +84,7 @@ public class PortForwardingUtilsTest {
 		Mockito.when(pod.accept(Mockito.any(CapabilityVisitor.class), Mockito.any(IPortForwardable.class)))
 				.thenReturn(portForwardable);
 		Mockito.when(portForwardable.isForwarding()).thenReturn(true);
-		Mockito.when(portForwardable.getPortPairs()).thenReturn(new PortPair[]{port});
+		Mockito.when(portForwardable.getPortPairs()).thenReturn(Arrays.asList(port));
 		PortForwardingUtils.startPortForwarding(pod, port);
 		// when
 		final IPortForwardable stopPortForwarding = PortForwardingUtils.stopPortForwarding(pod, null);
@@ -100,7 +101,7 @@ public class PortForwardingUtilsTest {
 		final IPod pod = Mockito.mock(IPod.class);
 		final PortPair port = Mockito.mock(PortPair.class);
 		final IPortForwardable portForwardable = Mockito.mock(IPortForwardable.class);
-		Mockito.when(portForwardable.getPortPairs()).thenReturn(new PortPair[]{port});
+		Mockito.when(portForwardable.getPortPairs()).thenReturn(Arrays.asList(port));
 		Mockito.when(pod.accept(Mockito.any(CapabilityVisitor.class), Mockito.any(IPortForwardable.class)))
 				.thenReturn(portForwardable);
 		PortForwardingUtils.startPortForwarding(pod, port);


### PR DESCRIPTION
Using the OpenShiftBinaryOptions to pass some options to the 'oc'
command that will be run by the client, to make sure that the '.git'
folder is still excluded during rsync and that the server certificates
are not verified during the TLS connection setup.