### PR TITLE
[JBIDE-22915] - Deploy Docker Image: Replication controller is not created for some images

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/DeployImageJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/DeployImageJob.java
@@ -248,7 +248,7 @@ public class DeployImageJob extends AbstractDelegatingMonitorJob
 			//check if cluster will be able to pull image
 			if(is == null && isImageVisibleByOpenShift(project, imageUri)){
 				is = factory.stub(ResourceKind.IMAGE_STREAM, name, project.getName());
-				is.setDockerImageRepository(imageUri.getUriWithoutTag());
+				is.addTag(imageUri.getTag(), "DockerImage", imageUri.toString());
 			}
 		}
 		if(is == null) {


### PR DESCRIPTION
- ImageStream is created with tag to mimic oc behavior

Signed-off-by: Jeff MAURY jmaury@redhat.com
