### PR TITLE
[JBIDE-23030] fix scaling pods starting from a service

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/.classpath
+++ b/plugins/org.jboss.tools.openshift.client/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-5.0.0-RC1.jar" sourcepath="lib/openshift-restclient-java-5.0.0-RC1-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okhttp-3.3.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okhttp-ws-3.3.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/okio-1.8.0.jar"/>
@@ -14,6 +13,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/commons-codec-1.6.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-lang-2.6.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-5.1.0-SNAPSHOT.jar" sourcepath="lib/openshift-restclient-java-5.1.0-SNAPSHOT-sources.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Bundle-ClassPath: lib/openshift-restclient-java-5.0.0-RC1.jar,
+Bundle-ClassPath: lib/openshift-restclient-java-5.1.0-SNAPSHOT.jar,
  lib/okhttp-3.3.1.jar,
  lib/okhttp-ws-3.3.1.jar,
  lib/okio-1.8.0.jar,
@@ -20,8 +20,13 @@ Bundle-ClassPath: lib/openshift-restclient-java-5.0.0-RC1.jar,
  lib/commons-io-2.1.jar,
  .
 Export-Package: com.openshift.internal.restclient;x-friends:="org.jboss.tools.openshift.test",
+ com.openshift.internal.restclient.model,
  com.openshift.internal.restclient.okhttp,
  com.openshift.restclient,
+ com.openshift.restclient.api,
+ com.openshift.restclient.api.capabilities,
+ com.openshift.restclient.api.models,
+ com.openshift.restclient.apis.autoscaling.models,
  com.openshift.restclient.authorization,
  com.openshift.restclient.capability,
  com.openshift.restclient.capability.resources,

--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -16,7 +16,7 @@
 			https://repository.jboss.org/nexus/content/repositories/snapshots/com/openshift/openshift-restclient-java/5.0.0-SNAPSHOT/
 			https://repository.jboss.org/nexus/content/repositories/snapshots/com/openshift/openshift-restclient-java/5.0.0-SNAPSHOT/openshift-restclient-java-5.0.0-20160809.161416-8.jar
 		-->
-		<openshift-restclient-java.version>5.0.0-RC1</openshift-restclient-java.version>
+		<openshift-restclient-java.version>5.1.0-SNAPSHOT</openshift-restclient-java.version>
 		<ok-http.version>3.3.1</ok-http.version>
 		<ok-http-ws.version>3.3.1</ok-http-ws.version>
 		<ok-io.version>1.8.0</ok-io.version>


### PR DESCRIPTION
This PR fixes pod scaling from the service by:

* deferring the act of scaling to the server endpoint (dc#scale, or rc#scale)

Note:  
* Testing against cdk 1.2.0 showed issue with scaling a dc that did not have a config change trigger.  Possibly reported as: https://bugzilla.redhat.com/show_bug.cgi?id=1369314
* Change is dependent upon #openshift/openshift-restclient-java/pull/205
* Change assumes dependency on openshift-restclient-java-5.1.0-SNAPSHOT

cc @fbricon @adietish 
