### PR TITLE
[JBIDE-22649] - When importing an OS2 app, the Git import does not use the default import folder used while importing OS3

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/OpenShiftCommonUIConstants.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/OpenShiftCommonUIConstants.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc..
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Incorporated - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.openshift.internal.common.ui;
+
+/**
+ * @author Jeff Maury
+ *
+ */
+public final class OpenShiftCommonUIConstants {
+    /**
+     * Name of the section storing info related to application import
+     */
+    public static final String IMPORT_APPLICATION_DIALOG_SETTINGS_KEY = "ImportApplicationWizard";
+    
+    /**
+     * Name of the key used to stored Git default repo path
+     */
+    public static final String REPO_PATH_KEY = "repoPath";
+}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
@@ -94,6 +94,8 @@ public abstract class ExpressApplicationWizard extends Wizard implements IWorkbe
 		if (isNotBlank(repoPath)) {
 			model.setUseDefaultRepoPath(false);
 			model.setRepositoryPath(repoPath);
+		} else {
+			model.setUseDefaultRepoPath(true);
 		}
 	}
 	

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ExpressApplicationWizard.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.DialogSettings;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -54,6 +55,7 @@ import org.jboss.tools.openshift.express.internal.ui.wizard.application.template
 import org.jboss.tools.openshift.internal.common.core.UsageStats;
 import org.jboss.tools.openshift.internal.common.core.job.AbstractDelegatingMonitorJob;
 import org.jboss.tools.openshift.internal.common.core.job.JobChainBuilder;
+import org.jboss.tools.openshift.internal.common.ui.OpenShiftCommonUIActivator;
 import org.jboss.tools.openshift.internal.common.ui.application.importoperation.ImportFailedException;
 import org.jboss.tools.openshift.internal.common.ui.application.importoperation.WontOverwriteException;
 import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
@@ -64,11 +66,16 @@ import com.openshift.client.IDomain;
 import com.openshift.client.OpenShiftException;
 import com.openshift.client.cartridge.IEmbeddedCartridge;
 
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.jboss.tools.openshift.internal.common.ui.OpenShiftCommonUIConstants.IMPORT_APPLICATION_DIALOG_SETTINGS_KEY;
+import static org.jboss.tools.openshift.internal.common.ui.OpenShiftCommonUIConstants.REPO_PATH_KEY;
+
 /**
  * A wizard to import and create OpenShift applications. 
  * 
  * @author Andre Dietisheim
  * @author Xavier Coulon
+ * @author Jeff Maury
  * 
  * @see NewApplicationWorkbenchWizard
  * @see ImportExpressApplicationWizard
@@ -81,7 +88,13 @@ public abstract class ExpressApplicationWizard extends Wizard implements IWorkbe
 			boolean useExistingApplication, String wizardTitle) {
 		setWindowTitle(wizardTitle);
 		setNeedsProgressMonitor(true);
+		setDialogSettings(DialogSettings.getOrCreateSection(OpenShiftCommonUIActivator.getDefault().getDialogSettings(), IMPORT_APPLICATION_DIALOG_SETTINGS_KEY));
 		this.model = new OpenShiftApplicationWizardModel(connection, domain, application, project, useExistingApplication);
+		String repoPath = getDialogSettings().get(REPO_PATH_KEY);
+		if (isNotBlank(repoPath)) {
+			model.setUseDefaultRepoPath(false);
+			model.setRepositoryPath(repoPath);
+		}
 	}
 	
 	@Override
@@ -127,6 +140,9 @@ public abstract class ExpressApplicationWizard extends Wizard implements IWorkbe
 				UsageStats.getInstance().newV2Application(model.getConnection().getHost(), success);
 			} else {
 				UsageStats.getInstance().importV2Application(model.getConnection().getHost(), success);
+			}
+			if (success && !model.isUseDefaultRepoPath()) {
+				getDialogSettings().put(REPO_PATH_KEY, model.getRepositoryPath());
 			}
 			return success;
 	}

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Red Hat, Inc.
+ * Copyright (c) 2011-2016 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -25,6 +25,7 @@ import com.openshift.client.cartridge.ICartridge;
  * @author Andre Dietisheim
  * @author Rob Stryker
  * @author Xavier Coulon
+ * @author Jeff Maury
  */
 public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 
