### PR TITLE
[JBIDE-22916] - Deploy Docker Wizard: Deploying a docker image from OpenShift explorer does not fetch metadata

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/ImageStreamTagMetaData.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/ImageStreamTagMetaData.java
@@ -37,7 +37,7 @@ public class ImageStreamTagMetaData implements IDockerImageMetadata {
 	public ImageStreamTagMetaData(final String json) {
 		this.node = ModelNode.fromJSONString(json);
 		final ModelNode config = this.node.get(ROOT).get(CONTAINER_CONFIG);
-		if(ModelType.OBJECT == config.getType() && config.keys().size() > 0) {
+		if(ModelType.OBJECT == config.getType() && config.has(EXPOSED_PORT)) {
 			 CONFIG_ROOT = (String [])ArrayUtils.add(ROOT, CONTAINER_CONFIG);
 		}else {
 			CONFIG_ROOT = (String [])ArrayUtils.add(ROOT, CONFIG);


### PR DESCRIPTION
- Change decision between Config and ContainerConfig

Signed-off-by: Jeff MAURY <jmaury@redhat.com>