### PR TITLE
Fix for integration tests reflecting edited name of Server Adapter.

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/ServerAdapterExists.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/ServerAdapterExists.java
@@ -41,7 +41,7 @@ public class ServerAdapterExists extends AbstractWaitCondition {
 	@Override
 	public boolean test() {
 		try {
-			new ServerAdapter(version, applicationName);
+			new ServerAdapter(version, applicationName, "Service");
 			return true;
 		} catch (OpenShiftToolsException ex) {
 			return false;

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/view/resources/ServerAdapter.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/view/resources/ServerAdapter.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.reddeer.view.resources;
 
+import org.apache.commons.lang.StringUtils;
 import org.jboss.reddeer.common.exception.RedDeerException;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
@@ -40,6 +41,7 @@ public class ServerAdapter {
 	
 	private Version version;
 	private String applicationName;
+	private String type;
 	
 	private TreeItem serverAdapterItem;
 	
@@ -50,11 +52,16 @@ public class ServerAdapter {
 	 * @param version version of an OpenShift server
 	 * @param applicationName name of an application that server adapter binds to
 	 */
-	public ServerAdapter(Version version, String applicationName) {
+	public ServerAdapter(Version version, String applicationName, String type) {
 		this.version = version;
 		this.applicationName = applicationName;
+		this.type = type;
 		
 		updateServerAdapterTreeItem();
+	}
+	
+	public ServerAdapter(Version version, String applicationName){
+		this(version, applicationName, StringUtils.EMPTY);
 	}
 	
 	/**
@@ -90,6 +97,9 @@ public class ServerAdapter {
 		if (version.equals(Version.OPENSHIFT2)) {
 			serverAdapterLabel += getOS2ServerAdapterAppendix();
 		} else {
+			if (type != StringUtils.EMPTY){
+				serverAdapterLabel += String.format(" (%s)", type);	
+			}
 			serverAdapterLabel += getOS3ServerAdapterAppendix();
 		}
 		return serverAdapterLabel;


### PR DESCRIPTION
Kind of resource (Service, Deployment config, ...) for which was the
server adapter created was added to name of the server adapter.

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
