### PR TITLE
JBIDE-22446 since...

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -29,6 +29,28 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-no-snapshots</id>
+						<configuration>
+							<rules>
+								<noSnapshotsAllowed implementation="org.jboss.tools.releng.NoSnapshotsAllowed">
+									<!-- include AM3, Final, and GA when failing if SNAPSHOTs present -->
+									<buildAliasSearch>AM3|Final|GA</buildAliasSearch>
+									<!-- properties to include when searching for SNAPSHOT versions, eg., openshift-restclient-java.version -->
+									<includePattern>.*</includePattern>
+									<!-- properties to exclude when searching for SNAPSHOT versions, eg.,  jbossTychoPluginsVersion|jbosstoolsRelengPublishVersion|TARGET_PLATFORM_VERSION_MAXIMUM -->
+									<excludePattern>openshift-restclient-java.version|BUILD_ALIAS|p2StatsUrl|jbossTychoPluginsVersion|jbosstoolsRelengPublishVersion|TARGET_PLATFORM_VERSION_MAXIMUM|tpc.version|central.tpc.version|discovery.tpc.version|parsedVersion.qualifier|parsedVersion.osgiVersion</excludePattern>
+								</noSnapshotsAllowed>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>2.7</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
@@ -58,19 +80,19 @@
 							<version>${openshift-restclient-java.version}</version>
 						</artifactItem>
 						<artifactItem>
-						  <groupId>com.squareup.okhttp3</groupId>
-						  <artifactId>okhttp</artifactId>
-						  <version>${ok-http.version}</version>
+							<groupId>com.squareup.okhttp3</groupId>
+							<artifactId>okhttp</artifactId>
+							<version>${ok-http.version}</version>
 						</artifactItem>
 						<artifactItem>
-						    <groupId>com.squareup.okio</groupId>
-						    <artifactId>okio</artifactId>
-						    <version>${ok-io.version}</version>
+							<groupId>com.squareup.okio</groupId>
+							<artifactId>okio</artifactId>
+							<version>${ok-io.version}</version>
 						</artifactItem>
 						<artifactItem>
-						  <groupId>com.squareup.okhttp3</groupId>
-						  <artifactId>okhttp-ws</artifactId>
-						  <version>${ok-http-ws.version}</version>
+							<groupId>com.squareup.okhttp3</groupId>
+							<artifactId>okhttp-ws</artifactId>
+							<version>${ok-http-ws.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.jboss</groupId>
@@ -98,14 +120,14 @@
 							<version>${commons-compress.version}</version>
 						</artifactItem>
 						<artifactItem>
-						    <groupId>commons-codec</groupId>
-						    <artifactId>commons-codec</artifactId>
-						    <version>${commons-codec.version}</version>
+							<groupId>commons-codec</groupId>
+							<artifactId>commons-codec</artifactId>
+							<version>${commons-codec.version}</version>
 						</artifactItem>
 						<artifactItem>
-						    <groupId>commons-lang</groupId>
-						    <artifactId>commons-lang</artifactId>
-						    <version>${commons-lang.version}</version>
+							<groupId>commons-lang</groupId>
+							<artifactId>commons-lang</artifactId>
+							<version>${commons-lang.version}</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>commons-io</groupId>
@@ -172,19 +194,19 @@
 			<version>${openshift-restclient-java.version}</version>
 		</dependency>
 		<dependency>
-		  <groupId>com.squareup.okhttp3</groupId>
-		  <artifactId>okhttp</artifactId>
-		  <version>${ok-http.version}</version>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${ok-http.version}</version>
 		</dependency>
 		<dependency>
-		  <groupId>com.squareup.okhttp3</groupId>
-		  <artifactId>okhttp-ws</artifactId>
-		  <version>${ok-http-ws.version}</version>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp-ws</artifactId>
+			<version>${ok-http-ws.version}</version>
 		</dependency>
 		<dependency>
-		    <groupId>com.squareup.okio</groupId>
-		    <artifactId>okio</artifactId>
-		    <version>${ok-io.version}</version>
+			<groupId>com.squareup.okio</groupId>
+			<artifactId>okio</artifactId>
+			<version>${ok-io.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss</groupId>
@@ -206,15 +228,15 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>${slf4j-log4j12.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-        </dependency>
 		<dependency>
-		    <groupId>commons-lang</groupId>
-		    <artifactId>commons-lang</artifactId>
-		    <version>${commons-lang.version}</version>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>${commons-codec.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>${commons-lang.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
JBIDE-22446 since maven-enforcer-plugin:enforce-no-snapshots is now enabled for all projects, this will allow you to SKIP the failure using excludePattern with openshift-restclient-java.version; could also skip by setting buildAliasSearch = Final|GA or fail = false