### PR TITLE
JBIDE-23421: Terminating Server Adapter running in debug mode does not terminate Node.js debug session

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/debug/DebugSessionTracker.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/debug/DebugSessionTracker.java
@@ -11,15 +11,18 @@
 package org.jboss.tools.openshift.core.debug;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.wst.server.core.IServer;
 
 /**
  * @author "Ilya Buziuk (ibuziuk)"
  */
 public interface DebugSessionTracker {
-	
+
 	void startDebugSession(IServer server, int port) throws CoreException;
-	
+
+	void stopDebugSession(IServer server) throws DebugException;
+
 	boolean isDebugSessionAlive(IServer server);
 
 }

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/debug/DebugTrackerContributionEvaluation.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/debug/DebugTrackerContributionEvaluation.java
@@ -25,9 +25,9 @@ import org.jboss.tools.openshift.internal.core.OpenShiftCoreActivator;
  * @author "Ilya Buziuk (ibuziuk)"
  */
 public class DebugTrackerContributionEvaluation {
-	
+
 	private static final String ID = "org.jboss.tools.openshift.core.debugSessionTracker"; //$NON-NLS-1$
-	
+
 	public static void startDebugSession(IServer server, int port) throws CoreException {
 		Collection<DebugSessionTracker> trackers = getTrackers();
 		trackers.forEach(tracker -> {
@@ -44,18 +44,38 @@ public class DebugTrackerContributionEvaluation {
 					OpenShiftCoreActivator.logError(e.getMessage(), e);
 				}
 			});
-			
+
 		});
 	}
