### PR TITLE
Fix for integration tests reflecting edited name of Server Adapter.

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/ServerAdapterExists.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/ServerAdapterExists.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.reddeer.condition;
 
+import org.apache.commons.lang.StringUtils;
 import org.jboss.reddeer.common.condition.AbstractWaitCondition;
 import org.jboss.tools.openshift.reddeer.exception.OpenShiftToolsException;
 import org.jboss.tools.openshift.reddeer.view.resources.ServerAdapter;
@@ -26,22 +27,33 @@ public class ServerAdapterExists extends AbstractWaitCondition {
 
 	private String applicationName;
 	private ServerAdapter.Version version;
+	private String resourceKind;
 	
 	/**
 	 * Constructs a new Server adapter exists wait condition.
 	 * 
-	 * @param applicationName name of an application that server adapter binds to
-	 * @param isOpenShift3ServerAdapter set to true if you want test OS3 server adapter, false for OS2
+	 * @param applicationName
+	 *            name of an application that server adapter binds to
+	 * @param isOpenShift3ServerAdapter
+	 *            set to true if you want test OS3 server adapter, false for OS2
+	 * @param resourceKind
+	 *            kind of resource for which the server adapter was created (for
+	 *            example Service or Deployment Config)
 	 */
-	public ServerAdapterExists(Version version, String applicationName) {
+	public ServerAdapterExists(Version version, String applicationName, String resourceKind) {
 		this.applicationName = applicationName;
 		this.version = version;
+		this.resourceKind = resourceKind;
+	}
+	
+	public ServerAdapterExists(Version version, String applicationName) {
+		this(version, applicationName, StringUtils.EMPTY);
 	}
 
 	@Override
 	public boolean test() {
 		try {
-			new ServerAdapter(version, applicationName);
+			new ServerAdapter(version, applicationName, resourceKind);
 			return true;
 		} catch (OpenShiftToolsException ex) {
 			return false;


### PR DESCRIPTION
Kind of resource (Service, Deployment config, ...) for which was the
server adapter created was added to name of the server adapter.

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
