### PR TITLE
JBIDE-22420 Application Wizard: Finish button is still enabled upon selection of a builder image if a template was selected before

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
@@ -163,10 +163,9 @@ public class NewApplicationWizard
 					return null;
 				}
 				if(isTemplateFlow()){
-					Stream.of(bcPage, dcPage, servicesPage).forEach(p->p.setPageComplete(true));
 					return getPage(TemplateParametersPage.PAGE_NAME);
 				}
-				return getPage(DeploymentConfigPage.PAGE_NAME);
+				return getPage(BuildConfigPage.PAGE_NAME);
 			}
 			
 		};

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromimage/BuildConfigPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromimage/BuildConfigPage.java
@@ -41,7 +41,7 @@ import org.jboss.tools.openshift.internal.ui.wizard.common.ResourceNameControl;
  */
 public class BuildConfigPage extends EnvironmentVariablePage {
 
-	public static final String PAGE_NAME = "Deployment Config Settings Page";
+	public static final String PAGE_NAME = "Build Config Settings Page";
 	private static final String PAGE_TITLE = "Build Configuration";
 	private static final String PAGE_DESCRIPTION = "";
 


### PR DESCRIPTION
1. Explicit setting completed to 'image flow' pages is removed - it should be enough that their method isPageComplete() is overridden.
2. Logical names of BuildConfigPage, DeploymentConfigPage were equal - the change makes them distinct. 