### PR TITLE
ITests: Extend wait for project creation & change label of builder image.

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
@@ -299,7 +299,7 @@ public class OpenShiftLabel {
 	public static class Others {
 		public static final String CONNECT_TOOL_ITEM = "Connection...";
 		public static final String EAP_TEMPLATE = "eap70-basic-s2i (eap, javaee, java, jboss, xpaas) - openshift";
-		public static final String EAP_BUILDER_IMAGE = "jboss-eap70-openshift:1.4 (builder, eap, javaee, java, jboss, xpaas) - openshift";
+		public static final String EAP_BUILDER_IMAGE = "jboss-eap70-openshift:1.5 (builder, eap, javaee, java, jboss, xpaas) - openshift";
 		public static final String NODEJS_TEMPLATE = "nodejs-example (quickstart, nodejs) - openshift";
 		public static final String RED_HAT_CENTRAL = "Red Hat Central";
 		public static final String MAVEN_MIRROR_URL = "MAVEN_MIRROR_URL";

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeProjectUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeProjectUtils.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.osgi.util.NLS;
 import org.jboss.reddeer.common.condition.AbstractWaitCondition;
 import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.tools.common.reddeer.utils.StackTraceUtils;
 import org.jboss.tools.openshift.core.connection.Connection;
@@ -63,7 +64,7 @@ public class OpenShift3NativeProjectUtils {
 		request.setDescription(StringUtils.isEmpty(description) ? name : description);
 		
 		CreateProjectWaitCondition createProjectWaitCondition = new CreateProjectWaitCondition(connection, request);
-		new WaitUntil(createProjectWaitCondition);
+		new WaitUntil(createProjectWaitCondition, TimePeriod.LONG);
 		IProject createdProject = createProjectWaitCondition.getProject();
 		
 		/**


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
