### PR TITLE
JBIDE-21995 - always set the route if it's available

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPageModel.java
@@ -362,9 +362,9 @@ public class ServerSettingsWizardPageModel extends ServiceViewModel {
 	}
 
 	private String getRoute(boolean isDefaultRoute, IRoute route) {
-		if (!isDefaultRoute || route == null) {
+		// We must return a route here, because setting the server host depends on the route
+		if( route == null )
 			return null;
-		}
 		return route.getURL();
 	}
 


### PR DESCRIPTION
I'm not 100% convinced this is the right solution... 

However, I do know trying to use only a 'default route' means that we get no route url, which means we get no server host. 

Furthermore, the existing code was already wrong. The existing code returned null if the model did NOT select 'default route'.  Something was very strange here. 

I can understand if no route is passed in, we can assume it's the default route to be determined later. However a route is being passed in, and the server ceases to function with no route selected. So if a route is provided, I'm definitely going to use its URL for server host. 