@@ -32,12 +33,11 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 	public static final String PROPERTY_NEW_PROJECT = "newProject";
 	public static final String PROPERTY_REPO_PATH = "repositoryPath";
 	public static final String PROPERTY_REMOTE_NAME = "remoteName";
-	public static final String PROPERTY_USE_DEFAULT_REPO_PATH = "useDefaultRepoPath";
+	public static final String PROPERTY_USE_DEFAULT_REPO_PATH = IOpenShiftApplicationWizardModel.PROP_USE_DEFAULT_REPO_PATH;
 	public static final String PROPERTY_USE_DEFAULT_REMOTE_NAME = "useDefaultRemoteName";
 	public static final String PROPERTY_HAS_REMOTEKEYS = "hasRemoteKeys";
 
 	private IOpenShiftApplicationWizardModel wizardModel;
-	private boolean useDefaultRepoPath = true;
 	private boolean useDefaultRemoteName = true;
 	private boolean hasRemoteKeys;
 
@@ -46,7 +46,7 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_APPLICATION_NAME, onWizardApplicationNameChanged());
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_PROJECT_NAME, onWizardProjectNameChanged());
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_NEW_PROJECT, onWizardProjectNameChanged());
-		setRepositoryPath(getDefaultRepositoryPath());
+		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_USE_DEFAULT_REPO_PATH, onUseDefaultRepoPathChanged());
 		setDefaultRemoteName();
 	}
 
@@ -84,6 +84,19 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 					}
 				}
 				setDefaultRemoteName();
+			}
+		};
+	}
+	
+	/**
+	 * Listener to propagate the default repository path flag changes from the underlying WizardModel into this WizardPageModel, so that properties can be affected here, too.
+	 * @return the property listener
+	 */
+	private PropertyChangeListener onUseDefaultRepoPathChanged() {
+		return new PropertyChangeListener() {
+			@Override
+			public void propertyChange(PropertyChangeEvent evt) {
+				firePropertyChange(PROPERTY_USE_DEFAULT_REPO_PATH, evt.getOldValue(), evt.getNewValue());
 			}
 		};
 	}
@@ -137,15 +150,15 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 
 	public void setUseDefaultRepoPath(boolean useDefaultRepoPath) {
 		firePropertyChange(PROPERTY_USE_DEFAULT_REPO_PATH
-				, this.useDefaultRepoPath
-				, this.useDefaultRepoPath = useDefaultRepoPath);
+				, wizardModel.isUseDefaultRepoPath()
+				, wizardModel.setUseDefaultRepoPath(useDefaultRepoPath));
 		if (useDefaultRepoPath) {
 			setRepositoryPath(getDefaultRepositoryPath());
 		}
 	}
 
 	public boolean isUseDefaultRepoPath() {
-		return useDefaultRepoPath;
+		return wizardModel.isUseDefaultRepoPath();
 	}
 
 	public void setUseDefaultRemoteName(boolean useDefaultRemoteName) {

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
@@ -48,6 +48,7 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_NEW_PROJECT, onWizardProjectNameChanged());
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_USE_DEFAULT_REPO_PATH, onUseDefaultRepoPathChanged());
 		setDefaultRemoteName();
+		setUseDefaultRepoPath(true);
 	}
 
 

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/GitCloningSettingsWizardPageModel.java
@@ -48,7 +48,6 @@ public class GitCloningSettingsWizardPageModel extends ObservableUIPojo {
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_NEW_PROJECT, onWizardProjectNameChanged());
 		wizardModel.addPropertyChangeListener(IOpenShiftApplicationWizardModel.PROP_USE_DEFAULT_REPO_PATH, onUseDefaultRepoPathChanged());
 		setDefaultRemoteName();
