### PR TITLE
JBIDE-22120 Fix cdk plugin blurb string - should not say vagrant

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/about.properties
+++ b/plugins/org.jboss.tools.openshift.cdk.server/about.properties
@@ -1,2 +1,1 @@
-blurb=JBoss Vagrant Core Plugin\n\nVersion\: {featureVersion}\n\n(c) Copyright (c) Red Hat, Inc., contributors and others 2016.  All rights reserved.\nVisit http\://jboss.org/tools
-
+blurb=JBoss OpenShift Tools - CDK Server Adapter\n\nVersion\: {featureVersion}\n\n(c) Copyright (c) Red Hat, Inc., contributors and others 2016.  All rights reserved.\nVisit http\://jboss.org/tools


### PR DESCRIPTION
This is just a small addition to a previous commit on this topic