### PR TITLE
[JBIDE-22515] Don't create resources when its an image update

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImageWizard.java
@@ -147,7 +147,7 @@ public class DeployImageWizard extends AbstractOpenShiftWizard<IDeployImageParam
 			@Override
 			public void done(IJobChangeEvent event) {
 				IStatus status = event.getResult();
-				if(JobUtils.isOk(status) || JobUtils.isWarning(status)) {
+				if((JobUtils.isOk(status) || JobUtils.isWarning(status)) && !deployJob.getResources().isEmpty()) {
 					Display.getDefault().syncExec(new Runnable() {
 						@Override
 						public void run() {


### PR DESCRIPTION
cc @fbricon 

This skips resource creation if its determined to be an update of deploying an image.  I have not yet tested the create from app builder scenario that relies upon this, but its a first pass.  I suppose you are going to want some unit tests too...:)