### PR TITLE
Test-framework: wait for project creation based on displayed name

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeProjectUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeProjectUtils.java
@@ -70,7 +70,7 @@ public class OpenShift3NativeProjectUtils {
 		 * 
 		 * @see WatchManager#KINDS
 		 */
-		new WaitUntil(new OpenShiftProjectExists(name, connection));
+		new WaitUntil(new OpenShiftProjectExists(createdProject.getDisplayName(), connection));
 		
 		return createdProject;
 	}


### PR DESCRIPTION
The tree item lookup uses displayed name, but the method would use project name and error every time these names differ.

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
