### PR TITLE
JBIDE-22304 Server Editor: Pod deployment path is not shown

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/InferPodPathJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/InferPodPathJob.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.ui.server;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Hashtable;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.wst.server.core.ServerUtil;
+import org.jboss.tools.openshift.common.core.utils.StringUtils;
+import org.jboss.tools.openshift.core.connection.Connection;
+import org.jboss.tools.openshift.core.server.PodDeploymentPathProvider;
+
+import com.openshift.restclient.model.IService;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class InferPodPathJob extends Job implements PropertyChangeListener {
+	static String POD_PATH_LOADING_MESSAGE = "loading...";
+
+	protected ServerSettingsWizardPageModel model;
+
+	protected IService service; //service to load pod path for. When path is loaded, service is set to null.
+	protected IService last;
+	protected boolean isLoaded = false;
+	protected String customPodPath = null;
+	protected Hashtable<String, String> cache = new Hashtable<String, String>();
+	
+	public InferPodPathJob(ServerSettingsWizardPageModel model) {
+		super("Infer pod path");
+		this.model = model;
+	}
+
+	public boolean isLoaded() {
+		return isLoaded;
+	}
+
+	@Override
+	public boolean belongsTo(Object family) {
+		return ServerUtil.SERVER_JOB_FAMILY.equals(family);
+	}
+
+	@Override
+	protected IStatus run(IProgressMonitor monitor) {
+		if(service == null) {
+			return Status.OK_STATUS;
+		}
+		setLoadingMessage();
+		while(true) {
+			IService current = service;
+			if(current == null) {
+				isLoaded = false;
+				removeLoadingMessage();
+				break;
+			}
+			try {
+				String path = loadPodPath(current);
+				if(current == service) { //otherwise, the service is changed, continue
+					if(!StringUtils.isEmpty(path)) {
+						cache.put(getServiceKey(current), path);
+					}
+					setLoadedPath(path);
+					break;
+				}
+			} catch (CoreException e) {
+				// just do another attempt.
+			}
+			try {
+				Thread.sleep(300);
+			} catch (InterruptedException e) {
+				removeLoadingMessage();
+				break;
+			}
+		}
+		return Status.OK_STATUS;
+	}
+
+	private void setLoadingMessage() {
+		if(!POD_PATH_LOADING_MESSAGE.equals(model.getPodPath())) {
+			customPodPath = model.getPodPath();
+			model.setInferredPodPath(POD_PATH_LOADING_MESSAGE);
+		}
+	}
+
+	private void removeLoadingMessage() {
+		if(POD_PATH_LOADING_MESSAGE.equals(model.getPodPath())) {
+			model.setInferredPodPath(customPodPath);
+		}
+	}
+
+	private void setLoadedPath(String path) {
+		model.setInferredPodPath(path);
+		isLoaded = true;
+		customPodPath = model.getPodPath();
+		if(service != null) {
+			last = service;
+		}
+		service = null;
+	}
+
+	@Override
+	public void propertyChange(PropertyChangeEvent evt) {
+		String name = evt.getPropertyName();
+		boolean serviceUpdate = ServerSettingsWizardPageModel.PROPERTY_SERVICE.equals(name);
+		boolean useUpdate = ServerSettingsWizardPageModel.PROPERTY_USE_INFERRED_POD_PATH.equals(name);
+		if(serviceUpdate || useUpdate) {
+			final IService newService = model.isUseInferredPodPath() ? model.getService() : null;
+			if(this.service != newService && (this.service != null || last != newService || useUpdate)) {
+	    		service = newService;
+	    		isLoaded = false;
+				if(newService == null || cache.containsKey(getServiceKey(newService))) {
+					final String path = newService == null ? null : cache.get(getServiceKey(newService));
+					//without new thread it will wait for this job to complete.
+					new Thread() {
+						@Override
+						public void run() {
+							if(path == null) {
+								removeLoadingMessage();
+							}else {
+								setLoadedPath(path);
+							}
+						}
+					}.start();
+				} else if(this.getState() == Job.NONE) {
+					schedule(300);
+				}
+			}
+		}			
+	}
+
+	protected String getServiceKey(IService service) {
+		return new StringBuilder().append(service.getNamespace()).append("/").append(service.getName()).toString();
+	}
+
+	protected String loadPodPath(IService service) throws CoreException {
+		return new PodDeploymentPathProvider().load(service, (Connection)model.getConnection());
+	}
+
+	public void stop() {
+		service = null;
+		last = null;
+		cache.clear();
+	}
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorModel.java
@@ -272,6 +272,13 @@ public class OpenShiftServerEditorModel extends ServerSettingsWizardPageModel {
 			section.execute(new SetPodPathCommand(getServer(), previous, podPath));
 	}
 
+	@Override
+	protected void setInferredPodPath(String podPath) {
+		//Inferred pod path is set asynchronously after initialization is formally completed, 
+		//When setting inferred path, no undoable command should be created.
+		setPodPath(podPath, false);
+	}
+
 	public class SetPodPathCommand extends ServerWorkingCopyPropertyCommand {
 		private String oldPath, newPath;
 		public SetPodPathCommand(IServerWorkingCopy server, String oldPath, String newPath) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardFragment.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardFragment.java
@@ -261,6 +261,9 @@ public class ServerSettingsWizardFragment extends WizardHandleAwareFragment impl
 	
 		void unhook() {
 			uiHook = null;
+			if(model != null) {
+				model.dispose();
+			}
 			model = null;
 		}
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
@@ -891,6 +891,9 @@ public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implem
 	public void dispose() {
 		super.dispose();
 		uiHook = null;
+		if(model != null) {
+			model.dispose();
+		}
 		//not good set model to null here
 	}
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -156,7 +156,7 @@ public class NewApplicationWizardModel
 	
 	private List<ObservableTreeItem> getProjectTemplates(IProject selectedProject, List<ObservableTreeItem> allProjects) {
 		if (allProjects == null) {
-			return null;
+			return Collections.emptyList();
 		}
 		for (ObservableTreeItem item : allProjects) {
 			if (item.getModel().equals(selectedProject)) {


### PR DESCRIPTION
Pod path will be asynchronously loaded. When job is on, text field will have message 'loading...'. User can modify data/cancel/finish without waiting for loading to complete. If it is completed, the loaded path will be saved to server data. The loading is on only when 'Use inferred pod path' checkbox is selected. Checking it off stops the process and returns the previous pod path value.
