### PR TITLE
[JBIDE-22300] Application Wizard: Context dir and ref are ignored in builder images

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromimage/BuildConfigPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromimage/BuildConfigPage.java
@@ -212,7 +212,7 @@ public class BuildConfigPage extends EnvironmentVariablePage {
 			.span(2, 1)
 			.applyTo(gitReferenceText);
 		ValueBindingBuilder
-			.bind(WidgetProperties.text().observe(gitReferenceText))
+			.bind(WidgetProperties.text(SWT.Modify).observe(gitReferenceText))
 			.to(BeanProperties.value(IBuildConfigPageModel.PROPERTY_GIT_REFERENCE).observe(model))
 			.in(dbc);
 		
@@ -232,7 +232,7 @@ public class BuildConfigPage extends EnvironmentVariablePage {
 			.span(2, 1)
 			.applyTo(contextDirText);
 		ValueBindingBuilder
-			.bind(WidgetProperties.text().observe(contextDirText))
+			.bind(WidgetProperties.text(SWT.Modify).observe(contextDirText))
 			.to(BeanProperties.value(IBuildConfigPageModel.PROPERTY_CONTEXT_DIR).observe(model))
 			.in(dbc);
 	}


### PR DESCRIPTION
[JBIDE-22300] Application Wizard: Context dir and ref are ignored in builder images

- Listen to proper SWT events

Signed-off-by: Jeff MAURY <jmaury@redhat.com>