### PR TITLE
[JBIDE-24965] retrieve pod when restarting adapter in debug

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/OpenShiftDebugMode.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/OpenShiftDebugMode.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.core.server.debug;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -18,7 +17,6 @@ import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -35,6 +33,7 @@ import org.jboss.tools.openshift.internal.core.models.PortSpecAdapter;
 import org.jboss.tools.openshift.internal.core.util.NewPodDetectorJob;
 import org.jboss.tools.openshift.internal.core.util.ResourceUtils;
 
+import com.openshift.restclient.OpenShiftException;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IContainer;
 import com.openshift.restclient.model.IDeploymentConfig;
@@ -50,6 +49,8 @@ import com.openshift.restclient.model.IPort;
  */
 public class OpenShiftDebugMode {
 	
+	private static final String DEBUG_PORT_PROTOCOL = "TCP";
+	private static final String DEBUG_PORT_NAME = "debug";
 	protected DebugContext context;
 
 	/**
@@ -92,63 +93,6 @@ public class OpenShiftDebugMode {
 
 		return this;
 	}
-
-	private void updateDebugEnvVariables(IDeploymentConfig dc, DebugContext context) {
-		if (context.isDebugEnabled()) {
-			setDebugPort(context.getDebugPort(), context.getDebugPortKey(), dc);
-			dc.setEnvironmentVariable(context.getDebugPortKey(), String.valueOf(context.getDebugPort()));
-			dc.setEnvironmentVariable(context.getDevmodeKey(), String.valueOf(context.isDebugEnabled()));
-		} else {
-			dc.removeEnvironmentVariable(context.getDebugPortKey());
-			dc.removeEnvironmentVariable(context.getDevmodeKey());
-		}
-	}
-
-	private void setDebugPort(int requestedDebugPort, String debugPortKey, IDeploymentConfig dc) {
-		Collection<IContainer> originalContainers = dc.getContainers();
-		if (CollectionUtils.isEmpty(originalContainers)) {
-			return;
-		}
-
-		Collection<IContainer> containers = new ArrayList<>(originalContainers);
-		// TODO: support multiple containers
-		IContainer firstContainer = containers.iterator().next();
-		Set<IPort> ports = new HashSet<>(firstContainer.getPorts());
-		int currentDebugPort = NumberUtils.toInt(getEnv(dc, debugPortKey));
-		IPort current = getCurrentPort(currentDebugPort, ports);
-		boolean added = addDebugPort(requestedDebugPort, ports, current);
-		if (added) {
-			firstContainer.setPorts(ports); 
-			dc.setContainers(containers);
-		}
-	}
-
-	private IPort getCurrentPort(int currentDebugPort, Set<IPort> ports) {
-		IPort current = null;
-		if (currentDebugPort > 0) {
-			current = ports.stream()
-					.filter(p -> p.getContainerPort() == currentDebugPort)
-					.findFirst()
-					.orElse(null);
-		}
-		return current;
-	}
-
-	private boolean addDebugPort(int debugPort, Set<IPort> ports, IPort existing) {
-		boolean added = false;
-		if (existing == null) {
-			PortSpecAdapter newPort = new PortSpecAdapter("debug", "TCP", debugPort);
-			added = ports.add(newPort);
-		} else {
-			PortSpecAdapter newPort = new PortSpecAdapter(existing.getName(), existing.getProtocol(), debugPort);
-			if (!existing.equals(newPort)) {
-				ports.remove(existing);
-				added = ports.add(newPort);
-			}
-		}
-		return added;
-	}
-
 	
 	private boolean isDebugEnabled(IDeploymentConfig dc, String devmodeKey, String debugPortKey, int requestedDebugPort, boolean enableRequested) {
 		boolean debugEnabled = false;
@@ -213,29 +157,39 @@ public class OpenShiftDebugMode {
 					OpenShiftCoreActivator.PLUGIN_ID, "No deployment config present that can be updated."));
 		}
 
-		Connection connection = ConnectionsRegistryUtil.getConnectionFor(dc);
-		IPod pod = null;
-		if (updateDebugmode(dc, context, monitor)
-				| updateDevmode(dc, context, monitor)) {
-			pod = sendAndGetNewPod(dc, connection, monitor);
-		} else {
-			// dc already correctly set, so just get the pod
-			pod = getPod(dc, connection, monitor);
-		}
-
+		IPod pod = getNewPod(monitor, dc, ConnectionsRegistryUtil.getConnectionFor(dc));
 		context.setPod(pod);
 
+		toggleDebugger(context, monitor);
+		
+		return this;
+	}
+
+	protected IPod getNewPod(IProgressMonitor monitor, IDeploymentConfig dc, Connection connection) throws CoreException {
+		IPod pod;
+		if (updateDebugmode(dc, context, monitor)
+				| updateDevmode(dc, context, monitor)) {
+			send(dc, connection, monitor);
+			// do not kill all existing pods, the rc will re-create new ones before the
+			// updated dc eventually then kills them and re-creates new ones.
+			pod = waitForNewPod(dc, monitor);
+		} else {
+			// dc already correctly set, so just get the pod
+			pod = getExistingPod(dc, connection, monitor);
+		}
+		return pod;
+	}
+
+	private void toggleDebugger(DebugContext context, IProgressMonitor monitor) throws CoreException {
 		if (context.isDebugEnabled()) {
 			IDebugListener listener = context.getDebugListener();
 			if (listener != null) {
 				listener.onDebugChange(context, monitor);
 			}
 		}
-		
-		return this;
 	}
 
-	protected IPod getPod(IDeploymentConfig dc, Connection connection, IProgressMonitor monitor) {
+	protected IPod getExistingPod(IDeploymentConfig dc, Connection connection, IProgressMonitor monitor) {
 		monitor.subTask(NLS.bind("Retrieving existing pod for deployment config {0}.", dc.getName()));
 
 		List<IPod> allPods = connection.getResources(ResourceKind.POD, dc.getNamespace());
@@ -252,8 +206,10 @@ public class OpenShiftDebugMode {
 
 		boolean needsUpdate = needsDebugUpdate(dc, context);
 		if (needsUpdate) {
+			updateContainerDebugPort(dc, context);
 			updateDebugEnvVariables(dc, context);
 		}
+		
 		return needsUpdate;
 	}
 
@@ -261,6 +217,74 @@ public class OpenShiftDebugMode {
 		boolean debugEnabled = isDebugEnabled(dc, 
 				context.getDevmodeKey(), context.getDebugPortKey(), context.getDebugPort(), context.isDebugEnabled());
 		return debugEnabled != context.isDebugEnabled();
+	}
+
+	private void updateDebugEnvVariables(IDeploymentConfig dc, DebugContext context) {
+		if (context.isDebugEnabled()) {
+			dc.setEnvironmentVariable(context.getDebugPortKey(), String.valueOf(context.getDebugPort()));
+			dc.setEnvironmentVariable(context.getDevmodeKey(), String.valueOf(context.isDebugEnabled()));
+		} else {
+			dc.removeEnvironmentVariable(context.getDebugPortKey());
+			dc.removeEnvironmentVariable(context.getDevmodeKey());
+		}
+	}
+
+	private void updateContainerDebugPort(IDeploymentConfig dc, DebugContext context) {
+		Collection<IContainer> containers = dc.getContainers();
+		if (CollectionUtils.isEmpty(containers)) {
+			return;
+		}
+
+		// TODO: support multiple containers
+		IContainer firstContainer = containers.iterator().next();
+		IPort currentContainerPort = getCurrentContainerPort(firstContainer.getPorts());
+
+		boolean modified = false;
+		Set<IPort> ports = new HashSet<>(firstContainer.getPorts());
+		if (context.isDebugEnabled()) {
+			modified = addReplaceDebugPort(context.getDebugPort(), currentContainerPort, ports);
+		} else {
+			modified = removeDebugPort(currentContainerPort, ports);
+		}
+
+		if (modified) {
+			firstContainer.setPorts(ports); 
+		}
+	}
+
+	private IPort getCurrentContainerPort(Set<IPort> ports) {
+		return ports.stream()
+				.filter(p -> 
+					// find by name
+					DEBUG_PORT_NAME.equals(p.getName()))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private boolean addReplaceDebugPort(int debugPort, IPort existing, Set<IPort> ports) {
+		boolean modified = false;
+		if (matchesPort(debugPort, existing)) {
+			ports.remove(existing);
+			modified = true;
+		}
+		PortSpecAdapter newPort = new PortSpecAdapter(DEBUG_PORT_NAME, DEBUG_PORT_PROTOCOL, debugPort);
+		// use bit-wise OR to avoid short-circuit
+		modified = modified | ports.add(newPort);
+		return modified;
+	}
+
+	private boolean matchesPort(int debugPort, IPort currentContainerPort) {
+		return currentContainerPort != null 
+				&& currentContainerPort.getContainerPort() != debugPort;
+	}
+
+	private boolean removeDebugPort(IPort currentContainerPort, Set<IPort> ports) {
+		boolean modified = false;
+		if (currentContainerPort != null) {
+			ports.remove(currentContainerPort);
+			modified = true;
+		}
+		return modified;
 	}
 
 	private boolean updateDevmode(IDeploymentConfig dc, DebugContext context, IProgressMonitor monitor) {
@@ -302,26 +326,28 @@ public class OpenShiftDebugMode {
 		}
 	}
 
-	protected IPod sendAndGetNewPod(IDeploymentConfig dc, Connection connection, IProgressMonitor monitor) throws CoreException {
+	protected void send(IDeploymentConfig dc, Connection connection, IProgressMonitor monitor) throws CoreException {
 		monitor.subTask(NLS.bind("Updating deployment config {0} and waiting for new pods to run.", dc.getName()));
 
-		connection.updateResource(dc);
-		// do not kill all existing pods, the rc will re-create new ones before the
-		// updated dc eventually then kills them and re-creates new ones.
-		return waitForNewPod(dc, monitor);
+		try {
+			connection.updateResource(dc);
+		} catch (OpenShiftException e) {
+			throw new CoreException(
+					StatusFactory.errorStatus(OpenShiftCoreActivator.PLUGIN_ID, NLS.bind("Could update resource {0}.", dc.getName()), e));
+		}
 	}
 	
 	private IDeploymentConfig getDeploymentConfig(DebugContext context, IProgressMonitor monitor) throws CoreException {
 		return OpenShiftServerUtils.getDeploymentConfig(context.getServer(), monitor);
 	}
 
-	private IPod waitForNewPod(IDeploymentConfig dc, IProgressMonitor monitor) throws CoreException {
+	protected IPod waitForNewPod(IDeploymentConfig dc, IProgressMonitor monitor) throws CoreException {
 		NewPodDetectorJob newPodDetector = new NewPodDetectorJob(dc);
 		newPodDetector.schedule();
 		return waitFor(newPodDetector, monitor);
 	}
 
-	private IPod waitFor(NewPodDetectorJob podDetector, IProgressMonitor monitor) throws CoreException {
+	protected IPod waitFor(NewPodDetectorJob podDetector, IProgressMonitor monitor) throws CoreException {
 		try {
 			podDetector.join(NewPodDetectorJob.TIMEOUT, monitor);
 			IStatus result = podDetector.getResult();


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
