### PR TITLE
JBIDE-22263 Deploy Docker Wizard: Reset button on Deployment Configuration wizard page in Deploy Image could reset ALL env. vars

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/wizard/KeyValueWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/wizard/KeyValueWizardPage.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.common.ui.wizard;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.databinding.Binding;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
@@ -113,6 +114,13 @@ public class KeyValueWizardPage<T extends IKeyValueItem> extends AbstractOpenShi
 		if(initialKey != null && !initialKey.isEmpty()) {
 			DataChangedValidator validator = new DataChangedValidator(keyTextObservable, valueTextObservable);
 			dbc.addValidationStatusProvider(validator);
+		}
+
+		if(!model.isKeyEditable()) {
+			valueText.forceFocus();
+			if(!StringUtils.isEmpty(valueText.getText())) {
+				valueText.setSelection(0, valueText.getText().length());
+			}
 		}
 	}
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/EnvironmentVariablesPageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/EnvironmentVariablesPageModel.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.jboss.tools.common.databinding.ObservablePojo;
 import org.jboss.tools.openshift.internal.common.ui.wizard.IKeyValueItem;
@@ -99,5 +100,14 @@ public class EnvironmentVariablesPageModel extends ObservablePojo implements IEn
 		firePropertyChange(PROPERTY_ENVIRONMENT_VARIABLES, old, Collections.unmodifiableList(environmentVariables));
 	}
 
+	@Override
+	public boolean isEnvironmentVariableModified(EnvironmentVariable envVar) {
+		return envVar.isNew() || (imageEnvVars.containsKey(envVar.getKey()) && !Objects.equals(imageEnvVars.get(envVar.getKey()), envVar.getValue()));
+	}
+	
+	@Override
+	public EnvironmentVariable getEnvironmentVariable(String key) {
+		return environmentVariables.stream().filter(var -> key.equals(var.getKey())).findAny().orElse(null);
+	}
 
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/IEnvironmentVariablesPageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/IEnvironmentVariablesPageModel.java
@@ -27,9 +27,12 @@ public interface IEnvironmentVariablesPageModel {
 	
 	void setSelectedEnvironmentVariable(EnvironmentVariable envVar);
 	EnvironmentVariable getSelectedEnvironmentVariable();
+	EnvironmentVariable getEnvironmentVariable(String key);
+	boolean isEnvironmentVariableModified(EnvironmentVariable envVar);
 	
 	void removeEnvironmentVariable(EnvironmentVariable envVar);
 	void resetEnvironmentVariable(EnvironmentVariable envVar);
 	void updateEnvironmentVariable(EnvironmentVariable envVar, String key, String value);
 	void addEnvironmentVariable(String key, String value);
+	
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizardModel.java
@@ -286,10 +286,20 @@ public class DeployImageWizardModel
 	public List<EnvironmentVariable> getEnvironmentVariables() {
 		return envModel.getEnvironmentVariables();
 	}
+
+	@Override
+	public boolean isEnvironmentVariableModified(EnvironmentVariable envVar) {
+		return envModel.isEnvironmentVariableModified(envVar);
+	}
 	
 	@Override
 	public void setEnvironmentVariables(List<EnvironmentVariable> envVars) {
 		envModel.setEnvironmentVariables(envVars);
+	}
+
+	@Override
+	public EnvironmentVariable getEnvironmentVariable(String key) {
+		return envModel.getEnvironmentVariable(key);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeploymentConfigPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeploymentConfigPage.java
@@ -51,8 +51,6 @@ public class DeploymentConfigPage extends EnvironmentVariablePage {
 	private TableViewer dataViewer;
 
 	//Layout
-	private int heightScale = 30;
-	private Composite envTableContainer;
 	private Composite volTableContainer;
 
 	public DeploymentConfigPage(IWizard wizard, IDeploymentConfigPageModel model) {
@@ -109,19 +107,21 @@ public class DeploymentConfigPage extends EnvironmentVariablePage {
 
 				int h = parent.getSize().y;
 				if(h > 0) {
-					int table = heightScale * 4 + 30; //Minimum height that can be assigned to both tables.
+					int envtable = heightScale * 5 + 30; //Minimum height that can be assigned to envVars table.
+					int voltable = heightScale * 4 + 24; //Minimum height that can be assigned to volumes table.
 					int replicas = heightScale * 7; //Preferred height for bottom.
-					int all = 2 * table + replicas;
+					int all = envtable + voltable + replicas;
 					int minVolume = heightScale * 2;
 	
-					int hEnvVar = table;
-					int hVolumes = table;
+					int hEnvVar = envtable;
+					int hVolumes = voltable;
 					if(h > all) {
-						//In this case the bottom gets its preferred size and the remainder is evenly shared by tables.
-						hEnvVar = hVolumes = (h - replicas) / 2;
-					} else if(h > table + replicas + minVolume) {
+						//In this case the bottom gets its preferred size and the remainder is proportionally shared by tables.
+						hEnvVar = (h - replicas) * envtable / (envtable + voltable);
+						hVolumes = (h - replicas) * voltable / (envtable + voltable);
+					} else if(h > envtable + replicas + minVolume) {
 						//Shrink volumes table, no use to shrink env-var table because of buttons.
-						hVolumes = h - table - replicas;
+						hVolumes = h - envtable - replicas;
 					} else {
 						//At a smaller available height, all components will be in lack of height evenly.
 						hVolumes = minVolume;
@@ -137,7 +137,6 @@ public class DeploymentConfigPage extends EnvironmentVariablePage {
 			}
 		});
 	}
-
 
 	@SuppressWarnings("unchecked")
 	private void createDataVolumeControl(Composite parent, DataBindingContext dbc) {


### PR DESCRIPTION
1. Button 'Reset All' is added.
2. Added env var is selected. Edited/reset env var keeps selection.
3. For user to see which env vars he added, and which values he edited, background of cells with added/edited values is set to a light grey color.
4. Implementing (2) allowed to enable buttons 'Reset' and 'Reset All' only when there is something they can change.
5. When 'Edit Environment Variable' is opened with uneditable Name field, value field is initially focused and value selected.