### PR TITLE
JBIDE-22119 Improve treatment of missing/invalid date in timestamp comparator

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/DateTimeUtils.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/DateTimeUtils.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DurationFormatUtils;
 import org.jboss.tools.openshift.internal.common.ui.OpenShiftCommonUIActivator;
 
@@ -62,6 +63,10 @@ public class DateTimeUtils {
 		return value;
 	}
 	public static Date parse(String value) throws ParseException {
+		if(StringUtils.isEmpty(value)) {
+			//prevent null pointer and index out of bounds exceptions.
+			throw new ParseException("Date is not provided", 0);
+		}
 		//ref: http://www.java2s.com/Code/Java/Data-Type/ISO8601dateparsingutility.htm
 		//assume date is like: '2015-11-11T20:32:37Z' 
 		String modValue = value.substring(0, value.length()-1) + "GMT-00:00";

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/comparators/CreationTimestampComparator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/comparators/CreationTimestampComparator.java
@@ -12,12 +12,13 @@ package org.jboss.tools.openshift.internal.ui.comparators;
 
 import java.text.ParseException;
 import java.util.Comparator;
+import java.util.Date;
 
 import org.jboss.tools.openshift.internal.common.ui.utils.DateTimeUtils;
 import org.jboss.tools.openshift.internal.ui.models.IResourceUIModel;
 
 /**
- * Comparator for sorting display models by resource createion timestamp
+ * Comparator for sorting display models by resource creation timestamp
  * @author jeff.cantrill
  *
  */
@@ -25,12 +26,28 @@ public class CreationTimestampComparator implements Comparator<IResourceUIModel>
 
 	@Override
 	public int compare(IResourceUIModel o1, IResourceUIModel o2) {
-		try {
-			return -1 * DateTimeUtils.parse(o1.getResource().getCreationTimeStamp())
-					.compareTo(DateTimeUtils.parse(o2.getResource().getCreationTimeStamp()));
-		} catch (ParseException e) {
+		Date date1 = getDate(o1);
+		Date date2 = getDate(o2);
+		if(date1 == null || date2 == null) {
+			//invalid date goes to the end of list.
+			if(date1 != null) {
+				return -1;
+			} else if(date2 != null) {
+				return 1;
+			} else {
+				return 0;
+			}
 		}
-		return 0;
+		return -1 * date1.compareTo(date2);
+	}
+
+	private Date getDate(IResourceUIModel o1) {
+		String value = o1.getResource().getCreationTimeStamp();
+		try {
+			return DateTimeUtils.parse(value);
+		} catch (ParseException e) {
+			return null;
+		}
 	}
 
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/tabbed/OpenShiftResourcePropertySection.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/tabbed/OpenShiftResourcePropertySection.java
@@ -11,8 +11,6 @@
 
 package org.jboss.tools.openshift.internal.ui.property.tabbed;
 
-import java.text.ParseException;
-
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.databinding.viewers.ObservableListContentProvider;
@@ -41,6 +39,7 @@ import org.jboss.tools.openshift.internal.common.ui.utils.DateTimeUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.DisposeUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.TableViewerBuilder;
 import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
+import org.jboss.tools.openshift.internal.ui.comparators.CreationTimestampComparator;
 import org.jboss.tools.openshift.internal.ui.models.IResourceUIModel;
 
 import com.openshift.restclient.model.IResource;
@@ -217,17 +216,11 @@ public class OpenShiftResourcePropertySection extends AbstractPropertySection im
 	
 
 	protected ViewerSorter createCreatedBySorter() {
+		final CreationTimestampComparator comparator = new CreationTimestampComparator();
 		return new ViewerSorter() {
 			@Override
 			public int compare(Viewer viewer, Object e1, Object e2) {
-				IResource r1 = ((IResourceUIModel)e1).getResource();
-				IResource r2 = ((IResourceUIModel)e2).getResource();
-				try {
-					return -1 * DateTimeUtils.parse(r1.getCreationTimeStamp())
-							.compareTo(DateTimeUtils.parse(r2.getCreationTimeStamp()));
-				} catch (ParseException e) {
-				}
-				return 0;
+				return comparator.compare((IResourceUIModel)e1, (IResourceUIModel)e2);
 			}
 		};
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/comparators/CreationTimestampComparatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/comparators/CreationTimestampComparatorTest.java
@@ -53,11 +53,17 @@ public class CreationTimestampComparatorTest {
 	}
 
 	@Test
-	public void testResourcesAreEqualOnParseException() {
+	public void testResourcesAreEqualWhenBothInvalid() {
 		when(projectTwo.getCreationTimeStamp()).thenReturn("aaa");
+		when(projectOne.getCreationTimeStamp()).thenReturn("");
 		assertEquals(EQUAL, comparator.compare(one, two));
 	}
 	
+	@Test
+	public void testResourcesAreSortedFromCorrectToInvalid() {
+		when(projectOne.getCreationTimeStamp()).thenReturn("abc");
+		assertEquals(AFTER, comparator.compare(one, two));
+	}
 
 
 }


### PR DESCRIPTION
Changes:
1) DateTimeUtils.parse(String) prevents NPE or ArrayIndexOutOfBoundsException
and throws the declared ParseException for empty value instead.

2) In CreationTimestampComparator, invalid timestamp is made less than any
valid timestamp.

3) OpenShiftResourcePropertySection.createCreatedBySorter() reuses
CreationTimestampComparator.