### PR TITLE
Throwing of exception instead of test fail when server fails to start

### DIFF
--- a/test-framework/org.jboss.tools.cdk.reddeer/META-INF/MANIFEST.MF
+++ b/test-framework/org.jboss.tools.cdk.reddeer/META-INF/MANIFEST.MF
@@ -10,9 +10,11 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
  org.jboss.reddeer.go;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.swt
-Export-Package: org.jboss.tools.cdk.reddeer.condition,
+Export-Package: org.jboss.tools.cdk.reddeer.core.condition,
+ org.jboss.tools.cdk.reddeer.core.matcher,
  org.jboss.tools.cdk.reddeer.preferences,
  org.jboss.tools.cdk.reddeer.requirements,
+ org.jboss.tools.cdk.reddeer.server.exception,
  org.jboss.tools.cdk.reddeer.server.ui,
  org.jboss.tools.cdk.reddeer.server.ui.editor,
  org.jboss.tools.cdk.reddeer.server.ui.wizard

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/condition/ServerHasState.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/condition/ServerHasState.java
@@ -8,7 +8,7 @@
  * Contributor:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.tools.cdk.reddeer.condition;
+package org.jboss.tools.cdk.reddeer.core.condition;
 
 import org.jboss.reddeer.common.condition.AbstractWaitCondition;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/condition/SystemJobIsRunning.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/condition/SystemJobIsRunning.java
