### PR TITLE
JBIDE-24010 bump openshift.client to 3.3.3...

### DIFF
--- a/features/org.jboss.tools.openshift.cdk.feature/feature.xml
+++ b/features/org.jboss.tools.openshift.cdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.openshift.cdk.feature"
       label="%featureName"
-      version="3.3.2.qualifier"
+      version="3.3.3.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.openshift.cdk.server"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.jboss.tools.openshift.cdk.feature/pom.xml
+++ b/features/org.jboss.tools.openshift.cdk.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.openshift.features</groupId>
 	<artifactId>org.jboss.tools.openshift.cdk.feature</artifactId> 
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.jboss.tools.openshift.egit.integration.feature/feature.xml
+++ b/features/org.jboss.tools.openshift.egit.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.openshift.egit.integration.feature"
       label="%featureName"
-      version="3.3.2.qualifier"
+      version="3.3.3.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.openshift.egit.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.jboss.tools.openshift.egit.integration.feature/pom.xml
+++ b/features/org.jboss.tools.openshift.egit.integration.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.openshift.features</groupId>
 	<artifactId>org.jboss.tools.openshift.egit.integration.feature</artifactId> 
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.jboss.tools.openshift.express.feature/feature.xml
+++ b/features/org.jboss.tools.openshift.express.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.openshift.express.feature"
       label="%featureName"
-      version="3.3.2.qualifier"
+      version="3.3.3.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.openshift.express.client"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.jboss.tools.openshift.express.feature/pom.xml
+++ b/features/org.jboss.tools.openshift.express.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.openshift.features</groupId>
 	<artifactId>org.jboss.tools.openshift.express.feature</artifactId> 
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.jboss.tools.openshift.feature/feature.xml
+++ b/features/org.jboss.tools.openshift.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.openshift.feature"
       label="%featureName"
-      version="3.3.2.qualifier"
+      version="3.3.3.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.openshift.ui"
       license-feature="org.jboss.tools.foundation.license.feature"
@@ -25,9 +25,39 @@
       <import feature="org.eclipse.linuxtools.docker.feature"/>
    </requires>
 
-   <plugin id="org.jboss.tools.openshift.client" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
-   <plugin id="org.jboss.tools.openshift.ui" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
-   <plugin id="org.jboss.tools.openshift.core" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
-   <plugin id="org.jboss.tools.openshift.common.core" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
-   <plugin id="org.jboss.tools.openshift.common.ui" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin
+         id="org.jboss.tools.openshift.client"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.jboss.tools.openshift.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.jboss.tools.openshift.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.jboss.tools.openshift.common.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.jboss.tools.openshift.common.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/org.jboss.tools.openshift.feature/pom.xml
+++ b/features/org.jboss.tools.openshift.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.openshift.features</groupId>
 	<artifactId>org.jboss.tools.openshift.feature</artifactId> 
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.jboss.tools.openshift.js.feature/feature.xml
+++ b/features/org.jboss.tools.openshift.js.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.openshift.js.feature"
       label="%featureName"
-      version="3.3.2.qualifier"
+      version="3.3.3.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.openshift.js"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.jboss.tools.openshift.js.feature/pom.xml
+++ b/features/org.jboss.tools.openshift.js.feature/pom.xml
@@ -8,5 +8,6 @@
 	</parent>
 	<groupId>org.jboss.tools.openshift.features</groupId>
 	<artifactId>org.jboss.tools.openshift.js.feature</artifactId>
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jboss.tools.openshift.client;singleton:=true
-Bundle-Version: 3.3.2.qualifier
+Bundle-Version: 3.3.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -8,6 +8,7 @@
 	</parent>
 	<groupId>org.jboss.tools.openshift.plugins</groupId>
 	<artifactId>org.jboss.tools.openshift.client</artifactId> 
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/plugins/org.jboss.tools.openshift.common.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.common.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jboss.tools.openshift.common.ui;singleton:=true
-Bundle-Version: 3.3.2.qualifier
+Bundle-Version: 3.3.3.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.jboss.tools.openshift.internal.common.ui.OpenShiftCommonUIActivator
 Require-Bundle: org.jboss.tools.openshift.common.core;bundle-version="[3.0.0,4.0.0)",

--- a/plugins/org.jboss.tools.openshift.common.ui/pom.xml
+++ b/plugins/org.jboss.tools.openshift.common.ui/pom.xml
@@ -7,6 +7,7 @@
 		<version>3.3.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.openshift.plugins</groupId>
-	<artifactId>org.jboss.tools.openshift.common.ui</artifactId> 
+	<artifactId>org.jboss.tools.openshift.common.ui</artifactId>
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jboss.tools.openshift.core;singleton:=true
-Bundle-Version: 3.3.2.qualifier
+Bundle-Version: 3.3.3.qualifier
 Bundle-Activator: org.jboss.tools.openshift.internal.core.OpenShiftCoreActivator
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.openshift.core/pom.xml
+++ b/plugins/org.jboss.tools.openshift.core/pom.xml
@@ -7,6 +7,7 @@
 		<version>3.3.2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.openshift.plugins</groupId>
-	<artifactId>org.jboss.tools.openshift.core</artifactId> 
+	<artifactId>org.jboss.tools.openshift.core</artifactId>
+	<version>3.3.3-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
JBIDE-24010 bump openshift.client to 3.3.3 in 4.4.x branch

Signed-off-by: nickboldt <nboldt@redhat.com>

JBIDE-24010 bump core and client plugins, plus other things that need to
increment