### PR TITLE
JBIDE-22640 - after failure to init editor, editor is unusable.

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorSection.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorSection.java
@@ -551,6 +551,7 @@ public class OpenShiftServerEditorSection extends ServerEditorSection {
 													getConnectionErrorMessage(OpenShiftServerUtils.getConnectionURL(server), server)),
 											IStatus.ERROR)
 										.open());
+								model.setInitializing(false);
 								return false;
 							} else {
 								return true;


### PR DESCRIPTION
After a failure to load,  variable "initializing" is still true, so changes to editor do not take effect. 