### PR TITLE
	JBIDE-23769 - New Application: Do not throw exception in error log when provided template is of wrong kind.

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -296,7 +296,8 @@ public class NewApplicationWizardModel
         } catch (OpenShiftException e) {
             status = StatusFactory.errorStatus(OpenShiftUIActivator.PLUGIN_ID, e.getLocalizedMessage(), e);
         } catch (NotATemplateException e) {
-            status = StatusFactory.errorStatus(OpenShiftUIActivator.PLUGIN_ID, e.getLocalizedMessage());
+            status = StatusFactory.errorStatus(OpenShiftUIActivator.PLUGIN_ID, 
+            		NLS.bind("{0} is not a template: {1}", localAppSourceFilename, e.getLocalizedMessage()));
         }
         updateAppSourceStatus(status);
     }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizardModel.java
@@ -293,8 +293,10 @@ public class NewApplicationWizardModel
                 IApplicationSource source = getLocalAppSource(monitor, localAppSourceFilename);
                 updateSelectedAppSource(useLocalAppSource, serverAppSource, source, localAppSourceFilename);
             }
-        } catch (OpenShiftException | NotATemplateException e) {
+        } catch (OpenShiftException e) {
             status = StatusFactory.errorStatus(OpenShiftUIActivator.PLUGIN_ID, e.getLocalizedMessage(), e);
+        } catch (NotATemplateException e) {
+            status = StatusFactory.errorStatus(OpenShiftUIActivator.PLUGIN_ID, e.getLocalizedMessage());
         }
         updateAppSourceStatus(status);
     }


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
