### PR TITLE
[JBIDE-24033] finish adapter wizard upon double clicking resource

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/SelectResourceWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/SelectResourceWizard.java
@@ -10,8 +10,6 @@ package org.jboss.tools.openshift.internal.ui.server;
 
 import java.lang.reflect.InvocationTargetException;
 
-import javax.print.attribute.standard.Finishings;
-
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.core.databinding.observable.list.IListChangeListener;
@@ -129,6 +127,7 @@ public class SelectResourceWizard extends AbstractOpenShiftWizard<ServerResource
 					.applyTo(selectorText);
 
 			final TreeViewer resourcesViewer = createServicesTreeViewer(servicesGroup, selectorText);
+			resourcesViewer.addDoubleClickListener(onDoubleClickService());
 			IObservableList resourceItemsObservable = BeanProperties.list(ServerResourceViewModel.PROPERTY_RESOURCE_ITEMS).observe(getModel());
 			DataBindingUtils.addDisposableListChangeListener(
 					onServiceItemsChanged(resourcesViewer), resourceItemsObservable, resourcesViewer.getTree());
@@ -167,7 +166,7 @@ public class SelectResourceWizard extends AbstractOpenShiftWizard<ServerResource
 			GridDataFactory.fillDefaults()
 					.span(2, 1).align(SWT.FILL, SWT.FILL).grab(true, false).hint(SWT.DEFAULT, 150)
 					.applyTo(detailsContainer);
-			IObservableValue selectedResource = new WritableValue();
+			IObservableValue<? extends IResource> selectedResource = new WritableValue<>();
 			ValueBindingBuilder
 				.bind(selectedResourceTreeItem)
 				.converting(new ObservableTreeItem2ModelConverter())
@@ -192,11 +191,11 @@ public class SelectResourceWizard extends AbstractOpenShiftWizard<ServerResource
 			};
 		}
 
-		private IListChangeListener onServiceItemsChanged(final TreeViewer servicesViewer) {
-			return new IListChangeListener() {
+		private IListChangeListener<Object> onServiceItemsChanged(final TreeViewer servicesViewer) {
+			return new IListChangeListener<Object>() {
 				
 				@Override
-				public void handleListChange(ListChangeEvent event) {
+				public void handleListChange(ListChangeEvent<? extends Object> event) {
 					servicesViewer.expandAll();
 				}
 			};

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
@@ -60,6 +60,8 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
@@ -441,6 +443,19 @@ public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implem
         dbc.addValidationStatusProvider(validator);
 	}
 
+	private IDoubleClickListener onDoubleClickService() {
+		return new IDoubleClickListener() {
+
+			@Override
+			public void doubleClick(DoubleClickEvent event) {
+				if (getWizard().canFinish()) {
+					Button finishButton = getShell().getDefaultButton();
+					UIUtils.clickButton(finishButton);
+				}
+			}
+		};
+	}
+
 	/**
 	 * Open a dialog box to select an open project when clicking on the 'Browse' button.
 	 * 
@@ -721,6 +736,7 @@ public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implem
 				.applyTo(selectorText);
 
 		final TreeViewer resourcesViewer = createResourcesTreeViewer(resourcesGroup, model, selectorText);
+		resourcesViewer.addDoubleClickListener(onDoubleClickService());
 		IObservableList resourceItemsObservable = BeanProperties.list(ServerSettingsWizardPageModel.PROPERTY_RESOURCE_ITEMS).observe(model);
 		DataBindingUtils.addDisposableListChangeListener(
 				onResourceItemsChanged(resourcesViewer), resourceItemsObservable, resourcesViewer.getTree());


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
