### PR TITLE
JBIDE-22194 Select template: inform user of his mistake in a more friendly way

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -105,7 +105,11 @@ public class NewApplicationWizardModel
 			if (!Files.isRegularFile(Paths.get(filename))) {
 				return null;
 			}
-			template = resourceFactory.create(createInputStream(filename));
+			IResource resource = resourceFactory.create(createInputStream(filename));
+			if(resource != null && !(resource instanceof ITemplate)) {
+				throw new NotATemplateException(resource.getKind());
+			}
+			template = (ITemplate)resource;
 		} catch (FileNotFoundException e) {
 			throw new OpenShiftException(e, NLS.bind("Could not find the file \"{0}\" to upload", filename));
 		} catch (ResourceFactoryException | ClassCastException e) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NotATemplateException.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NotATemplateException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.ui.wizard.newapp;
+
+public class NotATemplateException extends IllegalArgumentException {
+	private static final long serialVersionUID = 1L;
+
+	String resourceKind;
+
+	public NotATemplateException(String resourceKind) {
+		super("Wrong resource kind: " + resourceKind);
+		this.resourceKind = resourceKind;
+	}
+
+	public String getResourceKind() {
+		return resourceKind;
+	}
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TemplateListPage.java
@@ -48,6 +48,7 @@ import org.eclipse.jface.databinding.viewers.ViewerProperties;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.viewers.ComboViewer;
@@ -466,7 +467,12 @@ public class TemplateListPage  extends AbstractOpenShiftWizardPage  {
 		try {
 			model.setLocalTemplateFileName(file);
 			return;
+		} catch (NotATemplateException ex) {
+			MessageDialog.openWarning(getShell(), "Wrong resource",
+					NLS.bind("The file \"{0}\" contains resource {1}. Please select OpenShift template.",
+							file, ex.getResourceKind()));
 		} catch (ClassCastException ex) {
+			//should not happen due to NotATemplateException.
 			IStatus status = ValidationStatus.error(ex.getMessage(), ex);
 			OpenShiftUIActivator.getDefault().getLogger().logStatus(status);
 			ErrorDialog.openError(getShell(), "Template Error",


### PR DESCRIPTION
When user selects a json file with wrong resource instead of template, he should be informed of his mistake in a more friendly way. Let's not log, nor show exception in this case, but just display what kind of resource user selected and what resource was expected.