-		setUseDefaultRepoPath(true);
 	}
 
 

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/IOpenShiftApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/IOpenShiftApplicationWizardModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Red Hat, Inc.
+ * Copyright (c) 2011-2016 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -42,6 +42,7 @@ import com.openshift.client.cartridge.IStandaloneCartridge;
 
 /**
  * @author André Dietisheim
+ * @author Jeff Maury
  */
 public interface IOpenShiftApplicationWizardModel extends IConnectionAware<ExpressConnection>, IObservablePojo {
 
@@ -62,6 +63,7 @@ public interface IOpenShiftApplicationWizardModel extends IConnectionAware<Expre
 	public static final String PROP_NEW_PROJECT = "newProject";
 	public static final String PROP_PROJECT_NAME = "projectName";
 	public static final String PROP_REMOTE_NAME = "remoteName";
+	public static final String PROP_USE_DEFAULT_REPO_PATH = "useDefaultRepoPath";
 	public static final String PROP_REPOSITORY_PATH = "repositoryPath";
 	public static final String PROP_SKIP_MAVEN_BUILD = "skipMavenBuild";
 	public static final String PROP_SERVER_ADAPTER = "serverAdapter";
@@ -223,6 +225,16 @@ public interface IOpenShiftApplicationWizardModel extends IConnectionAware<Expre
 	 */
 	public String getRemoteName();
 
+	public boolean setUseDefaultRepoPath(boolean useDefaultRepositoryPath);
+	
+	/**
+	 * Returns the flag to stores the information if the default path to the local git repository the wizard will clone the
+	 * existing/new OpenShift application to should be used or not.
+	 * 
+	 * @return
+	 */
+	public boolean isUseDefaultRepoPath();
+	
 	public String setRepositoryPath(String repositoryPath);
 
 	/**

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2014 Red Hat, Inc.
+ * Copyright (c) 2011-2016 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -53,6 +53,7 @@ import com.openshift.client.cartridge.IStandaloneCartridge;
 /**
  * @author Andre Dietisheim
  * @author Xavier Coulon
+ * @author Jeff Maury
  */
 class OpenShiftApplicationWizardModel extends ObservablePojo implements IOpenShiftApplicationWizardModel {
 
@@ -270,6 +271,16 @@ class OpenShiftApplicationWizardModel extends ObservablePojo implements IOpenShi
 	@Override
 	public String getRemoteName() {
 		return getProperty(PROP_REMOTE_NAME);
+	}
+
+	@Override
+	public boolean setUseDefaultRepoPath(boolean useDefaultRepoPath) {
+		return setProperty(PROP_USE_DEFAULT_REPO_PATH, useDefaultRepoPath);
+	}
+
+	@Override
+	public boolean isUseDefaultRepoPath() {
+		return getProperty(PROP_USE_DEFAULT_REPO_PATH, true);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
@@ -290,7 +290,7 @@ public class OpenShiftApplicationWizardModel extends ObservablePojo implements I
 
 	@Override
 	public String getRepositoryPath() {
-		return getProperty(PROP_REPOSITORY_PATH);
+		return getProperty(PROP_REPOSITORY_PATH, DEFAULT_REPOSITORY_PATH);
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/OpenShiftApplicationWizardModel.java
@@ -55,7 +55,7 @@ import com.openshift.client.cartridge.IStandaloneCartridge;
  * @author Xavier Coulon
  * @author Jeff Maury
  */
-class OpenShiftApplicationWizardModel extends ObservablePojo implements IOpenShiftApplicationWizardModel {
+public class OpenShiftApplicationWizardModel extends ObservablePojo implements IOpenShiftApplicationWizardModel {
 
 	protected HashMap<String, Object> dataModel = new HashMap<>();
 

--- a/tests/org.jboss.tools.openshift.express.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.express.test/META-INF/MANIFEST.MF
@@ -17,6 +17,7 @@ Require-Bundle: org.jboss.tools.openshift.express.ui;bundle-version="[3.0.0,4.0.
  org.eclipse.core.filesystem;bundle-version="1.3.100",
  org.junit;bundle-version="[4.8.2,5.0.0)",
  org.eclipse.ui.views,
- org.eclipse.ui;bundle-version="3.106.0"
+ org.eclipse.ui;bundle-version="3.106.0",
+ org.jboss.tools.openshift.egit.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .

--- a/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/ui/wizard/application/GitCloningSettingsWizardPageModelTest.java
+++ b/tests/org.jboss.tools.openshift.express.test/src/org/jboss/tools/openshift/express/test/ui/wizard/application/GitCloningSettingsWizardPageModelTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.express.test.ui.wizard.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.jboss.tools.openshift.egit.ui.util.EGitUIUtils;
+import org.jboss.tools.openshift.express.internal.core.connection.ExpressConnection;
+import org.jboss.tools.openshift.express.internal.ui.wizard.application.GitCloningSettingsWizardPageModel;
+import org.jboss.tools.openshift.express.internal.ui.wizard.application.OpenShiftApplicationWizardModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import com.openshift.client.IDomain;
+
+/**
+ * @author Jeff Maury
+ *
+ */
+public class GitCloningSettingsWizardPageModelTest {
+
+	private GitCloningSettingsWizardPageModel model;
+	
+	@Mock
+	private ExpressConnection connection;
+	
+	@Mock
+	private IDomain domain;
+	
+	@Before
+	public void setup() {
+		OpenShiftApplicationWizardModel parentModel = new OpenShiftApplicationWizardModel(connection, domain);
+		model = new GitCloningSettingsWizardPageModel(parentModel);
+	}
+	
+	@Test
+	public void testDefaultGitRepositoryPath() {
+		assertTrue(model.isUseDefaultRepoPath());
+		assertEquals(EGitUIUtils.getEGitDefaultRepositoryPath(), model.getRepositoryPath());
+	}
+	
+    @Test
+    public void testGitRepositoryPath() {
+    	model.setUseDefaultRepoPath(false);
+        assertFalse(model.isUseDefaultRepoPath());
+        assertEquals(EGitUIUtils.getEGitDefaultRepositoryPath(), model.getRepositoryPath());
+    }
+    
+    @Test
+    public void testGitRepositoryPathAndValue() {
+        model.setUseDefaultRepoPath(false);
+        String path = new File(".").getAbsolutePath();
+        model.setRepositoryPath(path);
+        assertFalse(model.isUseDefaultRepoPath());
+        assertEquals(path, model.getRepositoryPath());
+    }
+}

--- a/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.test/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Require-Bundle: org.jboss.tools.openshift.client;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.team.core,
  org.eclipse.jgit;bundle-version="4.2.0",
  org.eclipse.wst.server.ui,
- org.eclipse.jst.server.core
+ org.eclipse.jst.server.core,
+ org.jboss.tools.openshift.egit.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.jboss.tools.openshift.test.internal.OpenShiftTestActivator
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/importapp/ImportApplicationWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/wizard/importapp/ImportApplicationWizardModelTest.java
@@ -11,14 +11,18 @@
 package org.jboss.tools.openshift.test.ui.wizard.importapp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.tools.openshift.core.connection.Connection;
+import org.jboss.tools.openshift.egit.ui.util.EGitUIUtils;
 import org.jboss.tools.openshift.internal.ui.treeitem.ObservableTreeItem;
 import org.jboss.tools.openshift.internal.ui.wizard.importapp.ImportApplicationWizardModel;
 import org.junit.Before;
@@ -96,5 +100,26 @@ public class ImportApplicationWizardModelTest {
 		assertEquals(1, results.size());
 		assertEquals(bc3, results.get(0).getModel());
 	}
-
+	
+	@Test
+	public void testDefaultGitRepositoryPath() {
+		assertTrue(model.isUseDefaultRepositoryPath());
+		assertEquals(EGitUIUtils.getEGitDefaultRepositoryPath(), model.getRepositoryPath());
+	}
+	
+    @Test
+    public void testGitRepositoryPath() {
+    	model.setUseDefaultRepositoryPath(false);
+        assertFalse(model.isUseDefaultRepositoryPath());
+        assertEquals(EGitUIUtils.getEGitDefaultRepositoryPath(), model.getRepositoryPath());
+    }
+    
+    @Test
+    public void testGitRepositoryPathAndValue() {
+        model.setUseDefaultRepositoryPath(false);
+        String path = new File(".").getAbsolutePath();
+        model.setRepositoryPath(path);
+        assertFalse(model.isUseDefaultRepositoryPath());
+        assertEquals(path, model.getRepositoryPath());
+    }
 }


### PR DESCRIPTION
- Use common dialog settings to store the Git repo value

Signed-off-by: Jeff MAURY <jmaury@redhat.com>