### PR TITLE
[JBIDE-23815] dont NPE when BuildConfig.source.type is "Binary"

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/BuildConfigPropertySource.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/BuildConfigPropertySource.java
@@ -40,27 +40,45 @@ public class BuildConfigPropertySource extends ResourcePropertySource<IBuildConf
 	public IPropertyDescriptor[] getResourcePropertyDescriptors() {
 		List<IPropertyDescriptor> all = new ArrayList<>();
 		all.addAll(getBuildTriggerPropertyDescriptors());
-		switch (getResource().getBuildStrategy().getType()) {
-		case BuildStrategyType.CUSTOM:
-			all.addAll(getCustomPropertyDescriptors());
-			break;
-		case BuildStrategyType.DOCKER:
-			all.addAll(getDockerPropertyDescriptors());
-			break;
-		case BuildStrategyType.STI:
-		case BuildStrategyType.SOURCE:
-			all.addAll(getSTIPropertyDescriptors());
-			break;
-		default:
-		}
-		switch (getResource().getBuildSource().getType()) {
-		case BuildSourceType.GIT:
-			all.addAll(getGitBuildSource());
-			break;
-		default:
-		}
+		addBuildStrategyProperties(all, getResource());
+		addBuildSourceProperties(all, getResource());
 		all.add(new ExtTextPropertyDescriptor(BuildConfigPropertySource.Ids.OUTPUT_REPO_NAME, "Image Stream Name", "Output"));
 		return all.toArray(new IPropertyDescriptor[]{});
+	}
+
+	private void addBuildStrategyProperties(List<IPropertyDescriptor> all, IBuildConfig bc) {
+		if (bc == null
+				|| bc.getBuildStrategy() == null) {
+			return;
+		}
+
+		switch (bc.getBuildStrategy().getType()) {
+			case BuildStrategyType.CUSTOM:
+				all.addAll(getCustomPropertyDescriptors());
+				break;
+			case BuildStrategyType.DOCKER:
+				all.addAll(getDockerPropertyDescriptors());
+				break;
+			case BuildStrategyType.STI:
+			case BuildStrategyType.SOURCE:
+				all.addAll(getSTIPropertyDescriptors());
+				break;
+			default:
+		}
+	}
+
+	private void addBuildSourceProperties(List<IPropertyDescriptor> all, IBuildConfig bc) {
+		if (bc == null
+				|| bc.getBuildSource() == null) {
+			return;
+		}
+
+		switch (bc.getBuildSource().getType()) {
+			case BuildSourceType.GIT:
+				all.addAll(getGitBuildSource());
+				break;
+			default:
+		}
 	}
 
 	private List<IPropertyDescriptor> getBuildTriggerPropertyDescriptors() {


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
