### PR TITLE
JBIDE-23039 - an interactive terminal solution for all three operating major OS types

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.cdk.server/META-INF/MANIFEST.MF
@@ -38,7 +38,8 @@ Require-Bundle: org.jboss.tools.usage;bundle-version="2.1.0",
  org.jboss.tools.openshift.ui;bundle-version="3.1.0",
  org.eclipse.linuxtools.docker.core;bundle-version="2.0.0",
  org.eclipse.ui.navigator;bundle-version="3.4.0",
- org.jboss.tools.openshift.client;bundle-version="3.1.0"
+ org.jboss.tools.openshift.client;bundle-version="3.1.0",
+ org.eclipse.cdt.core.native;bundle-version="5.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.jboss.tools.openshift.cdk.server.core.internal;x-friends:="org.jboss.tools.openshift.cdk.server.test",

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDKLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDKLaunchController.java
@@ -33,6 +33,8 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.debug.core.model.IStreamsProxy;
+import org.eclipse.debug.core.model.RuntimeProcess;
 import org.eclipse.debug.internal.core.LaunchManager;
 import org.eclipse.tm.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.tm.terminal.view.core.interfaces.ITerminalService;
@@ -223,8 +225,13 @@ public class CDKLaunchController extends AbstractSubsystemController implements 
 		Map<String, String> processAttributes = new HashMap<String, String>();
 		String vagrantcmdloc = CDKConstantUtility.getVagrantLocation(s);
 		String progName = new Path(vagrantcmdloc).lastSegment();
+		launch.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, "false");
 		processAttributes.put(IProcess.ATTR_PROCESS_TYPE, progName);
-		IProcess process = DebugPlugin.newProcess(launch, p, vagrantcmdloc, processAttributes);
+		IProcess process = new RuntimeProcess(launch, p, vagrantcmdloc, processAttributes) {
+			protected IStreamsProxy createStreamsProxy() {
+				return null;
+			}
+		};
 		launch.addProcess(process);
 		return process;
 	}

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDKLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDKLaunchController.java
@@ -214,11 +214,11 @@ public class CDKLaunchController extends AbstractSubsystemController implements 
 		linkTerminal(p);
 		
 		IDebugEventSetListener debug = getDebugListener(new IProcess[]{process}, launch);
+		DebugPlugin.getDefault().addDebugEventListener(debug);
 		if( beh != null ) {
 			beh.putSharedData(AbstractStartJavaServerLaunchDelegate.PROCESS, process);
 			beh.putSharedData(AbstractStartJavaServerLaunchDelegate.DEBUG_LISTENER, debug);
 		}
-		DebugPlugin.getDefault().addDebugEventListener(debug);
 	}
 	
 	private IProcess addProcessToLaunch(Process p, ILaunch launch, IServer s) {
@@ -243,7 +243,7 @@ public class CDKLaunchController extends AbstractSubsystemController implements 
 		Map<String, Object> properties = new HashMap<>();
 		properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID, "org.eclipse.tm.terminal.connector.streams.launcher.streams");
 		properties.put(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID, "org.eclipse.tm.terminal.connector.streams.StreamsConnector");
-		properties.put(ITerminalsConnectorConstants.PROP_TITLE, "Test");
+		properties.put(ITerminalsConnectorConstants.PROP_TITLE, getServer().getName());
 		properties.put(ITerminalsConnectorConstants.PROP_LOCAL_ECHO, false);
 		properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, true);
 		properties.put(ITerminalsConnectorConstants.PROP_STREAMS_STDIN, out);

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDKShutdownController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDKShutdownController.java
@@ -96,7 +96,13 @@ public class CDKShutdownController extends AbstractSubsystemController implement
 		final IProcess[] processes = launch2.getProcesses();
 		
 		if( processes != null && processes.length >= 1 && processes[0] != null ) {
-			DebugPlugin.getDefault().addDebugEventListener(getDebugListener(processes));
+			IDebugEventSetListener l = getDebugListener(processes);
+			DebugPlugin dp = DebugPlugin.getDefault();
+			if( !processes[0].isTerminated())
+				dp.addDebugEventListener(l);
+			else {
+				processTerminated(getServer(), processes[0], null);
+			}
 		}
 
 	}
@@ -141,6 +147,7 @@ public class CDKShutdownController extends AbstractSubsystemController implement
 				}	
 			}
 		}.start();
-		DebugPlugin.getDefault().removeDebugEventListener(listener);
+		if( listener != null ) 
+			DebugPlugin.getDefault().removeDebugEventListener(listener);
 	}
 }

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/ServiceManagerEnvironment.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/ServiceManagerEnvironment.java
@@ -108,7 +108,7 @@ public class ServiceManagerEnvironment {
 		env.put("VAGRANT_NO_COLOR", "1");
     	String vagrantcmdloc = CDKConstantUtility.getVagrantLocation(server);
 	    try {
-	    	String[] lines = VagrantLaunchUtility.call(vagrantcmdloc, args,  CDKServerUtility.getWorkingDirectory(server), env);
+	    	String[] lines = VagrantLaunchUtility.callMachineReadable(vagrantcmdloc, args,  CDKServerUtility.getWorkingDirectory(server), env);
 	    	return parseLines(lines);
 		} catch( URISyntaxException urise) {
 			CDKCoreActivator.pluginLog().logError("Environment variable DOCKER_HOST is not a valid uri:  " + env.get("DOCKER_HOST"), urise);


### PR DESCRIPTION
Test patch to see if cdt.native works to fix the issue for windows and mac. 

This patch isn't suitable for merging and needs cleaning up. It's actually the same patch as before with just 3 or 4 lines changed, but since I've already reverted the original, the patch seems longer. 