### PR TITLE
[JBIDE-22240] fixed testing code to fix build

### DIFF
--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/connection/ConnectionsChange.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/connection/ConnectionsChange.java
@@ -113,12 +113,12 @@ public class ConnectionsChange {
 
 		@Override
 		public void connectionChanged(IConnection connection, String eventProperty, Object eventOldValue, Object eventNewValue) {
-			bumpCountdown();
 			changeNotified = true;
 			notifiedConnection = connection;
 			property = eventProperty;
 			oldValue = eventOldValue;
 			newValue = eventNewValue;
+			bumpCountdown();
 		}
 	}
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/explorer/OpenShiftExplorerContentProviderTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/explorer/OpenShiftExplorerContentProviderTest.java
@@ -54,8 +54,8 @@ public class OpenShiftExplorerContentProviderTest {
 		when(client.getBaseURL()).thenReturn(new URL("https://localhost:8442")); 
 
 		connection = spy(new Connection(client, null, null));
-		when(connection.ownsResource(any(IResource.class))).thenReturn(true);
-		when(connection.getUsername()).thenReturn("hookaboo");
+		doReturn(true).when(connection).ownsResource(any(IResource.class));
+		doReturn("hookaboo").when(connection).getUsername();
 		
 		registry = ConnectionsRegistrySingleton.getInstance();
 		registry.add(connection);


### PR DESCRIPTION
* the test class ConnectionsChange releases a lock before it is updating its internal values (that the testing code then asserts).
* an [erroneous usage of mockito|https://groups.google.com/forum/?fromgroups#!topic/mockito/9WUvkhZUy90]. To simulate returned values for partial mocks one should use

  doReturn(...).when(spy).method()

  (and not when(...).thenReturn())