-	
+
+	public static void stopDebugSession(IServer server) {
+		Collection<DebugSessionTracker> trackers = getTrackers();
+		trackers.forEach(tracker -> {
+
+			SafeRunner.run(new ISafeRunnable() {
+
+				@Override
+				public void run() throws Exception {
+					tracker.stopDebugSession(server);
+				}
+
+				@Override
+				public void handleException(Throwable e) {
+					OpenShiftCoreActivator.logError(e.getMessage(), e);
+				}
+			});
+
+		});
+	}
+
 	public static boolean isDebugSessionAlive(IServer server) {
 		Collection<DebugSessionTracker> trackers = getTrackers();
-		
+
 		// There are no debug session tracker extensions
 		if (trackers.isEmpty()) {
 			return false;
 		}
-		
+
 		for (DebugSessionTracker tracker : trackers) {
 			if (!tracker.isDebugSessionAlive(server)) {
 				return false;
@@ -63,7 +83,7 @@ public class DebugTrackerContributionEvaluation {
 		}
 		return true;
 	}
-	
+
 	private static Collection<DebugSessionTracker> getTrackers() {
 		IConfigurationElement[] elements = getConfigurationElements();
 		Collection<DebugSessionTracker> trackers = new ArrayList<>();
@@ -83,5 +103,5 @@ public class DebugTrackerContributionEvaluation {
 	private static IConfigurationElement[] getConfigurationElements() {
 		return Platform.getExtensionRegistry().getConfigurationElementsFor(ID);
 	}
-	
+
 }

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftShutdownController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftShutdownController.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.Status;
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.AbstractSubsystemController;
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.IServerShutdownController;
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.ISubsystemController;
+import org.jboss.tools.openshift.core.debug.DebugTrackerContributionEvaluation;
 import org.jboss.tools.openshift.core.server.OpenShiftServerBehaviour;
 import org.jboss.tools.openshift.internal.core.OpenShiftCoreActivator;
 import org.jboss.tools.openshift.internal.core.server.debug.OpenShiftDebugUtils;
@@ -39,6 +40,7 @@ public class OpenShiftShutdownController extends AbstractSubsystemController
 		behavior.setServerStopping();
 		try {
 			OpenShiftDebugUtils.get().terminateRemoteDebugger(behavior.getServer());
+			DebugTrackerContributionEvaluation.stopDebugSession(behavior.getServer());
 			behavior.setServerStopped();
 		} catch(CoreException ce) {
 			OpenShiftCoreActivator.getDefault().getLog().log(

--- a/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/internal/js/storage/SessionStorage.java
+++ b/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/internal/js/storage/SessionStorage.java
@@ -11,19 +11,20 @@
 package org.jboss.tools.openshift.internal.js.storage;
 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.openshift.core.server.behavior.OpenShiftPublishController;
 
 /**
- * Contains {@link Set} of {@link IServer} with Node.js Debugger attached.
- * {@link OpenShiftPublishController} checks if {@link IServer} is tracked by
- * {@link SessionStorage} in order to verify if 'rsync' is required. If
- * there is a Node.js debug session associated with {@link IServer} 'rsync' must
- * not be performed due to the fact that 'rsync' will cause Node.js app restart
- * and debug state will be lost
+ * Contains mapping between {@link IServer} with Node.js Debugger attached and it's
+ * {@link ILaunchConfiguration}. {@link OpenShiftPublishController}
+ * checks if {@link IServer} is tracked by {@link SessionStorage} in order to
+ * verify if 'rsync' is required. If there is a Node.js debug session associated
+ * with {@link IServer} 'rsync' must not be performed due to the fact that
+ * 'rsync' will cause Node.js app restart and debug state will be lost
  * 
  * @author "Ilya Buziuk (ibuziuk)"
  */
@@ -32,9 +33,9 @@ public final class SessionStorage {
 	private SessionStorage() {
 	}
 
-	private static final Set<IServer> INSTANCE = Collections.synchronizedSet(new HashSet<>());
+	private static final Map<IServer, ILaunchConfiguration> INSTANCE = Collections.synchronizedMap(new HashMap<>());
 
-	public static Set<IServer> get() {
+	public static Map<IServer, ILaunchConfiguration> get() {
 		return INSTANCE;
 	}
 

--- a/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/debug/NodeDebugSessionTracker.java
+++ b/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/debug/NodeDebugSessionTracker.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.openshift.js.debug;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.openshift.core.debug.DebugSessionTracker;
 import org.jboss.tools.openshift.internal.js.storage.SessionStorage;
@@ -30,8 +31,16 @@ public class NodeDebugSessionTracker implements DebugSessionTracker {
 	}
 
 	@Override
+	public void stopDebugSession(IServer server) throws DebugException {
+		if (NodeDebuggerUtil.isNodeJsProject(server)) {
+			NodeDebugLauncher.terminate(server);
+		}
+
+	}
+
+	@Override
 	public boolean isDebugSessionAlive(IServer server) {
-		return SessionStorage.get().contains(server);
+		return SessionStorage.get().containsKey(server);
 	}
 
 }

--- a/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/launcher/NodeDebugLauncher.java
+++ b/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/launcher/NodeDebugLauncher.java
@@ -12,7 +12,10 @@ package org.jboss.tools.openshift.js.launcher;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
@@ -72,9 +75,23 @@ public final class NodeDebugLauncher {
 			public void run() {
 				DebugUITools.launch(v8debugLaunch, ILaunchManager.DEBUG_MODE);
 				// Debug session has just started - adding server to tracker
-				SessionStorage.get().add(server);
+				SessionStorage.get().put(server, v8debugLaunch);
 			}
 		});
+	}
+	
+
+	public static void terminate(IServer server) throws DebugException {
+		ILaunchConfiguration v8debugLaunch = SessionStorage.get().get(server);
+		if (v8debugLaunch != null) {
+			ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
+			ILaunch[] runningLaunches = manager.getLaunches();
+			for (ILaunch launch : runningLaunches) {
+				if (v8debugLaunch.equals(launch.getLaunchConfiguration())) {
+					launch.terminate();
+				}
+			}
+		}
 	}
 
 	private static String getPodPath(IServer server) throws CoreException {


### PR DESCRIPTION
# Pull Request Checklist
## General
QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>