@@ -1,0 +1,55 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdk.reddeer.core.condition;
+
+import org.eclipse.core.runtime.jobs.Job;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.core.condition.JobIsRunning;
+
+/**
+ * Specific condition class testing existence of matching system job(s)
+ * @author odockal
+ *
+ */
+public class SystemJobIsRunning extends JobIsRunning {
+	
+	public static final Logger log = Logger.getLogger(SystemJobIsRunning.class);
+	
+	@SuppressWarnings("rawtypes")
+	private Matcher[] consideredJobs;
+	
+	public SystemJobIsRunning(Matcher<?> matcher) {
+		this(new Matcher[] { matcher });
+	}
+	
+	public SystemJobIsRunning(Matcher<?>[] consideredJobs) {
+		this.consideredJobs = consideredJobs;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.jboss.reddeer.common.condition.WaitCondition#test()
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean test() {
+		Job[] currentJobs = Job.getJobManager().find(null);
+		for (Job job: currentJobs) {
+			
+			if (CoreMatchers.anyOf(consideredJobs).matches(job.getName())) {
+				log.debug("  job '%s' has no excuses, wait for it", job.getName());
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/matcher/JobMatcher.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/matcher/JobMatcher.java
@@ -1,0 +1,59 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdk.reddeer.core.matcher;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.jobs.Job;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.jboss.reddeer.common.exception.RedDeerException;
+
+/**
+ * Matcher class matching given string parameter, it is used in SystemJobIsRunning wait condition
+ * @author odockal
+ *
+ */
+public class JobMatcher extends BaseMatcher<Job> {
+
+	private Job jobToMatch;
+	
+	public JobMatcher(String jobName) {
+		this.jobToMatch = new Job(jobName) {
+			
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		};
+	}
+	
+	public JobMatcher(Job job) {
+		this.jobToMatch = job;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("Job with name ");
+		description.appendValue(jobToMatch.getName());
+		description.appendText(" matches running job");
+	}
+
+	@Override
+	public boolean matches(Object item) {
+		if (jobToMatch != null && item != null) {
+			return jobToMatch.getName().equalsIgnoreCase(item.toString());
+		} else {
+			throw new RedDeerException("Null parameter was passed into matches method");
+		}
+	}
+}

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/exception/CDKServerException.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/exception/CDKServerException.java
@@ -1,0 +1,46 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdk.reddeer.server.exception;
+
+import org.jboss.reddeer.common.exception.RedDeerException;
+
+/**
+ * Exception class for CDK server failures
+ * @author odockal
+ *
+ */
+public class CDKServerException extends RedDeerException {
+
+	/**
+	 * Generated UID
+	 */
+	private static final long serialVersionUID = -1484606432928003515L;
+	
+	/**
+	 * Instantiates a new cdk server wizard exception.
+	 *
+	 * @param message the message
+	 * @param cause the cause
+	 */
+	public CDKServerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+	/**
+	 * Instantiates a new cdk server wizard exception.
+	 *
+	 * @param message the message
+	 */	
+	public CDKServerException(String message) {
+		super(message);
+	}	
+	
+}

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/ui/CDEServer.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/ui/CDEServer.java
@@ -10,23 +10,24 @@
  ******************************************************************************/
 package org.jboss.tools.cdk.reddeer.server.ui;
 
-import static org.junit.Assert.fail;
-
 import org.jboss.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
-import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.Server;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersView;
 import org.jboss.reddeer.eclipse.wst.server.ui.view.ServersViewEnums.ServerState;
 import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.impl.button.OkButton;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
-import org.jboss.tools.cdk.reddeer.condition.ServerHasState;
+import org.jboss.tools.cdk.reddeer.core.condition.ServerHasState;
+import org.jboss.tools.cdk.reddeer.core.condition.SystemJobIsRunning;
+import org.jboss.tools.cdk.reddeer.core.matcher.JobMatcher;
+import org.jboss.tools.cdk.reddeer.server.exception.CDKServerException;
 
 /**
  * Extended Server class for purposes of Container Development Kit Server Adapter
@@ -66,12 +67,33 @@ public class CDEServer extends Server {
 		log.debug("Operate server's state from: + '" + actualState + "' to '" + menuItem + "'");
 		select();
 		new ContextMenu(menuItem).select();
+		// waiting until servers's state has changed from initial state into something else, 
+		// ie. stopped -> starting or started -> stopping
 		new WaitWhile(new ServerHasState(this, actualState), TimePeriod.NORMAL);
+		// we might expect that after the state is changed it should not go back into initial state
+		// or that problem dialog appears
+		try {
+			new WaitUntil(new ShellWithTextIsAvailable("Problem Occured"), TimePeriod.NORMAL);
+			new DefaultShell("Problem Occured");
+			new OkButton().click();
+			String message = "Problem occured when trying to " + menuItem
+					+ " CDK server adapter";
+			throw new CDKServerException(message);	
+		} catch (WaitTimeoutExpiredException exc) {
+			log.info("Problem Occured dialog did not appear on CDK server " + menuItem);
+		}
+		try {
+			new WaitUntil(new ServerHasState(this, actualState), TimePeriod.NORMAL);
+			String message = "Server's state went back to " + actualState;
+			throw new CDKServerException(message);	
+		} catch (WaitTimeoutExpiredException exc) {
+			log.info("Server's state changed and did not go back to " + actualState);
+		}
 		if ((actualState == ServerState.STOPPING || actualState == ServerState.STOPPED) && !certificateAccepted) {
 			confirmSSLCertificateDialog();
 		}
-		new WaitUntil(new ServerHasState(this, resultState), timeout); // maybe add wait while job is running
-		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
+		new WaitUntil(new ServerHasState(this, resultState), timeout);
+		new WaitWhile(new SystemJobIsRunning(new JobMatcher("Inspecting CDK environment")), TimePeriod.LONG);
 		log.debug("Operate server's state finished, the result server's state is: '" + getLabel().getState() + "'");
 	}
 	
@@ -89,8 +111,10 @@ public class CDEServer extends Server {
 			new WaitWhile(new ShellWithTextIsAvailable(SSL_DIALOG_NAME));
 			setCertificateAccepted(true);
 		} catch (WaitTimeoutExpiredException ex) {
-			fail("WaitTimeoutExpiredException occured when handling Certificate dialog. "
-					+ "Dialog has not been shown");
+			String message ="WaitTimeoutExpiredException occured when handling Certificate dialog. "
+					+ "Dialog has not been shown";
+			log.error(message);
+			throw new CDKServerException(message, ex);
 		}
 	}
 }


### PR DESCRIPTION
   - added new CDKServerException class
   - moved another classes from integration test repo under cdk.reddeer plugin
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
