### PR TITLE
JBIDE-22992 JBIDE-22913 use default...

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -33,6 +33,15 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm</format>
+					<timestampProvider>default</timestampProvider>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>2.7</version><!--$NO-MVN-MAN-VER$-->
@@ -227,4 +236,27 @@
 			<version>${commons-io.version}</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>hudson</id>
+			<activation>
+				<property>
+					<name>BUILD_NUMBER</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-packaging-plugin</artifactId>
+						<version>${tychoVersion}</version>
+						<configuration>
+							<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm'-B${BUILD_NUMBER}'</format>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
JBIDE-22992 JBIDE-22913 use default timestampProvider with BUILD_ALIAS-vyyyyMMdd-HHmm instead of jgit timestampProvider, so that this plugin is ALWAYS rebuilt; will ensure that when SNAPSHOT deps are included in the plugin, we always rebuild it