### PR TITLE
JBIDE-24373 - Can't push an image to the CDK3 Docker registry

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dockerutils/PushImageToRegistryJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dockerutils/PushImageToRegistryJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Red Hat.
+ * Copyright (c) 2016-2017 Red Hat.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -83,7 +83,6 @@ public class PushImageToRegistryJob extends AbstractDelegatingMonitorJob {
 			}
 			monitor.done();
 		}
-		// TODO Auto-generated method stub
 		return Status.OK_STATUS;
 	}
 
@@ -98,7 +97,8 @@ public class PushImageToRegistryJob extends AbstractDelegatingMonitorJob {
 	 */
 	public String getPushToRegistryImageName() {
 		try {
-			final String registryHostname = new URL(this.registryAccount.getServerAddress()).getHost();
+		    final URL registryURL = new URL(this.registryAccount.getServerAddress());
+			final String registryHostname = (registryURL.getPort() == (-1))?registryURL.getHost():registryURL.getHost() + ':' + registryURL.getPort();
 			final String tmpImageName = registryHostname + '/' + this.openshiftProject + '/' + DockerImageUtils.extractImageNameAndTag(this.imageName);
 			return tmpImageName;
 		} catch (MalformedURLException e) {


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
