### PR TITLE
JBIDE-25192 - error with setting minishift_home in launch when editor…

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
@@ -25,7 +25,7 @@ public class CDK3Server extends CDKServer {
 	public static final String PROP_HYPERVISOR = "org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDKServer.hypervisor"; 
 	public static final String MINISHIFT_FILE = "minishift.file.location";
 	public static final String MINISHIFT_HOME = "minishift.home.location";
-	
+	public static final String DOT_MINISHIFT = ".minishift"; 
 	
 	public static final String[] getHypervisors() {
 		return getHypervisors(Platform.getOS());

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
@@ -108,10 +108,9 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 
 		Map<String, String> env = workingCopy.getAttribute(ENVIRONMENT_VARS_KEY, (Map<String, String>) null);
 		env = (env == null ? new HashMap<>() : new HashMap<>(env));
-		String msHome = s.getAttribute(CDK3Server.MINISHIFT_HOME, (String) null);
-		if (msHome != null) {
-			env.put("MINISHIFT_HOME", msHome);
-		}
+		
+		String msHome = getMinishiftHome(s);
+		env.put("MINISHIFT_HOME", msHome);
 
 		String userKey = cdkServer.getUserEnvironmentKey();
 		boolean passCredentials = cdkServer.passCredentials();
@@ -143,6 +142,15 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 		workingCopy.setAttribute(ATTR_ARGS, replaced);
 	}
 
+	protected String getMinishiftHome(IServer server) {
+		String home = System.getProperty("user.home");
+		String defaultMinishiftHome = new File(home, CDK3Server.DOT_MINISHIFT).getAbsolutePath();
+		String msHome = server.getAttribute(CDK3Server.MINISHIFT_HOME, defaultMinishiftHome);
+		if( !StringUtils.isEmpty(msHome))
+			msHome = defaultMinishiftHome;
+		return msHome;
+	}
+	
 	private void setMinishiftLocationOnLaunchConfig(CDKServer cdkServer, ILaunchConfigurationWorkingCopy workingCopy,
 			Map<String, String> env) throws CoreException {
 


### PR DESCRIPTION
… uses default value

Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
