### PR TITLE
Fix missing plugin.xml in org.jboss.tools.openshift.io.core

### DIFF
--- a/plugins/org.jboss.tools.openshift.io.core/build.properties
+++ b/plugins/org.jboss.tools.openshift.io.core/build.properties
@@ -2,8 +2,6 @@ source.. = src/main/java/
 bin.includes = .,\
                META-INF/,\
                plugin.properties,\
-               pom.xml,\
-               lib/,\
-               schema/,\
-               lib/jjwt-0.8.0.jar
+               lib/jjwt-0.8.0.jar,\
+               plugin.xml
 output.. = target/classes/


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
