### PR TITLE
[JBIDE-23486] - Build: DeployImageJobtest#testStubImageStreamWhereOneDoesNotExistAndImageIsPublic is failing

### DIFF
--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/DeployImageJobTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/DeployImageJobTest.java
@@ -216,7 +216,8 @@ public class DeployImageJobTest {
 		assertNotNull("Exp. an IS to be returned", is);
 		assertEquals(RESOURCE_NAME, is.getName());
 		assertEquals(project.getName(), is.getNamespace());
-		assertEquals(DOCKER_TAG, is.getDockerImageRepository());
+		assertEquals(1, is.getTags().size());
+		assertEquals(DOCKER_TAG.toString(), is.getTags().iterator().next().getFrom().getName());
 	}
 
 	@Test


### PR DESCRIPTION
- Fix faling test

Signed-off-by: Jeff MAURY <jmaury@redhat.com>