### PR TITLE
[JBIDE-22278] Show OpenShift Explorer when a new Connection is created

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/internal/common/core/job/AbstractDelegatingMonitorJob.java
+++ b/plugins/org.jboss.tools.openshift.common.core/src/org/jboss/tools/openshift/internal/common/core/job/AbstractDelegatingMonitorJob.java
@@ -27,6 +27,7 @@ public abstract class AbstractDelegatingMonitorJob extends Job {
 
 	public AbstractDelegatingMonitorJob(String name) {
 		super(name);
+		
 		this.delegatingMonitor = new DelegatingProgressMonitor();
 	}
 
@@ -45,4 +46,5 @@ public abstract class AbstractDelegatingMonitorJob extends Job {
 	public boolean isTimeouted(IStatus status){
 		return status.getCode() == TIMEOUTED;
 	}
+	
 }

--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/OpenShiftCommonUIActivator.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/OpenShiftCommonUIActivator.java
@@ -14,6 +14,10 @@ import org.eclipse.core.runtime.IStatus;
 import org.jboss.tools.foundation.core.plugin.log.IPluginLog;
 import org.jboss.tools.foundation.core.plugin.log.StatusFactory;
 import org.jboss.tools.foundation.ui.plugin.BaseUIPlugin;
+import org.jboss.tools.openshift.common.core.connection.ConnectionsRegistryAdapter;
+import org.jboss.tools.openshift.common.core.connection.ConnectionsRegistrySingleton;
+import org.jboss.tools.openshift.common.core.connection.IConnection;
+import org.jboss.tools.openshift.internal.common.ui.utils.OpenShiftUIUtils;
 import org.osgi.framework.BundleContext;
 
 public class OpenShiftCommonUIActivator extends BaseUIPlugin {
@@ -21,6 +25,8 @@ public class OpenShiftCommonUIActivator extends BaseUIPlugin {
 	public static final String PLUGIN_ID = "org.jboss.tools.openshift.ui"; //$NON-NLS-1$
 
 	private static OpenShiftCommonUIActivator plugin;
+
+	ConnectionsRegistryAdapter connectionsRegistryListener;
 	
 	public OpenShiftCommonUIActivator() {
 	}
@@ -33,14 +39,25 @@ public class OpenShiftCommonUIActivator extends BaseUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
+
+		connectionsRegistryListener = new ConnectionsRegistryAdapter() {
+			@Override
+			public void connectionAdded(IConnection connection) {
+				OpenShiftUIUtils.showOpenShiftExplorer();
+			}
+		};
+		ConnectionsRegistrySingleton.getInstance().addListener(connectionsRegistryListener);
 	}
 
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
+		if (connectionsRegistryListener != null) {
+			ConnectionsRegistrySingleton.getInstance().removeListener(connectionsRegistryListener);
+			connectionsRegistryListener = null;
+		}
 		super.stop(context);
 	}
-
 	public static OpenShiftCommonUIActivator getDefault() {
 		return plugin;
 	}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizard.java
@@ -110,7 +110,7 @@ public class DeployImageWizard extends AbstractOpenShiftWizard<IDeployImageParam
 									deployJob.getSummaryMessage()).open();
 						}
 					});
-					OpenShiftUIUtils.showOpenShiftExplorerView();
+					OpenShiftUIUtils.showOpenShiftExplorer();
 				}
 			}
 		});

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
@@ -213,7 +213,7 @@ public class NewApplicationWizard
 				if(JobUtils.isOk(status) 
 						|| JobUtils.isWarning(status)) {
 					Display.getDefault().syncExec(createJob.getSummaryRunnable(getShell()));
-					OpenShiftUIUtils.showOpenShiftExplorerView();
+					OpenShiftUIUtils.showOpenShiftExplorer();
 					if (model.getEclipseProject() != null) {
 						//No need to import the project from git, it's already here
 						return;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/resource/NewResourceWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/resource/NewResourceWizard.java
@@ -95,7 +95,7 @@ public class NewResourceWizard extends Wizard implements IWorkbenchWizard {
                                         "Results of creating the resource(s)").open();
                             }
                         });
