### PR TITLE
JBIDE-21394 Deploy docker: "Resource Name" should not error (but "*" required) if empty

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ResourceNameValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ResourceNameValidator.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.openshift.internal.ui.validator;
 
 import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.databinding.validation.IValidator;
 import org.eclipse.core.databinding.validation.MultiValidator;
 import org.eclipse.core.runtime.IStatus;
 
@@ -21,7 +22,7 @@ import org.eclipse.core.runtime.IStatus;
  * @author jeff.cantrill
  *
  */
-public class ResourceNameValidator extends MultiValidator{
+public class ResourceNameValidator extends MultiValidator implements IValidator {
 	
 	private final ServiceNameValidator validator = new ServiceNameValidator();
 	private final IObservableValue<String> observable;
@@ -32,6 +33,10 @@ public class ResourceNameValidator extends MultiValidator{
 	@Override
 	protected IStatus validate() {
 		return validator.validate(observable.getValue());
+	}
+	@Override
+	public IStatus validate(Object value) {
+		return validator.validate(value);
 	}
 	
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/ResourceNameControl.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/ResourceNameControl.java
@@ -58,11 +58,13 @@ public class ResourceNameControl {
 		layoutText(resourceNameText);
 		final IObservableValue resourceNameTextObservable = 
 				WidgetProperties.text(SWT.Modify).observe(resourceNameText);
+		ResourceNameValidator validator = new ResourceNameValidator(resourceNameTextObservable);
 		final Binding nameBinding = ValueBindingBuilder
 				.bind(resourceNameTextObservable)
+				.validatingAfterConvert(validator)
 				.to(BeanProperties.value(PROPERTY_RESOURCE_NAME).observe(model))
 				.in(dbc);
-		dbc.addValidationStatusProvider(new ResourceNameValidator(resourceNameTextObservable));
+		dbc.addValidationStatusProvider(validator);
 		ControlDecorationSupport.create(
 				nameBinding, SWT.LEFT | SWT.TOP, null, new RequiredControlDecorationUpdater(true));
 	}


### PR DESCRIPTION
Validating widget is restored. It is necessery to decorate widget with required/error marks.