### PR TITLE
JBIDE-22583...

### DIFF
--- a/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
@@ -24,5 +24,5 @@ Require-Bundle: org.jboss.tools.common.core;bundle-version="3.7.0",
  org.jboss.tools.openshift.common.core,
  org.eclipse.debug.core,
  org.jboss.ide.eclipse.as.core;bundle-version="3.1.1",
- org.jboss.tools.openshift.core;bundle-version="3.3.0"
+ org.jboss.tools.openshift.core;bundle-version="3.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
JBIDE-22583 org.jboss.tools.openshift.cdk.server.test should depend on 3.2.0 not 3.3.0