### PR TITLE
JBIDE-21994 - Cannot show OpenShift 3 application via live reload

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServer.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServer.java
@@ -64,9 +64,11 @@ public class OpenShiftServer extends DeployableServer implements IURLProvider, I
 	private String getContextRoot(IProject moduleProject, IProject deployProject) {
 		String contextRoot = null;
 		if (OpenShiftServerUtils.isIgnoresContextRoot(getServer()) 
-				&& moduleProject.equals(deployProject)) {
+				&& (moduleProject == null // case of the fake RootModule whose project is null
+				|| moduleProject.equals(deployProject))) {
 			contextRoot = "";
 		}
+		
 		return contextRoot;
 	}
 	

--- a/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
@@ -48,7 +48,8 @@ Require-Bundle: org.jboss.tools.openshift.common.ui;bundle-version="[3.0.0,4.0.0
  org.apache.commons.collections;bundle-version="3.2.0",
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.ui.editors,
- org.eclipse.core.expressions;bundle-version="3.5.0"
+ org.eclipse.core.expressions;bundle-version="3.5.0",
+ org.eclipse.jst.server.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.openshift.internal.ui;x-friends:="org.jboss.tools.openshift.test",

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerAdapterFactory.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerAdapterFactory.java
@@ -10,10 +10,12 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.ui.server;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jst.server.core.IWebModule;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IModuleType;
 import org.eclipse.wst.server.core.IServer;
@@ -102,6 +104,9 @@ public class OpenShiftServerAdapterFactory implements IAdapterFactory {
 
 		@Override
 		public Object getAdapter(Class adapter) {
+			if(adapter == IWebModule.class) {
+				return new RootWebModule();
+			}
 			return null;
 		}
 
@@ -110,6 +115,45 @@ public class OpenShiftServerAdapterFactory implements IAdapterFactory {
 			return null;
 		}
 
+	}
+	
+	private static class RootWebModule implements IWebModule {
+
+		@Override
+		public IContainer[] getResourceFolders() {
+			return null;
+		}
+
+		@Override
+		public IContainer[] getJavaOutputFolders() {
+			return null;
+		}
+
+		@Override
+		public boolean isBinary() {
+			return false;
+		}
+
+		@Override
+		public String getContextRoot() {
+			return null;
+		}
+
+		@Override
+		public String getContextRoot(IModule earModule) {
+			return null;
+		}
+
+		@Override
+		public IModule[] getModules() {
+			return null;
+		}
+
+		@Override
+		public String getURI(IModule module) {
+			return null;
+		}
+		
 	}
 
 }


### PR DESCRIPTION
the (fake) RootModule needs to return a (fake) IWebModule to
be able to retrieve load the adapter and get a proper context root
for the fake IModule

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>