### PR TITLE
[JBIDE 21068] Set maximum length for display name for project wizard

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ProjectDisplayNameValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ProjectDisplayNameValidator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.openshift.internal.ui.validator;
 
 import org.apache.commons.lang.StringUtils;
@@ -12,8 +22,9 @@ public class ProjectDisplayNameValidator implements IValidator {
 
 	@Override
 	public IStatus validate(Object value) {
-		if(value != null && !(value instanceof String))
+		if(!(value instanceof String)) {
 			return ValidationStatus.cancel("Display name is not an instance of a string");
+		}
 		String param = (String) value;
 		if(StringUtils.isNotEmpty(param)) {
 			if(param.indexOf(SWT.TAB) >= 0 || param.indexOf(SWT.LF) >= 0) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ProjectDisplayNameValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ProjectDisplayNameValidator.java
@@ -1,0 +1,29 @@
+package org.jboss.tools.openshift.internal.ui.validator;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.core.databinding.validation.IValidator;
+import org.eclipse.core.databinding.validation.ValidationStatus;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.swt.SWT;
+
+public class ProjectDisplayNameValidator implements IValidator {
+	
+	public static final int DISPLAY_NAME_LENGTH_LIMIT = 65535;
+
+	@Override
+	public IStatus validate(Object value) {
+		if(value != null && !(value instanceof String))
+			return ValidationStatus.cancel("Display name is not an instance of a string");
+		String param = (String) value;
+		if(StringUtils.isNotEmpty(param)) {
+			if(param.indexOf(SWT.TAB) >= 0 || param.indexOf(SWT.LF) >= 0) {
+				return ValidationStatus.error("Display name may not contain tabs or new lines");
+			}
+			if (param.length() > DISPLAY_NAME_LENGTH_LIMIT) {
+				return ValidationStatus.error("Display name may not be longer than " + DISPLAY_NAME_LENGTH_LIMIT + " characters");
+			}
+		}
+		return ValidationStatus.ok();
+	}
+
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/NewProjectWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/NewProjectWizardPage.java
@@ -10,13 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.ui.wizard.project;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.databinding.Binding;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
-import org.eclipse.core.databinding.validation.IValidator;
-import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.databinding.fieldassist.ControlDecorationSupport;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
@@ -32,6 +29,7 @@ import org.jboss.tools.common.ui.databinding.ValueBindingBuilder;
 import org.jboss.tools.openshift.internal.common.ui.databinding.RequiredControlDecorationUpdater;
 import org.jboss.tools.openshift.internal.common.ui.wizard.AbstractOpenShiftWizardPage;
 import org.jboss.tools.openshift.internal.ui.OpenShiftUIMessages;
+import org.jboss.tools.openshift.internal.ui.validator.ProjectDisplayNameValidator;
 import org.jboss.tools.openshift.internal.ui.validator.ProjectNameValidator;
 
 import com.openshift.restclient.model.IProject;
@@ -41,8 +39,6 @@ import com.openshift.restclient.model.IProject;
  */
 public class NewProjectWizardPage extends AbstractOpenShiftWizardPage {
 	
-	private static final int DISPLAY_NAME_LENGTH_LIMIT = 65535;
-
 	private NewProjectWizardModel model;
 
 	public NewProjectWizardPage(NewProjectWizardModel model, IWizard wizard) {
@@ -89,23 +85,7 @@ public class NewProjectWizardPage extends AbstractOpenShiftWizardPage {
 			.align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(txtDispalayName);
 		ValueBindingBuilder
 			.bind(WidgetProperties.text(SWT.Modify).observe(txtDispalayName))
-			.validatingAfterConvert(new IValidator() {
-
-				@Override
-				public IStatus validate(Object value) {
-					String param = (String) value;
-					if(StringUtils.isNotEmpty(param)) {
-						if(param.indexOf(SWT.TAB) >= 0 || param.indexOf(SWT.LF) >= 0) {
-							return ValidationStatus.error("Display name may not contain tabs or new lines");
-						}
-						if (param.length() > DISPLAY_NAME_LENGTH_LIMIT) {
-							return ValidationStatus.error("Display name may not be longer than " + DISPLAY_NAME_LENGTH_LIMIT + " characters");
-						}
-					}
-					return ValidationStatus.ok();
-				}
-				
-			})
+			.validatingAfterConvert(new ProjectDisplayNameValidator())
 			.to(BeanProperties.value(NewProjectWizardModel.PROPERTY_DISPLAY_NAME).observe(model))
 			.in(dbc);
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/NewProjectWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/NewProjectWizardPage.java
@@ -40,6 +40,8 @@ import com.openshift.restclient.model.IProject;
  * @author jeff.cantrill
  */
 public class NewProjectWizardPage extends AbstractOpenShiftWizardPage {
+	
+	private static final int DISPLAY_NAME_LENGTH_LIMIT = 65535;
 
 	private NewProjectWizardModel model;
 
@@ -93,8 +95,11 @@ public class NewProjectWizardPage extends AbstractOpenShiftWizardPage {
 				public IStatus validate(Object value) {
 					String param = (String) value;
 					if(StringUtils.isNotEmpty(param)) {
-						if(param.contains("\t") || param.contains("\n")) {
+						if(param.indexOf(SWT.TAB) >= 0 || param.indexOf(SWT.LF) >= 0) {
 							return ValidationStatus.error("Display name may not contain tabs or new lines");
+						}
+						if (param.length() > DISPLAY_NAME_LENGTH_LIMIT) {
+							return ValidationStatus.error("Display name may not be longer than " + DISPLAY_NAME_LENGTH_LIMIT + " characters");
 						}
 					}
 					return ValidationStatus.ok();

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ProjectDisplayNameValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ProjectDisplayNameValidatorTest.java
@@ -1,0 +1,43 @@
+package org.jboss.tools.openshift.test.ui.validator;
+
+import org.jboss.tools.openshift.internal.ui.validator.ProjectDisplayNameValidator;
+import org.junit.Test;
+
+public class ProjectDisplayNameValidatorTest extends AbstractValidatorTest {
+
+	public ProjectDisplayNameValidatorTest() {
+		super(new ProjectDisplayNameValidator());
+	}
+	
+	@Test
+	public void validDisplayNameShouldBeValid() {
+		assertPass("jboss tools dream team");
+	}
+	
+	@Test
+	public void emptyDisplayNameShouldBeValid() {
+		assertPass("");
+		assertPass(null);
+	}
+	
+	@Test
+	public void notStringShouldBeCanceled() {
+		assertCancel(new Object());
+	}
+	
+	@Test
+	public void tabsShouldBeInvalid() {
+		assertFailure("jboss\tools");
+	}
+	
+	@Test
+	public void newLinesShouldBeInvalid() {
+		assertFailure("happy\new year");
+	}
+	
+	@Test
+	public void veryLongDisplayNameShouldBeInvalid() {
+		assertFailure(new String(new char[ProjectDisplayNameValidator.DISPLAY_NAME_LENGTH_LIMIT + 1]));
+	}
+
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ProjectDisplayNameValidatorTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/validator/ProjectDisplayNameValidatorTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.openshift.test.ui.validator;
 
 import org.jboss.tools.openshift.internal.ui.validator.ProjectDisplayNameValidator;
@@ -17,7 +27,11 @@ public class ProjectDisplayNameValidatorTest extends AbstractValidatorTest {
 	@Test
 	public void emptyDisplayNameShouldBeValid() {
 		assertPass("");
-		assertPass(null);
+	}
+	
+	@Test
+	public void nullDisplayNameShouldBeCanceled() {
+		assertCancel(null);
 	}
 	
 	@Test


### PR DESCRIPTION
The limit is, actually, set in swt Text and it is [platform dependent](http://help.eclipse.org/luna/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/swt/widgets/Text.html#LIMIT). In my Fedora 23 
```
public int getTextLimit () {
	checkWidget ();
	if ((style & SWT.MULTI) != 0) return LIMIT;
	int limit = OS.gtk_entry_get_max_length (handle);
	return limit == 0 ? 0xFFFF : untranslateOffset (limit);
}
```
always returns 0xFFFF which is exactly 65536. So couldn't test it in a usual way, but just setting the limit lower for testing purposes.
However, i added ValidationStatus.error when input is bigger so that this check works in another OSs.