### PR TITLE
JBIDE-22545 Application Wizard: Default values in template parameters table are in italics

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromtemplate/ApplicationSourceFromTemplateModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromtemplate/ApplicationSourceFromTemplateModel.java
@@ -182,12 +182,12 @@ public class ApplicationSourceFromTemplateModel
 
 	@Override
 	public void setParameters(List<IParameter> parameters) {
-		firePropertyChange(PROPERTY_PARAMETERS, this.parameters, this.parameters = injectProjectParameters(this.eclipseProject, parameters));
 		Map<String, String> paramsMap = new HashMap<>();
 		if (parameters != null) {
 		  parameters.forEach(p -> paramsMap.put(p.getName(), p.getValue()));
 		}
 		originalValueMap = paramsMap;
+		firePropertyChange(PROPERTY_PARAMETERS, this.parameters, this.parameters = injectProjectParameters(this.eclipseProject, parameters));
 	}
 
 	private static List<IParameter> injectProjectParameters(org.eclipse.core.resources.IProject project, List<IParameter> originalParameters) {


### PR DESCRIPTION
The firing of parameters list change was happening before the default values were stored in the model. Fixed.