### PR TITLE
JBIDE-22473 Environment Var Wizard: Cannot remove env vars

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/wizard/KeyValueWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/wizard/KeyValueWizardPage.java
@@ -116,8 +116,8 @@ public class KeyValueWizardPage<T extends IKeyValueItem> extends AbstractOpenShi
 			dbc.addValidationStatusProvider(validator);
 		}
 
-		if(!model.isKeyEditable()) {
-			valueText.forceFocus();
+		if(!model.isKeyEditable() || nameText.getText().length() > 0) {
+			valueText.forceFocus(); //if name is set, it is more important to modify value.
 			if(!StringUtils.isEmpty(valueText.getText())) {
 				valueText.setSelection(0, valueText.getText().length());
 			}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/IEnvironmentVariablesPageModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/IEnvironmentVariablesPageModel.java
@@ -12,12 +12,16 @@ package org.jboss.tools.openshift.internal.ui.wizard.common;
 
 import java.util.List;
 
+import org.jboss.tools.openshift.internal.common.ui.wizard.IKeyValueItem;
+
 /**
  * Model interface for manipulating env variables
  * @author jeff.cantrill
  *
  */
 public interface IEnvironmentVariablesPageModel {
+	//A constant set as value to an environment variable to mark it deleted
+	static final String DELETED = "&Deleted";
 	
 	static final String PROPERTY_ENVIRONMENT_VARIABLES = "environmentVariables";
 	static final String PROPERTY_SELECTED_ENVIRONMENT_VARIABLE = "selectedEnvironmentVariable";
@@ -29,6 +33,10 @@ public interface IEnvironmentVariablesPageModel {
 	EnvironmentVariable getSelectedEnvironmentVariable();
 	EnvironmentVariable getEnvironmentVariable(String key);
 	boolean isEnvironmentVariableModified(EnvironmentVariable envVar);
+
+	default boolean isEnvironmentVariableDeleted(IKeyValueItem envVar) {
+		return DELETED.equals(envVar.getValue());
+	}
 	
 	void removeEnvironmentVariable(EnvironmentVariable envVar);
 	void resetEnvironmentVariable(EnvironmentVariable envVar);

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/deployimage/DeployImageWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/deployimage/DeployImageWizardModelTest.java
@@ -336,8 +336,10 @@ public class DeployImageWizardModelTest {
         // then
         assertThat(result).isTrue();
         model.removeEnvironmentVariable(model.getEnvironmentVariable("V1"));
-        assertThat(model.getEnvironmentVariables()).hasSize(1);
-        assertThat(model.getEnvironmentVariables()).isEqualTo(Collections.singletonList(new EnvironmentVariable("V2", "value2")));
+        assertThat(model.getEnvironmentVariables()).hasSize(2);
+        //Deleted existing environment variable is marked as deleted, but remains in the table.
+        assertThat(model.isEnvironmentVariableDeleted(model.getEnvironmentVariable("V1"))).isTrue();
+        assertThat(model.getEnvironmentVariable("V2").getValue()).isEqualTo("value2");
     }
     
     @Test


### PR DESCRIPTION
Any environment var can be deleted or renamed. The result of rename is shown as the sum of the deleted original var and added new var. A deleted original var is shown in the table in italic with text decoration '[deleted]'. User can restore it in one of the following ways: 1) select and push Restore, 2) select and push Edit, set value and finish, 3) Push Add, enter the same key (it is not prohibited since the var is marked deleted) and finish, 4) Rename another var to its name.
All these operations are consistent and show user which original vars are deleted/modified and which new are added.

The option to delete/rename original vars is implemented only for 'Manage Environment Variables' wizard. Other wizards are not affected. 