### PR TITLE
(itests, test-framework) Move Project creation logic from requirement to separate class.

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftProjectRequirement.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftProjectRequirement.java
@@ -11,7 +11,6 @@
 package org.jboss.tools.openshift.reddeer.requirement;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -20,35 +19,30 @@ import java.lang.annotation.Target;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.osgi.util.NLS;
-import org.jboss.reddeer.common.logging.Logger;
-import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.junit.requirement.Requirement;
 import org.jboss.tools.openshift.core.connection.Connection;
-import org.jboss.tools.openshift.reddeer.condition.OpenShiftProjectExists;
 import org.jboss.tools.openshift.reddeer.requirement.OpenShiftProjectRequirement.RequiredProject;
 import org.jboss.tools.openshift.reddeer.utils.DatastoreOS3;
 import org.jboss.tools.openshift.reddeer.utils.TestUtils;
+import org.jboss.tools.openshift.reddeer.utils.v3.OpenShift3NativeProjectUtils;
 
-import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IProject;
-import com.openshift.restclient.model.project.IProjectRequest;
 
 /**
- * A requirement that makes sure a given project exists. If it doesnt it will get created
+ * A requirement that makes sure a given project exists. If it doesnt it will
+ * get created
  * 
  * @author adietish@redhat.com
  */
 public class OpenShiftProjectRequirement implements Requirement<RequiredProject> {
-
-	private final static Logger LOGGER = new Logger(OpenShiftProjectRequirement.class);
 
 	private RequiredProject projectSpec;
 
 	private IProject project;
 
 	@Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
-    public @interface RequiredProject {
+	@Target(ElementType.TYPE)
+	public @interface RequiredProject {
 		/**
 		 * the connection to use when connecting. If nothing is provided
 		 * {@link DatastoreOS3#SERVER} and {@link DatastoreOS33#USERNAME} are
@@ -61,18 +55,20 @@ public class OpenShiftProjectRequirement implements Requirement<RequiredProject>
 		 * {@link OpenShiftResources#TEST_PROJECT} is used
 		 */
 		String name() default StringUtils.EMPTY;
+
 		/**
 		 * the project display name to use. If nothing is provided
 		 * {@link #name()} is used
 		 */
 		String displayName() default StringUtils.EMPTY;
+
 		/**
 		 * the project description to use. If nothing is provided
 		 * {@link #name()} is used
 		 */
 		String description() default StringUtils.EMPTY;
 	}
-	
+
 	@Override
 	public boolean canFulfill() {
 		return true;
@@ -84,43 +80,8 @@ public class OpenShiftProjectRequirement implements Requirement<RequiredProject>
 		Connection connection = ConnectionUtils.getConnectionOrDefault(projectSpec.connectionURL());
 		assertNotNull(NLS.bind("No connection {0} exists", projectSpec.connectionURL()), connection);
 
-		this.project = getOrCreateProject(projectName, connection);
-	}
-
-
-	private IProject getOrCreateProject(String name, Connection connection) {
-		IProject project = OpenShiftResourceUtils.getProject(name, connection);
-		if (project == null) {
-			LOGGER.debug(NLS.bind("Project {0} doesnt exist yet in {1}, creating it.", name, connection.getHost()));
-			project = createProject(name, projectSpec, connection);
-//			new WaitUntil(
-//					new ProjectExists(name, connection),
-//					TimePeriod.LONG);
-			/**
-			 * WORKAROUND: explorer wont get notified of the the new project and
-			 * therefore wont display it unless a manual refresh is done on the connection.
-			 * https://issues.jboss.org/browse/JBIDE-23513 remove this wait once
-			 * WatchManager is watching projects and notifies the ui.
-			 * 
-			 * @see WatchManager#KINDS
-			 */
-			new WaitUntil(new OpenShiftProjectExists(name, connection));
-		}
-		return project;
-	}
-
-	private IProject createProject(String name, RequiredProject projectSpec, Connection connection) {
-		assertTrue(StringUtils.isNotBlank(name));
-		assertNotNull(projectSpec);
-		assertNotNull(connection);
-
-		IProjectRequest request = connection.getResourceFactory().stub(ResourceKind.PROJECT_REQUEST, name);
-		request.setDisplayName(StringUtils.isEmpty(projectSpec.displayName())? 
-				name : projectSpec.displayName());
-		request.setDescription(StringUtils.isEmpty(projectSpec.description())? 
-				name : projectSpec.description());
-
-		return (IProject) connection.createResource(request);
+		this.project = OpenShift3NativeProjectUtils.getOrCreateProject(projectName, projectSpec.displayName(),
+				projectSpec.description(), connection);
 	}
 
 	@Override
@@ -130,7 +91,7 @@ public class OpenShiftProjectRequirement implements Requirement<RequiredProject>
 
 	@Override
 	public void cleanUp() {
-	}	
+	}
 
 	public IProject getProject() {
 		return project;

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftServiceRequirement.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftServiceRequirement.java
@@ -50,6 +50,7 @@ import org.jboss.tools.openshift.reddeer.enums.ResourceState;
 import org.jboss.tools.openshift.reddeer.requirement.OpenShiftServiceRequirement.RequiredService;
 import org.jboss.tools.openshift.reddeer.utils.DatastoreOS3;
 import org.jboss.tools.openshift.reddeer.utils.TestUtils;
+import org.jboss.tools.openshift.reddeer.utils.v3.OpenShift3NativeResourceUtils;
 import org.jboss.tools.openshift.reddeer.view.OpenShiftExplorerView;
 import org.jboss.tools.openshift.reddeer.view.resources.OpenShift3Connection;
 import org.jboss.tools.openshift.reddeer.view.resources.OpenShiftProject;
@@ -100,7 +101,7 @@ public class OpenShiftServiceRequirement implements Requirement<RequiredService>
 		assertNotNull(NLS.bind("No connection for {0} exists", serviceSpec.connectionURL()), connection);
 		final String projectName = TestUtils.getValueOrDefault(serviceSpec.project(), DatastoreOS3.TEST_PROJECT);
 		assertTrue(NLS.bind("No project {0} exists on server {1}", projectName, connection.getHost()), 
-				OpenShiftResourceUtils.hasProject(projectName, connection));
+				OpenShift3NativeResourceUtils.hasProject(projectName, connection));
 		final String serviceName = serviceSpec.service();
 		final String templateName = serviceSpec.template();
 		
@@ -191,7 +192,7 @@ public class OpenShiftServiceRequirement implements Requirement<RequiredService>
 	}
 
 	private IService getOrCreateService(String projectName, String serviceName, String templateName) {
-		IService service = OpenShiftResourceUtils.safeGetResource(
+		IService service = OpenShift3NativeResourceUtils.safeGetResource(
 				ResourceKind.SERVICE, serviceName, projectName, connection);
 		if (service == null) {
 			service = createService(serviceName, templateName, projectName, connection);
@@ -202,7 +203,7 @@ public class OpenShiftServiceRequirement implements Requirement<RequiredService>
 	private IService createService(String serviceName, String templateName, String projectName, Connection connection) {
 		LOGGER.debug(NLS.bind("Creating service in project {0} on server {1} using template {2}",
 				new Object[] { projectName, connection.getHost(), templateName }));
-		IProject project = OpenShiftResourceUtils.getProject(projectName, connection);
+		IProject project = OpenShift3NativeResourceUtils.getProject(projectName, connection);
 		assertNotNull(project);
 		ITemplate template = connection.getResource(
 				ResourceKind.TEMPLATE, OpenShiftResources.OPENSHIFT_PROJECT, templateName);

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeProjectUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeProjectUtils.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v 1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.reddeer.utils.v3;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.osgi.util.NLS;
+import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.common.wait.WaitUntil;
+import org.jboss.tools.openshift.core.connection.Connection;
+import org.jboss.tools.openshift.reddeer.condition.OpenShiftProjectExists;
+
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.model.IProject;
+import com.openshift.restclient.model.project.IProjectRequest;
+
+/**
+ * Utils class for working with OS3 projects using openshift core api (not UI).
+ * 
+ * @author rhopp
+ *
+ */
+
+public class OpenShift3NativeProjectUtils {
+	
+	private OpenShift3NativeProjectUtils() {
+		throw new IllegalAccessError("Utilities class");
+	}
+
+	private static Logger LOGGER = new Logger(OpenShift3NativeProjectUtils.class);
+
+	public static IProject getOrCreateProject(String name, String displayName, String description, Connection connection) {
+		IProject project = OpenShift3NativeResourceUtils.getProject(name, connection);
+		if (project == null) {
+			LOGGER.debug(NLS.bind("Project {0} doesnt exist yet in {1}, creating it.", name, connection.getHost()));
+			project = createProject(name, displayName, description, connection);
+
+		}
+		return project;
+	}
+
+	public static IProject createProject(String name, String displayName, String description, Connection connection) {
+		assertTrue(StringUtils.isNotBlank(name));
+		assertNotNull(displayName);
+		assertNotNull(description);
+		assertNotNull(connection);
+
+		IProjectRequest request = connection.getResourceFactory().stub(ResourceKind.PROJECT_REQUEST, name);
+		request.setDisplayName(StringUtils.isEmpty(displayName) ? name : displayName);
+		request.setDescription(StringUtils.isEmpty(description) ? name : description);
+
+		IProject createdProject = (IProject) connection.createResource(request);
+		
+		/**
+		 * WORKAROUND: explorer wont get notified of the the new project and
+		 * therefore wont display it unless a manual refresh is done on the
+		 * connection. https://issues.jboss.org/browse/JBIDE-23513 remove
+		 * this wait once WatchManager is watching projects and notifies the
+		 * ui.
+		 * 
+		 * @see WatchManager#KINDS
+		 */
+		new WaitUntil(new OpenShiftProjectExists(name, connection));
+		
+		return createdProject;
+	}
+
+}

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeResourceUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeResourceUtils.java
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.openshift.reddeer.requirement;
+package org.jboss.tools.openshift.reddeer.utils.v3;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -32,9 +32,9 @@ import com.openshift.restclient.model.IService;
 /**
  * @author adietish@redhat.com
  */
-public class OpenShiftResourceUtils {
+public class OpenShift3NativeResourceUtils {
 	
-	private static final Logger LOGGER = new Logger(OpenShiftResourceUtils.class);
+	private static final Logger LOGGER = new Logger(OpenShift3NativeResourceUtils.class);
 
 	/**
 	 * Returns the project with the given name that exists on the server that


### PR DESCRIPTION
So this logic can be consumed by tests.

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