-                        OpenShiftUIUtils.showOpenShiftExplorerView();
+                        OpenShiftUIUtils.showOpenShiftExplorer();
                     }
                 }
             });

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/ui/OpenShiftCommonUIActivatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/ui/OpenShiftCommonUIActivatorTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.common.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.tools.openshift.internal.common.ui.utils.OpenShiftUIUtils.hideOpenShiftExplorer;
+import static org.jboss.tools.openshift.internal.common.ui.utils.OpenShiftUIUtils.isOpenShiftExplorerVisible;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.intro.IIntroManager;
+import org.eclipse.ui.intro.IIntroPart;
+import org.jboss.tools.openshift.common.core.connection.ConnectionsRegistrySingleton;
+import org.jboss.tools.openshift.core.connection.Connection;
+import org.jboss.tools.openshift.test.util.UITestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OpenShiftCommonUIActivatorTest {
+
+	@BeforeClass
+	public static void closeIntro() throws Exception {
+		final IIntroManager introManager = PlatformUI.getWorkbench().getIntroManager();
+		IIntroPart intro = introManager.getIntro();
+		if (intro != null) {
+			introManager.closeIntro(intro);
+		}
+	}	
+	
+	@Before
+	public void setup() {
+		hideOpenShiftExplorer();
+	}
+	
+	@After
+	public void tearDown() {
+		hideOpenShiftExplorer();
+		ConnectionsRegistrySingleton.getInstance().clear();
+	}
+	
+	
+	@Test
+	public void testShowExplorerOnNewConnections() throws Exception {
+		//Ensure OpenShift Explorer is hidden
+		assertThat(isOpenShiftExplorerVisible()).isFalse();
+		
+		//Come up with a dummy connection
+		Connection connection = mock(Connection.class);
+		when(connection.getHost()).thenReturn("foo");
+		when(connection.getUsername()).thenReturn("bar");
+		
+		//adding a new connection should open the OpenShift explorer
+		ConnectionsRegistrySingleton.getInstance().add(connection);
+		
+		UITestUtils.waitForDeferredEvents();
+		
+		//check OpenShift explorer is visible now
+		assertThat(isOpenShiftExplorerVisible()).isTrue();
+	}
+
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/util/UITestUtils.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/util/UITestUtils.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.util;
+
+import org.eclipse.swt.widgets.Display;
+
+public class UITestUtils {
+
+	public static final long DEFAULT_TIMEOUT = 10_000;
+	
+	/**
+	 * Wraps a call to <code>Display.getDefault().readAndDispatch()</code>, thus waits for events 
+	 * created by {@link Display#syncExec(Runnable)} or {@link Display#asyncExec(Runnable)} 
+	 * to be processed. 
+	 * This method will wait for all events to be processed or until timeout is reached, and will simply return.
+	 * 
+	 * @param timeout maximum time to wait UI events to be processed, in milliseconds
+	 */
+	public static void waitForDeferredEvents(long timeout) {
+		boolean wait = true;
+		long start = System.currentTimeMillis();
+		while (wait) {
+			if (!Display.getDefault().readAndDispatch() || 
+					(System.currentTimeMillis() - start) > timeout) {
+				wait = false;
+			}
+		}
+	}
+
+	
+	/**
+	 * Wraps a call to <code>Display.getDefault().readAndDispatch()</code>, thus waits for events 
+	 * created by {@link Display#syncExec(Runnable)} or {@link Display#asyncExec(Runnable)} 
+	 * to be processed. 
+	 * This method will wait for all events to be processed or until the default timeout is reached (i.e. 10 seconds), and will simply return.
+	 * 
+	 */
+	public static void waitForDeferredEvents() {
+		waitForDeferredEvents(DEFAULT_TIMEOUT);
+	}
+
+}


### PR DESCRIPTION
OpenShift Explorer is shown when creating the OpenShift Connection from the CDK server adapter or the regular New OpenShift Application wizard.

http://screencast.com/t/j6EWxqS2adP

Signed-off-by: Fred Bricon <fbricon@gmail.com>