### PR TITLE
[JBIDE-23514] - Server adapter: adapters for non-java app should not have a JMX child (double clicking it causes error)

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -520,6 +520,14 @@ public class OpenShiftServerUtils {
 		}
 		return attribute;
 	}
-
 	
+    public static boolean isJavaProject(IServerAttributes server) {
+        IProject p = getDeployProject(server);
+        try {
+            return p != null && p.isAccessible() && p.hasNature(JavaCore.NATURE_ID);
+        } catch (CoreException e) {
+            OpenShiftCoreActivator.pluginLog().logError(e);
+        }
+        return false;
+    }
 }

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -23,6 +23,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenshiftJMXConnectionProvider.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenshiftJMXConnectionProvider.java
@@ -28,10 +28,6 @@ import com.openshift.restclient.model.IService;
 public class OpenshiftJMXConnectionProvider extends AbstractJBossJMXConnectionProvider {
 	public static final String PROVIDER_ID = "org.jboss.tools.openshift.core.server.OpenshiftJMXConnection"; //$NON-NLS-1$
 
-	public OpenshiftJMXConnectionProvider() {
-		super();
-		System.out.println("Noop constructor");
-	}
 	@Override 
 	protected boolean getConnectionPersistenceBehavior() {
 		return ON_START;
@@ -39,7 +35,8 @@ public class OpenshiftJMXConnectionProvider extends AbstractJBossJMXConnectionPr
 	
 	@Override
 	protected boolean belongsHere(IServer server) {
-		if( server != null && server.getServerType().getId().equals(OpenShiftServer.SERVER_TYPE_ID)) {
+		if( server != null && server.getServerType().getId().equals(OpenShiftServer.SERVER_TYPE_ID) &&
+		        OpenShiftServerUtils.isJavaProject(server)) {
 			return true;
 		}
 		return false;
@@ -89,7 +86,6 @@ public class OpenshiftJMXConnectionProvider extends AbstractJBossJMXConnectionPr
 
 	@Override
 	public String getName(IConnectionWrapper wrapper) {
-		// TODO Auto-generated method stub
 		return ((JolokiaConnectionWrapper)wrapper).getId();
 	}
 }

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
@@ -27,7 +27,6 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IDebugTarget;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.debug.core.IJavaHotCodeReplaceListener;
 import org.eclipse.jdt.launching.SocketUtil;
@@ -184,7 +183,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 				}
 				int localPort = mapPortForwarding(debuggingContext, monitor);
 				
-				if(isJavaProject(server)) {
+				if(OpenShiftServerUtils.isJavaProject(server)) {
 					ILaunch debuggerLaunch = attachRemoteDebugger(server, localPort, monitor);
 					if( debuggerLaunch != null ) {
 						overrideHotcodeReplace(server, debuggerLaunch);
@@ -252,16 +251,6 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		// Do Nothing
 	}
 	
-	private boolean isJavaProject(IServer server) {
-		IProject p = OpenShiftServerUtils.getDeployProject(server);
-		try {
-			return p != null && p.isAccessible() && p.hasNature(JavaCore.NATURE_ID);
-		} catch (CoreException e) {
-			OpenShiftCoreActivator.pluginLog().logError(e);
-		}
-		return false;
-	}
-
 	/**
 	 * Unmap the port forwarding. 
 	 * @throws CoreException 

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/OpenShiftServerUtilsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/OpenShiftServerUtilsTest.java
@@ -26,6 +26,7 @@ import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.Map;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServerAttributes;
 import org.eclipse.wst.server.core.IServerWorkingCopy;
@@ -237,5 +238,12 @@ public class OpenShiftServerUtilsTest {
 		} catch(CoreException e) {
 			assertThat(e.getMessage().contains("not find deployment config"));
 		}
+	}
+	
+	@Test
+	public void should_not_show_jmx_on_non_java_project() throws CoreException {
+	    IProject eclipseProject = ResourceMocks.createEclipseProject("project1");
+	    doReturn(eclipseProject.getName()).when(server).getAttribute(eq(OpenShiftServerUtils.ATTR_DEPLOYPROJECT), anyString());
+	    assertThat(OpenShiftServerUtils.isJavaProject(server)).isFalse();
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>