### PR TITLE
bump for openshift-restclient-java-5.0.0-RC1

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/.classpath
+++ b/plugins/org.jboss.tools.openshift.client/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-5.0.0-SNAPSHOT.jar" sourcepath="lib/openshift-restclient-java-5.0.0-SNAPSHOT-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-5.0.0-RC1.jar" sourcepath="lib/openshift-restclient-java-5.0.0-RC1-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okhttp-3.3.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okhttp-ws-3.3.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okio-1.8.0.jar"/>

--- a/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Bundle-ClassPath: lib/openshift-restclient-java-5.0.0-SNAPSHOT.jar,
+Bundle-ClassPath: lib/openshift-restclient-java-5.0.0-RC1.jar,
  lib/okhttp-3.3.1.jar,
  lib/okhttp-ws-3.3.1.jar,
  lib/okio-1.8.0.jar,

--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -16,7 +16,7 @@
 			https://repository.jboss.org/nexus/content/repositories/snapshots/com/openshift/openshift-restclient-java/5.0.0-SNAPSHOT/
 			https://repository.jboss.org/nexus/content/repositories/snapshots/com/openshift/openshift-restclient-java/5.0.0-SNAPSHOT/openshift-restclient-java-5.0.0-20160809.161416-8.jar
 		-->
-		<openshift-restclient-java.version>5.0.0-SNAPSHOT</openshift-restclient-java.version>
+		<openshift-restclient-java.version>5.0.0-RC1</openshift-restclient-java.version>
 		<ok-http.version>3.3.1</ok-http.version>
 		<ok-http-ws.version>3.3.1</ok-http-ws.version>
 		<ok-io.version>1.8.0</ok-io.version>


### PR DESCRIPTION
depends on https://github.com/openshift/openshift-restclient-java/pull/202 being deployed

cc @fbricon 