### PR TITLE
JBIDE-24250 - OpenShift Explorer sometimes don't show the objects in Properties view

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ProjectWrapper.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ProjectWrapper.java
@@ -108,4 +108,10 @@ public class ProjectWrapper extends ResourceContainer<IProject, ConnectionWrappe
 		state.set(LoadingState.LOADED);
 		fireChanged();
 	}
+
+    @Override
+    public Collection<IResourceWrapper<?, ?>> getResources() {
+        load(IExceptionHandler.NULL_HANDLER);
+        return super.getResources();
+    }
 }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
