### PR TITLE
Test-framework: Move acceptSSLCertificate method to a public place

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/SecureStorage.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/SecureStorage.java
@@ -25,7 +25,6 @@ import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.button.FinishButton;
 import org.jboss.reddeer.swt.impl.button.NoButton;
 import org.jboss.reddeer.swt.impl.button.OkButton;
-import org.jboss.reddeer.swt.impl.button.YesButton;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
@@ -88,7 +87,7 @@ public class SecureStorage {
 			new CheckBox(1).click();
 			new FinishButton().click();
 			
-			acceptSSLCertificate(); 
+			TestUtils.acceptSSLCertificate(); 
 
 			
 			boolean firstStorage = provideSecureStoragePassword(SystemProperties.SECURE_STORAGE_PASSWORD);
@@ -134,16 +133,6 @@ public class SecureStorage {
 			new DefaultShell("Loading OpenShift 2 connection details");
 			connection.select();
 		} catch (RedDeerException ex) {
-		}
-	}
-
-	private static void acceptSSLCertificate() {
-		try {
-			DefaultShell shell = new DefaultShell(OpenShiftLabel.Shell.UNTRUSTED_SSL_CERTIFICATE);
-			shell.setFocus();
-			new YesButton().click();
-		} catch (RedDeerException e) {
-			// there was no certificate dialog
 		}
 	}
 	

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/TestUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/TestUtils.java
@@ -17,9 +17,14 @@ import java.net.URL;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.api.Git;
+import org.jboss.reddeer.common.exception.RedDeerException;
+import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
 import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.button.RadioButton;
+import org.jboss.reddeer.swt.impl.button.YesButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.jboss.tools.openshift.reddeer.preference.page.OpenShift3PreferencePage;
 import org.jboss.tools.openshift.reddeer.requirement.OpenShiftCommandLineToolsRequirement;
@@ -133,5 +138,15 @@ public class TestUtils {
         } catch (Exception e) {
             return false;
         }
+	}
+	
+	public static void acceptSSLCertificate() {
+		try {
+			new DefaultShell(OpenShiftLabel.Shell.UNTRUSTED_SSL_CERTIFICATE);
+			new YesButton().click();
+			new WaitWhile(new ShellWithTextIsAvailable(OpenShiftLabel.Shell.UNTRUSTED_SSL_CERTIFICATE));
+		} catch (RedDeerException ex) {
+			// no dialog was presented
+		}
 	}
 }


### PR DESCRIPTION
I've found some uses for this method outside the secure storage handler. TestUtils seems like a good place to make it public.

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
