### PR TITLE
JBIDE-25167 - both cdk3 runtime detectors validate against cdk3 / 3.1

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/CDK3RuntimeDetector.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/CDK3RuntimeDetector.java
@@ -38,17 +38,15 @@ public class CDK3RuntimeDetector extends AbstractCDKRuntimeDetector{
 	public static final String PROP_CDK_VERSION = "cdk.version";
 	
 	public static final String OVERRIDE_MINISHIFT_LOCATION = "OVERRIDE_MINISHIFT_LOCATION";
-	
+
 	@Override
 	protected boolean validate(File root) {
 		boolean matchesHomeMinishift = isHomeDirectory(root.getParentFile()) && 
 				".minishift".equals(root.getName()) && super.validate(root);
-		if( matchesHomeMinishift )
-			return true;
-		
 		String envvar = System.getenv("MINISHIFT_HOME");
 		boolean matchesEnvVar = envvar != null && new File(envvar).exists() && super.validate(root);
-		if( matchesEnvVar ) {
+
+		if( matchesHomeMinishift || matchesEnvVar ) {
 			String vers = getDefinitionVersion(root);
 			if( matchesExpectedVersion(vers)) {
 				return true;

--- a/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
@@ -24,5 +24,6 @@ Require-Bundle: org.jboss.tools.common.core;bundle-version="3.7.0",
  org.jboss.tools.openshift.common.core,
  org.eclipse.debug.core,
  org.jboss.ide.eclipse.as.core;bundle-version="3.1.1",
- org.jboss.tools.openshift.core;bundle-version="3.3.0"
+ org.jboss.tools.openshift.core;bundle-version="3.3.0",
+ org.jboss.tools.runtime.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/AllTestsSuite.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/AllTestsSuite.java
@@ -14,6 +14,7 @@ import org.jboss.tools.openshift.cdk.server.test.internal.CDKDockerUtilityTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.CDKLaunchControllerTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.CDKOpenshiftUtilityTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.CDKRegistryTest;
+import org.jboss.tools.openshift.cdk.server.test.internal.CDKRuntimeDetectorTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.ServiceManagerParsingTest;
 import org.jboss.tools.openshift.cdk.server.test.internal.VagrantPollerTest;
 import org.junit.runner.RunWith;
@@ -27,7 +28,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	CDKOpenshiftUtilityTest.class,
 	CDKLaunchControllerTest.class,
 	VagrantPollerTest.class,
-	CDKRegistryTest.class
+	CDKRegistryTest.class,
+	CDKRuntimeDetectorTest.class
 })
 /**
  * @author Andre Dietisheim

--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/CDKRuntimeDetectorTest.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/CDKRuntimeDetectorTest.java
@@ -1,0 +1,83 @@
+package org.jboss.tools.openshift.cdk.server.test.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.jboss.ide.eclipse.as.core.util.FileUtil;
+import org.jboss.tools.runtime.core.model.IRuntimeDetector;
+import org.jboss.tools.runtime.core.model.RuntimeDefinition;
+import org.jboss.tools.runtime.core.model.RuntimePath;
+import org.jboss.tools.runtime.core.util.RuntimeInitializerUtil;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class CDKRuntimeDetectorTest extends TestCase {
+
+	@Test
+	public void testCDK30() {
+		testCDK("3.0.1", "org.jboss.tools.openshift.cdk.server.core.internal.detection.CDK3RuntimeDetector");
+	}
+
+	@Test
+	public void testCDK31() {
+		testCDK("3.1.1", "org.jboss.tools.openshift.cdk.server.core.internal.detection.CDK3RuntimeDetector");
+	}
+
+	@Test
+	public void testCDK32() {
+		testCDK("3.2.0-alpha.1-1", "org.jboss.tools.openshift.cdk.server.core.internal.detection.CDK32RuntimeDetector");
+	}
+	
+	public void testCDK(String version, String detectorId) {
+		try {
+			// Create a mock cdk30
+			createCDK(version);
+			RuntimePath runtimePath = new RuntimePath(getDotMinishift().getAbsolutePath());
+			List<RuntimeDefinition> runtimeDefinitions = RuntimeInitializerUtil.createRuntimeDefinitions(runtimePath, new NullProgressMonitor());
+			assertNotNull(runtimeDefinitions);
+			assertEquals(runtimeDefinitions.size(), 1);
+			RuntimeDefinition def = runtimeDefinitions.get(0);
+			assertNotNull(def);
+			IRuntimeDetector detector = def.getDetector();
+			assertNotNull(detector);
+			assertEquals(detector.getId(), detectorId);
+		} catch(IOException ioe) {
+			cleanupCDK();
+			fail();
+		}
+	}
+
+	private File getDotMinishift() {
+		File home = getHomeDirectory();
+		File minishift = new File(home, ".minishift");
+		return minishift;
+	}
+	private void cleanupCDK() {
+		File home = getHomeDirectory();
+		home.mkdirs();
+		File minishift = new File(home, ".minishift");
+		FileUtil.completeDelete(minishift);
+	}
+	private void createCDK(String version) throws IOException {
+		cleanupCDK();
+		File home = getHomeDirectory();
+		home.mkdirs();
+		File minishift = new File(home, ".minishift");
+		minishift.mkdir();
+		File config = new File(minishift, "config");
+		config.mkdir();
+		new File(config, "config.json").createNewFile();
+		String cdkFileContents = "openshift.auth.scheme=basic\nopenshift.auth.username=developer\nopenshift.auth.password=developer\ncdk.version=" + version;
+		FileUtil.writeTo(new ByteArrayInputStream(cdkFileContents.getBytes()), new File(minishift, "cdk"));
+	}
+	
+	
+	protected File getHomeDirectory() {
+		String home = System.getProperty("user.home");
+		return new File(home);
+	}
+}


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
