### PR TITLE
CDEServersView.getServer should override parent's getServer

### DIFF
--- a/test-framework/org.jboss.tools.cdk.reddeer/META-INF/MANIFEST.MF
+++ b/test-framework/org.jboss.tools.cdk.reddeer/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
  org.eclipse.reddeer.go;bundle-version="[2.0.0,2.1.0)",
- org.eclipse.ui.forms
+ org.eclipse.ui.forms,
+ org.eclipse.wst.server.core
 Export-Package: org.jboss.tools.cdk.reddeer.core.condition,
  org.jboss.tools.cdk.reddeer.core.matcher,
  org.jboss.tools.cdk.reddeer.preferences,
@@ -18,4 +19,3 @@ Export-Package: org.jboss.tools.cdk.reddeer.core.condition,
  org.jboss.tools.cdk.reddeer.server.ui,
  org.jboss.tools.cdk.reddeer.server.ui.editor,
  org.jboss.tools.cdk.reddeer.server.ui.wizard
-

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/ui/CDEServersView.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/ui/CDEServersView.java
@@ -14,17 +14,13 @@ import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 
 public class CDEServersView extends ServersView2 {
-	
-	protected boolean cdk3 = false;
-	
-	public CDEServersView(boolean cdk3) {
-		this.cdk3 = cdk3;
-	}
 
+	public CDEServersView() {
+		super();
+	}
+	
 	@Override
 	public Server getServer(String name) {
-		return super.getServer(CDEServer.class, name);
+		return getServer(CDEServer.class, name);
 	}
-	
-	
 }


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
