### PR TITLE
JBIDE-24783 - don't use default image registry url

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/MinishiftServiceManagerEnvironmentLoader.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/MinishiftServiceManagerEnvironmentLoader.java
@@ -98,11 +98,15 @@ public class MinishiftServiceManagerEnvironmentLoader extends ServiceManagerEnvi
 		try {
 			String[] lines = callAndGetLines(env, args, cmdLoc, wd);
 			if( lines != null && lines.length > 0) {
-				return lines[0];
+				if( lines[0] != null )
+					return lines[0];
+				else
+					CDKCoreActivator.pluginLog().logWarning(
+							"Call to '" + cmdLoc + " openshift registry' was unable to locate an image registry for server " + server.getName());
 			}
 		} catch(IOException ioe) {
 			CDKCoreActivator.pluginLog().logError(
-					"Unable to successfully complete a call to minishift docker-env ",ioe);
+					"Unable to successfully complete a call to minishift openshift registry ",ioe);
 		}
 		return null;
 	}

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/ServiceManagerEnvironment.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/ServiceManagerEnvironment.java
@@ -24,6 +24,8 @@ public class ServiceManagerEnvironment {
 	public static final String KEY_DOCKER_CERT_PATH = "DOCKER_CERT_PATH";
 	public static final String KEY_DOCKER_API_VERSION = "DOCKER_API_VERSION";
 	public static final String IMAGE_REGISTRY_KEY = "DOCKER_REGISTRY";
+	public static final String KEY_DEFAULT_IMAGE_REGISTRY = "jbt.default.DOCKER_REGISTRY";
+	
 	
 	public static final String KEY_OPENSHIFT_HOST = "HOST";
 	public static final String KEY_OPENSHIFT_PORT = "PORT";
@@ -32,9 +34,6 @@ public class ServiceManagerEnvironment {
 	private static final String DOTCDK_AUTH_SCHEME = "openshift.auth.scheme";
 	private static final String DOTCDK_AUTH_USERNAME = "openshift.auth.username";
 	private static final String DOTCDK_AUTH_PASS = "openshift.auth.password";
-	
-	private static final String DEFAULT_IMAGE_REGISTRY_URL = "https://hub.openshift.rhel-cdk.10.1.2.2.xip.io";
-	
 	
 	private static final String HTTPS_SCHEMA = "https://";
 	
@@ -78,11 +77,10 @@ public class ServiceManagerEnvironment {
 	public String getDockerRegistry() {
 		String dockerReg = env.get(IMAGE_REGISTRY_KEY);
 		if( dockerReg == null ) {
-			dockerReg = DEFAULT_IMAGE_REGISTRY_URL;
-		} else {
-			if( !dockerReg.contains("://")) {
-				dockerReg = "https://" + dockerReg;
-			}
+			dockerReg = env.get(KEY_DEFAULT_IMAGE_REGISTRY);
+		} 
+		if (dockerReg != null && !dockerReg.contains("://")) {
+			dockerReg = "https://" + dockerReg;
 		}
 		return dockerReg;
 	}

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/VagrantServiceManagerEnvironmentLoader.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/listeners/VagrantServiceManagerEnvironmentLoader.java
@@ -23,7 +23,7 @@ import org.jboss.tools.openshift.cdk.server.core.internal.CDKCoreActivator;
 import org.jboss.tools.openshift.cdk.server.core.internal.VagrantBinaryUtility;
 
 public class VagrantServiceManagerEnvironmentLoader extends ServiceManagerEnvironmentLoader {
-
+	private static final String DEFAULT_IMAGE_REGISTRY_URL = "https://hub.openshift.rhel-cdk.10.1.2.2.xip.io";
 	public VagrantServiceManagerEnvironmentLoader() {
 		super(TYPE_VAGRANT);
 	}
@@ -38,8 +38,13 @@ public class VagrantServiceManagerEnvironmentLoader extends ServiceManagerEnviro
 			
 			// merge the two
 			Map<String, String> merged = merge(adbEnv, dotcdkProps);
+			
+			
 			try {
 				if (merged != null) {
+					// Manually set default for image registry url
+					merged.put(ServiceManagerEnvironment.KEY_DEFAULT_IMAGE_REGISTRY, DEFAULT_IMAGE_REGISTRY_URL);
+					
 					return new ServiceManagerEnvironment(merged);
 				}
 			} catch (URISyntaxException urise) {


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
