### PR TITLE
JBIDE-22032 Set common default width to buttons in dialogs that are more narrow than OK or Finish button

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/SelectProjectComponentBuilder.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/SelectProjectComponentBuilder.java
@@ -38,6 +38,7 @@ import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
 import org.jboss.tools.openshift.common.core.utils.ProjectUtils;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
 import org.jboss.tools.openshift.internal.common.ui.databinding.RequiredControlDecorationUpdater;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 
 public class SelectProjectComponentBuilder {
 	String textLabel = "Use existing workspace project:";
@@ -120,9 +121,9 @@ public class SelectProjectComponentBuilder {
 		browseProjectsButton.setText("Browse...");
 		GridDataFactory.fillDefaults()
 				.align(SWT.LEFT, SWT.CENTER)
-				.hint(100, SWT.DEFAULT)
 				.grab(false, false)
 				.applyTo(browseProjectsButton);
+		UIUtils.setDefaultButtonWidth(browseProjectsButton);
 		browseProjectsButton.addSelectionListener(selectionListener);
 	}
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/preferences/SSLCertificatesPreferencePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/preferences/SSLCertificatesPreferencePage.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.ui.preferences.SSLCertificatesPreference.Item;
 import org.jboss.tools.openshift.internal.ui.wizard.connection.SSLCertificateUIHelper;
 
@@ -107,6 +108,7 @@ public class SSLCertificatesPreferencePage extends FieldEditorPreferencePage imp
 		GridData d = new GridData();
 		d.verticalAlignment = SWT.BEGINNING;
 		remove.setLayoutData(d);
+		UIUtils.setDefaultButtonWidth(remove);
 		listViewer.addSelectionChangedListener(new ISelectionChangedListener() {
 			@Override
 			public void selectionChanged(SelectionChangedEvent event) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/ResourceLabelsPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/ResourceLabelsPage.java
@@ -104,6 +104,7 @@ public class ResourceLabelsPage extends AbstractOpenShiftWizardPage {
 				.align(SWT.FILL, SWT.FILL).applyTo(addButton);
 		addButton.setText("Add...");
 		addButton.addSelectionListener(onAdd());
+		UIUtils.setDefaultButtonWidth(addButton);
 		
 		Button editExistingButton = new Button(labelsGroup, SWT.PUSH);
 		GridDataFactory.fillDefaults()
@@ -116,6 +117,7 @@ public class ResourceLabelsPage extends AbstractOpenShiftWizardPage {
 				.to(BeanProperties.value(IResourceLabelsPageModel.PROPERTY_SELECTED_LABEL).observe(model))
 				.converting(new IsNotNullOrReadOnlyBooleanConverter())
 				.in(dbc);
+		UIUtils.setDefaultButtonWidth(editExistingButton);
 		
 		Button removeButton = new Button(labelsGroup, SWT.PUSH);
 		GridDataFactory.fillDefaults()
@@ -128,6 +130,7 @@ public class ResourceLabelsPage extends AbstractOpenShiftWizardPage {
 				.to(BeanProperties.value(IResourceLabelsPageModel.PROPERTY_SELECTED_LABEL).observe(model))
 				.converting(new IsNotNullOrReadOnlyBooleanConverter())
 				.in(dbc);
+		UIUtils.setDefaultButtonWidth(removeButton);
 	}
 
 	private SelectionListener onRemove() {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicesAndRoutingPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/ServicesAndRoutingPage.java
@@ -143,6 +143,7 @@ public class ServicesAndRoutingPage extends AbstractOpenShiftWizardPage  {
 		btnAdd.setText("Add...");
 		btnAdd.setToolTipText("Add a port to be exposed by the service which is not explicilty declared by the image.");
 		btnAdd.addSelectionListener(onAdd());
+		UIUtils.setDefaultButtonWidth(btnAdd);
 
 		Button btnEdit = new Button(container, SWT.PUSH);
 		GridDataFactory.fillDefaults()
@@ -156,6 +157,7 @@ public class ServicesAndRoutingPage extends AbstractOpenShiftWizardPage  {
 			.to(BeanProperties.value(IServiceAndRoutingPageModel.PROPERTY_SELECTED_SERVICE_PORT).observe(model))
 			.converting(new IsNotNull2BooleanConverter())
 			.in(dbc);
+		UIUtils.setDefaultButtonWidth(btnEdit);
 
 		Button removeButton = new Button(container, SWT.PUSH);
 		GridDataFactory.fillDefaults()
@@ -169,6 +171,7 @@ public class ServicesAndRoutingPage extends AbstractOpenShiftWizardPage  {
 			.to(BeanProperties.value(IServiceAndRoutingPageModel.PROPERTY_SELECTED_SERVICE_PORT).observe(model))
 			.converting(new IsNotNull2BooleanConverter())
 			.in(dbc);
+		UIUtils.setDefaultButtonWidth(removeButton);
 
 		Button btnReset = new Button(container, SWT.PUSH);
 		GridDataFactory.fillDefaults()
@@ -176,6 +179,7 @@ public class ServicesAndRoutingPage extends AbstractOpenShiftWizardPage  {
 		btnReset.setText("Reset");
 		btnReset.setToolTipText("Resets the list of ports to the exposed ports of the image.");
 		btnReset.addSelectionListener(onReset());
+		UIUtils.setDefaultButtonWidth(btnReset);
 		
 	}
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
@@ -389,8 +389,9 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 		Button btnBrowseFiles = new Button(parent, SWT.NONE);
 		btnBrowseFiles.setText("File system...");
 		GridDataFactory.fillDefaults()
-				.align(SWT.LEFT, SWT.CENTER).hint(100, SWT.DEFAULT)
+				.align(SWT.LEFT, SWT.CENTER)
 				.applyTo(btnBrowseFiles);
+		UIUtils.setDefaultButtonWidth(btnBrowseFiles);
 
 		btnBrowseFiles.addSelectionListener(onFileSystemBrowseClicked());
 		
@@ -398,8 +399,9 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 		Button btnBrowseWorkspaceFiles = new Button(parent, SWT.NONE);
 		btnBrowseWorkspaceFiles.setText("Workspace...");
 		GridDataFactory.fillDefaults()
-				.align(SWT.LEFT, SWT.CENTER).hint(100, SWT.DEFAULT)
+				.align(SWT.LEFT, SWT.CENTER)
 				.applyTo(btnBrowseWorkspaceFiles);
+		UIUtils.setDefaultButtonWidth(btnBrowseWorkspaceFiles);
 
 		btnBrowseWorkspaceFiles.addSelectionListener(onBrowseWorkspaceClicked());
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateParametersPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateParametersPage.java
@@ -55,6 +55,7 @@ import org.jboss.tools.openshift.common.core.utils.UrlUtils;
 import org.jboss.tools.openshift.internal.common.ui.databinding.IsNotNull2BooleanConverter;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerCellDecorationManager;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.common.ui.wizard.AbstractOpenShiftWizardPage;
 import org.jboss.tools.openshift.internal.ui.wizard.newapp.TemplateParameterViewerUtils.ParameterNameViewerComparator;
 
@@ -105,8 +106,9 @@ public class TemplateParametersPage extends AbstractOpenShiftWizardPage {
 		// edit button
 		Button editExistingButton = new Button(container, SWT.PUSH);
 		GridDataFactory.fillDefaults()
-				.align(SWT.FILL, SWT.FILL).hint(100, SWT.DEFAULT).applyTo(editExistingButton);
+				.align(SWT.FILL, SWT.FILL).applyTo(editExistingButton);
 		editExistingButton.setText("Edit...");
+		UIUtils.setDefaultButtonWidth(editExistingButton);
 		editExistingButton.addSelectionListener(onEdit());
 		ValueBindingBuilder
 				.bind(WidgetProperties.enabled().observe(editExistingButton))
@@ -120,6 +122,7 @@ public class TemplateParametersPage extends AbstractOpenShiftWizardPage {
 		GridDataFactory.fillDefaults()
 				.align(SWT.FILL, SWT.FILL).applyTo(resetButton);
 		resetButton.setText("Reset");
+		UIUtils.setDefaultButtonWidth(resetButton);
 		resetButton.addSelectionListener(onReset());
 
 		// required explanation

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/ManageProjectsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/ManageProjectsWizardPage.java
@@ -47,6 +47,7 @@ import org.jboss.tools.foundation.core.plugin.log.IPluginLog;
 import org.jboss.tools.openshift.internal.common.core.job.AbstractDelegatingMonitorJob;
 import org.jboss.tools.openshift.internal.common.ui.databinding.IsNotNull2BooleanConverter;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder.ICellToolTipProvider;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder.IColumnLabelProvider;
 import org.jboss.tools.openshift.internal.common.ui.wizard.AbstractOpenShiftWizardPage;
@@ -107,6 +108,7 @@ public class ManageProjectsWizardPage extends AbstractOpenShiftWizardPage {
 				.align(SWT.FILL, SWT.FILL).applyTo(newButton);
 		newButton.setText("New...");
 		newButton.addSelectionListener(onNew());
+		UIUtils.setDefaultButtonWidth(newButton);
 
 		// remove
 		Button removeButton = new Button(group, SWT.PUSH);
@@ -120,6 +122,7 @@ public class ManageProjectsWizardPage extends AbstractOpenShiftWizardPage {
 				.to(viewerSingleSelection)
 				.converting(new IsNotNull2BooleanConverter())
 				.in(dbc);
+		UIUtils.setDefaultButtonWidth(removeButton);
 
 		Composite filler = new Composite(group, SWT.None);
 		GridDataFactory.fillDefaults()
@@ -131,6 +134,7 @@ public class ManageProjectsWizardPage extends AbstractOpenShiftWizardPage {
 				.align(SWT.FILL, SWT.END).applyTo(refreshButton);
 		refreshButton.setText("Refresh...");
 		refreshButton.addSelectionListener(onRefresh(dbc));
+		UIUtils.setDefaultButtonWidth(refreshButton);
 	}
 
 	private void loadProjects(DataBindingContext dbc) {


### PR DESCRIPTION
Narrow buttons in the following pages are set to the standard button width for dialogs, that is as wide as 'Finish' or 'OK' button:
OpenShift Projects (ManageProjectsWizardPage)
Resource Labels (ResourceLabelsPage)
Services & Routing Settings (ServicesAndRoutingPage)
SSL certificates (SSLCertificatesPreferencePage)
Select template (TemplateListPage, SelectProjectComponentBuilder)
Template Parameters (TemplateParametersPage)