### PR TITLE
JBIDE-22671 Remove trailing space in registry url

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/CDKOpenshiftUtility.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/CDKOpenshiftUtility.java
@@ -30,7 +30,7 @@ public class CDKOpenshiftUtility {
 	private static String DOTCDK_AUTH_PASS = "openshift.auth.password";
 	
 	private static final String IMAGE_REGISTRY_KEY = "DOCKER_REGISTRY";
-	private static final String DEFAULT_IMAGE_REGISTRY_URL = "https://hub.openshift.rhel-cdk.10.1.2.2.xip.io ";
+	private static final String DEFAULT_IMAGE_REGISTRY_URL = "https://hub.openshift.rhel-cdk.10.1.2.2.xip.io";
 
 
 	public IConnection findExistingOpenshiftConnection(IServer server, ServiceManagerEnvironment adb) {


### PR DESCRIPTION
There is an extra trailing space in the default docker
registry url.