### PR TITLE
[JBIDE-23708] - Pod Log: unable to get build log if build failed with error

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PodLogsHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PodLogsHandler.java
@@ -40,7 +40,7 @@ import com.openshift.restclient.model.IPod;
  * @author Jeff Maury
  */
 public class PodLogsHandler extends AbstractOpenShiftCliHandler {
-	private static final String [] STATES = new String [] {"Running", "Succeeded", "Failed", "Completed"};
+	private static final String [] STATES = new String [] {"Running", "Succeeded", "Failed", "Completed", "Error"};
 	
 	public static final String INVALID_POD_STATUS_MESSAGE = "The log is unavailable while the pod is in {0} state.";
 	


### PR DESCRIPTION


Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
