### PR TITLE
JBIDE-22306 Properties view freaks out on resize

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/tabbed/OpenShiftResourcePropertySection.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/tabbed/OpenShiftResourcePropertySection.java
@@ -86,6 +86,7 @@ public class OpenShiftResourcePropertySection extends AbstractPropertySection im
 		SashForm container = new SashForm(parent, SWT.VERTICAL);
 		GridData d = new GridData(GridData.FILL_BOTH);
 		d.widthHint = 100; //A dirty trick that keeps table from growing unlimitedly within scrolled parent composite.
+		d.heightHint = 100;
 		container.setLayoutData(d);
 		Composite tableContainer = new Composite(container, SWT.NONE);
 


### PR DESCRIPTION
The same approach that fixed column width at resizing (see JBIDE-21529) works for vertical layout. At least, on Ubuntu.