### PR TITLE
jbide-22471: connection stays "Loading" after the token provided

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/connection/Connection.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/connection/Connection.java
@@ -365,7 +365,7 @@ public class Connection extends ObservablePojo implements IRefreshable, IOpenShi
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((client  == null) ? 0 : client.getBaseURL().hashCode());
+		result = prime * result + ((client  == null) ? 0 : client.getBaseURL().toString().hashCode());
 		if(client != null) {
 			result = prime * result + ((client.getAuthorizationContext().getUserName() == null) ? 0 : client.getAuthorizationContext().getUserName().hashCode());
 		}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/AbstractOpenshiftUIElement.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/AbstractOpenshiftUIElement.java
@@ -68,7 +68,11 @@ abstract class AbstractOpenshiftUIElement<R, P extends AbstractOpenshiftUIElemen
 	
 	@Override
 	public int hashCode() {
-		return wrapped.hashCode();
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((parent == null) ? 0 : parent.hashCode());
+		result = prime * result + wrapped.hashCode();
+		return result;
 	}
 	
 	synchronized void updateWith(R r) {


### PR DESCRIPTION
Shortly about the bug:
All OS connections in OS Explorer view a stored in CustomHashtable elementMap (see org.eclipse.jface.viewers.StructuredViewer class). We add connection there when the view is being opened (for example on eclipse startup). At that moment connection to the remote server is not established yet. And, say, hash1 is generated when adding to map. After we provide the token and want to expand the connection UI element, the real connection to the remote server almost always has already bee established and ANOTHER hash2 was generated. That's why connection wasn't just found in the view.
This bug is more about the way how java counts hashCode for URL objects. The thing is that it tries to resolve ip address and connect to the URL. You can find lots of posts complaining on that theme in the internet. Most relative are:
1) http://bugs.java.com/view_bug.do?bug_id=6810437
2) http://brian.pontarelli.com/2006/12/05/mr-gosling-why-did-you-make-url-equals-suck/

So counting hashCode of String representation of URL and not of the URL object really solves the problem.