### PR TITLE
JBIDE-23603: do a clean publish for eap

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftPublishController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftPublishController.java
@@ -206,7 +206,9 @@ public class OpenShiftPublishController extends StandardFileSystemPublishControl
 	public int publishModule(int kind,
 			int deltaKind, IModule[] module, IProgressMonitor monitor)
 			throws CoreException {
-		if( syncDownFailed ) {
+		if (isEapProfile()) {
+			return super.publishModule(IServer.PUBLISH_CLEAN, deltaKind, module, monitor);
+		} else if( syncDownFailed ) {
 			return super.publishModule(IServer.PUBLISH_FULL, deltaKind, module, monitor);
 		} else {
 			return super.publishModule(kind, deltaKind, module, monitor);


### PR DESCRIPTION
I'm really not sure about the correctness of the fix, but it works for me.

The thing is that, despite the fact that the publish kind is called `IServer.PUBLISH_CLEAN` it doesn't clean all the deployed files, but just a changed one: here is rsync log from Console View after the changes in Member.java:
> sent 46 bytes  received 1,375 bytes  2,842.00 bytes/sec
total size is 8,535,536  speedup is 6,006.71
sending incremental file list
ROOT.war.dodeploy
ROOT.war/WEB-INF/classes/org/jboss/as/quickstarts/kitchensink/model/Member.class
sent 2,147 bytes  received 190 bytes  1,558.00 bytes/sec
total size is 8,535,531  speedup is 3,652.35

i'm mostly unsure about the condition `isEapProfile()`. Is it ok to check if it is a EAP project like this?

@adietish @robstryker @jeffmaury please, take a look and test