### PR TITLE
[JBIDE-23783] fixed layout in server editor section

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/UIUtils.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/UIUtils.java
@@ -23,6 +23,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.ContributionManager;
 import org.eclipse.jface.action.GroupMarker;
 import org.eclipse.jface.action.IContributionManager;
@@ -40,6 +41,8 @@ import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.GC;
@@ -523,5 +526,32 @@ public class UIUtils {
     	ISelectionService service = (window != null) ? window.getSelectionService() : null;
     	return service != null ? service.getSelection() : null;
     }
+    
+    /**
+     * Makes sure combos in GTK3 are displayed in the correct size.
+     * 
+     * @param combo the container which contains combos wont have those in too small size
+     * 
+     * @see https://issues.jboss.org/browse/JBIDE-16877,
+	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=431425
+     */
+    public static void ensureGTK3CombosAreCorrectSize(final Composite composite) {
+    	if (!Platform.WS_GTK.equals(Platform.getWS())
+    			|| DisposeUtils.isDisposed(composite)) {
+    		return;
+    	}
 
-}
+		composite.addPaintListener(new PaintListener() {
+
+			@Override
+			public void paintControl(PaintEvent e) {
+				if (!DisposeUtils.isDisposed(composite)
+						&& composite.isVisible()) {
+					composite.layout(true, true);
+					composite.update();
+					composite.removePaintListener(this);
+				}
+			}
+		});
+    }
+   }

--- a/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationConfigurationWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.express.ui/src/org/jboss/tools/openshift/express/internal/ui/wizard/application/ApplicationConfigurationWizardPage.java
@@ -818,10 +818,8 @@ public class ApplicationConfigurationWizardPage extends AbstractOpenShiftWizardP
 		} catch (OpenShiftException e) {
 			Logger.error("Failed to reset page fields", e);
 		}
-		// fix GTK3 combo boxes too small
-		// https://issues.jboss.org/browse/JBIDE-16877,
-		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=431425
-		((Composite) getControl()).layout(true, true);
+
+		UIUtils.ensureGTK3CombosAreCorrectSize((Composite) getControl());
 	}
 	
 	protected void loadOpenshiftResources(final DataBindingContext dbc) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/deployimage/DeployImagePage.java
@@ -51,8 +51,6 @@ import org.eclipse.linuxtools.internal.docker.core.RegistryInfo;
 import org.eclipse.linuxtools.internal.docker.ui.wizards.NewDockerConnection;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.PaintEvent;
-import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Point;
@@ -185,20 +183,7 @@ public class DeployImagePage extends AbstractOpenShiftWizardPage {
 	@Override
 	protected void onPageActivated(DataBindingContext dbc) {
 		loadResources(dbc);
-		// https://issues.jboss.org/browse/JBIDE-22912,
-		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=500703
-		getControl().addPaintListener(new PaintListener() {
-
-			@Override
-			public void paintControl(PaintEvent e) {
-				if (getControl().isVisible()) {
-					((Composite) getControl()).layout(true, true);
-					((Composite) getControl()).update();
-					getControl().getShell().pack();
-					getControl().removePaintListener(this);
-				}
-			}
-		});
+		UIUtils.ensureGTK3CombosAreCorrectSize((Composite) getControl());
 	}
 
 	private void loadResources(DataBindingContext dbc) {


### PR DESCRIPTION
corrected layout issues in OpenShiftServerEditorSection and centralized
the paintlistener, that ensures combos in GTK3 have the correct size, to
UIUtils#ensureGTK3CombosAreCorrectSize

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
