### PR TITLE
JBIDE-21965 - oc rsync triggered when adding/removing breakpoints

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/resources/OpenshiftResourceChangeListener.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/resources/OpenshiftResourceChangeListener.java
@@ -79,11 +79,10 @@ public class OpenshiftResourceChangeListener implements IResourceChangeListener 
 				// has this deltaResource been changed?
 				if (delta2.getKind() == IResourceDelta.NO_CHANGE) {
 					return false;
-				} else if(delta2.getResource() instanceof IFolder) {
-					// by default, assume that a change on an IFolder must be taken
-					// into account.
+				} else if(delta2.getResource() instanceof IFolder
+						&& (delta2.getKind() == IResourceDelta.ADDED || delta2.getKind() == IResourceDelta.REMOVED)) {
+					// only take folders additions and removals into account.
 					changed.add(delta2.getResource());
-
 				} else if (delta2.getResource() instanceof IFile) {
 					if (delta2.getKind() == IResourceDelta.CHANGED 
 							&& (delta2.getFlags() & IResourceDelta.MARKERS) != 0


### PR DESCRIPTION
ignoring changes at folders level, only taking relevant changes
on files.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>