### PR TITLE
JBIDE-22316 Filter template + arrow down should focus on template list and navigate through templates

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TabFolderTraverseListener.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/TabFolderTraverseListener.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.ui.wizard.newapp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.TabFolder;
+
+/**
+ * Shifts focus from tab item header into its children and then out to the tab sibling.
+ * 
+ * @author Viacheslav Kabanovich
+ */
+public class TabFolderTraverseListener  implements Listener {
+	TabFolder tabFolder;
+	List<Control> firstControls = new ArrayList<>();
+
+	public TabFolderTraverseListener(TabFolder tabFolder) {
+		this.tabFolder = tabFolder;
+		tabFolder.addListener(SWT.Traverse, this);
+	}
+	@Override
+	public void handleEvent(Event event) {
+		if(event.detail == SWT.TRAVERSE_ARROW_NEXT || event.detail == SWT.TRAVERSE_TAB_NEXT) {
+			int i = tabFolder.getSelectionIndex();
+			if(i >= 0 && i < firstControls.size() && firstControls.get(i) != null) {
+				firstControls.get(i).forceFocus();
+				event.doit = false;
+			}
+		}
+	}
+
+	/**
+	 * Call this method for i-th tab with all controls that may be focused.
+	 * 
+	 * @param i
+	 * @param controls
+	 */
+	public void bindTabControls(int i, final Control... controls) {
+		while(firstControls.size() < i) {
+			firstControls.add(null);
+		}
+		if(firstControls.size() == i) {
+			firstControls.add(controls[0]);
+		} else {
+			firstControls.set(i, controls[0]);
+		}
+		for (Control c: controls) {
+			c.addListener(SWT.Traverse, new Listener() {
+				@Override
+				public void handleEvent(Event event) {
+					if(event.detail == SWT.TRAVERSE_TAB_NEXT) {
+						if(c != controls[controls.length - 1]) {
+							setFocusToNextSibling(c);
+						} else {
+							setFocusToNextSibling(tabFolder);
+						}
+						event.doit = false;
+					}
+				}
+			});
+		}
+	}
+
+	private void setFocusToNextSibling(Control c) {
+		Composite parent = c.getParent();
+		Control[] children = parent.getTabList();
+		for (int i = 0; i < children.length; i++) {
+			Control child = children[i];
+			if (child == c) {
+				for (int j = i + 1; j < children.length; j++) {
+					Control nc = children[j];
+					if (nc.isEnabled() && nc.setFocus()) {
+						return;
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/newapp/TabFolderTraverseListenerTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/newapp/TabFolderTraverseListenerTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.ui.wizard.newapp;
+
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.TabFolder;
+import org.eclipse.swt.widgets.TabItem;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+import org.jboss.tools.openshift.internal.ui.wizard.newapp.TabFolderTraverseListener;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TabFolderTraverseListenerTest {
+	static final int TAB_COUNT = 3;
+	TestWindow window;
+
+	@Before
+	public void before() {
+		Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		window = new TestWindow(shell, TAB_COUNT);
+		window.open();
+	}
+
+	@After
+	public void after() {
+		if(window != null) {
+			window.close();
+			window = null;
+		}
+	}
+
+	@Test
+	public void testTabFolderTraverseListener() {
+		for (int i = 0; i < window.items.length; i++) {
+			checkTab(i);
+		}
+	}
+
+	/**
+	 * For the tab with the given index sends traverse event 
+	 * to the focus control and checks that
+	 * 1. After traverse on the tab, the first focusable control gets focus.
+	 * 2. After traverse on child controls before the last one, the next child control gets focus.
+	 * 3. After traverse on the last child, the next sibling of the tab folder gets focus.
+	 * @param index
+	 */
+	private void checkTab(int index) {
+		window.tabFolder.forceFocus();
+		window.tabFolder.setSelection(index);
+		fireTraverse(window.tabFolder);
+		TestItem item = window.items[index];
+		Assert.assertTrue(item.controls[0].isFocusControl());
+		for (int i = 0; i < item.controls.length - 1; i++) {
+			fireTraverse(item.controls[i]);
+			Assert.assertTrue(item.controls[i + 1].isFocusControl());
+		}
+		fireTraverse(item.controls[item.controls.length - 1]);
+		Assert.assertTrue(window.next.isFocusControl());
+	}
+
+	private void fireTraverse(Control control) {
+		control.notifyListeners(SWT.Traverse, createTraverseEvent());
+	}
+
+	private Event createTraverseEvent() {
+		Event event = new Event();
+		event.detail = SWT.TRAVERSE_TAB_NEXT;
+		return event;
+	}
+
+	class TestWindow extends Window {
+		TabFolder tabFolder;
+		TabFolderTraverseListener listener;
+		
+		TestItem[] items;
+		
+		//A control to be focused after all child controls of the selected tab are traversed. 
+		Control next;
+
+		protected TestWindow(Shell shellProvider, int tabCount) {
+			super(shellProvider);
+			items = new TestItem[tabCount];
+		}
+
+		@Override
+		protected Control createContents(Composite parent) {
+			Composite root = new Composite(parent, SWT.NONE);
+
+			tabFolder = new TabFolder(root, SWT.NONE);
+
+			listener = new TabFolderTraverseListener(tabFolder);
+			
+			for (int i = 0; i < items.length; i++) {
+				items[i] = new TestItem();
+				items[i].create(tabFolder, listener);
+			}
+			next = new Text(root, SWT.NONE);
+			return root;
+		}
+	}
+
+	class TestItem {
+		TabItem tabItem;
+		Composite itemRoot;
+		Control[] controls = new Control[5];
+
+		public void create(TabFolder tabFolder, TabFolderTraverseListener listener) {
+			tabItem = new TabItem(tabFolder, SWT.NONE);
+			tabItem.setText("Tab " + tabFolder.getItemCount());
+			
+			Composite parent = new Composite(tabFolder, SWT.NONE);
+			tabItem.setControl(parent);
+			
+			for (int i = 0; i < controls.length - 1; i++) {
+				Label label = new Label(parent, SWT.NONE); //Label will not get focus.
+				label.setText("Input " + i);
+				controls[i] = new Text(parent, SWT.NONE);
+				Text disabledText = new Text(parent, SWT.NONE); //Disabled text will not get focus.
+				disabledText.setEnabled(false);
+			}
+			controls[controls.length - 1] = new Button(parent, SWT.NONE);
+			
+			listener.bindTabControls(tabFolder.getItemCount() - 1, controls);
+		}
+
+	}
+}


### PR DESCRIPTION
1. Children widgets of tab items are included into the list
of controls traversed by tab key.
2. List is navigated with arrows while filter remains focused.