### PR TITLE
JBIDE-25308 - minishift_home is not passed to launch command

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
@@ -56,7 +56,7 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 
 	@Override
 	public void initialize(ILaunchConfigurationWorkingCopy wc) throws CoreException {
-		final IServer s = ServerUtil.getServer(wc);
+		final IServer s = getServerFromLaunch(wc);
 		final CDKServer cdkServer = (CDKServer) s.loadAdapter(CDKServer.class, new NullProgressMonitor());
 		// for testing purposes.
 		// we can't mock final methods like getServer(), so we need to be creative
@@ -98,12 +98,23 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 		}
 		return profiles;
 	}
+	
+	protected IServer getServerFromLaunch(ILaunchConfigurationWorkingCopy wc) throws CoreException {
+		return ServerUtil.getServer(wc);
+	}
 
 	@Override
 	protected void performOverrides(ILaunchConfigurationWorkingCopy workingCopy) throws CoreException {
 		// Overrides, things that should always match whats in server editor
-		final IServer s = ServerUtil.getServer(workingCopy);
+		final IServer s = getServerFromLaunch(workingCopy);
 		final CDKServer cdkServer = (CDKServer) s.loadAdapter(CDKServer.class, new NullProgressMonitor());
+		performOverrides(workingCopy, s, cdkServer);
+	}
+	
+	/*
+	 * Not expected to be extended. 
+	 */
+	protected void performOverrides(ILaunchConfigurationWorkingCopy workingCopy, IServer s, CDKServer cdkServer) throws CoreException {
 		String workingDir = JBossServerCorePlugin.getServerStateLocation(s).toOSString();
 		workingCopy.setAttribute(ATTR_WORKING_DIR, workingDir);
 
@@ -148,7 +159,7 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 		String home = System.getProperty("user.home");
 		String defaultMinishiftHome = new File(home, CDKConstants.CDK_RESOURCE_DOTMINISHIFT).getAbsolutePath();
 		String msHome = server.getAttribute(CDK3Server.MINISHIFT_HOME, defaultMinishiftHome);
-		if( !StringUtils.isEmpty(msHome))
+		if( StringUtils.isEmpty(msHome))
 			msHome = defaultMinishiftHome;
 		return msHome;
 	}

--- a/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/META-INF/MANIFEST.MF
@@ -27,3 +27,5 @@ Require-Bundle: org.jboss.tools.common.core;bundle-version="3.7.0",
  org.jboss.tools.openshift.core;bundle-version="3.3.0",
  org.jboss.tools.runtime.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Activator: org.jboss.tools.openshift.cdk.server.test.CDKTestActivator
+Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/CDKTestActivator.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/CDKTestActivator.java
@@ -1,0 +1,14 @@
+package org.jboss.tools.openshift.cdk.server.test;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+
+public class CDKTestActivator extends AbstractUIPlugin {
+	static CDKTestActivator instance;
+	public static CDKTestActivator getDefault() {
+		return instance;
+	}
+	public CDKTestActivator() {
+		instance = this;
+	}
+
+}

--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/CDK32LaunchControllerTest.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/CDK32LaunchControllerTest.java
@@ -11,23 +11,31 @@
 package org.jboss.tools.openshift.cdk.server.test.internal;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.List;
+import java.util.Map;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.IServerType;
+import org.eclipse.wst.server.core.ServerUtil;
 import org.jboss.tools.openshift.cdk.server.core.internal.CDKConstants;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDK32Server;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDK3Server;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDKServer;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.controllers.CDK3LaunchController;
+import org.jboss.tools.openshift.cdk.server.test.CDKTestActivator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.AdditionalAnswers;
@@ -35,14 +43,21 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class CDK32LaunchControllerTest {
-	
-	private CDK3LaunchController controller;
-	
-	@Before
-	public void setUp() {
-		controller = new CDK3LaunchController();
+	private class CDK3TestLaunchController extends CDK3LaunchController {
+		private IServer s23;
+		private CDKServer cdk;
+		public CDK3TestLaunchController(IServer s, CDKServer cdk) {
+			s23 = s;
+			this.cdk = cdk;
+		}
+		public void initialize(ILaunchConfigurationWorkingCopy wc) throws CoreException {
+			initialize(wc, cdk.getUsername(), s23);
+		}
+		protected void performOverrides(ILaunchConfigurationWorkingCopy workingCopy) throws CoreException {
+			performOverrides(workingCopy, s23, cdk);
+		}
 	}
-
+	
 	@Test
 	public void testInitialize() throws Exception {
 		
@@ -53,7 +68,8 @@ public class CDK32LaunchControllerTest {
 		ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<String> valCaptor = ArgumentCaptor.forClass(String.class);
 		
-		
+		CDKServer cdkServer = (CDKServer) server.loadAdapter(CDKServer.class, new NullProgressMonitor());
+		CDK3TestLaunchController controller = new CDK3TestLaunchController(server, cdkServer);
 		controller.initialize(wc, userName, server);
 		verify(wc, Mockito.times(3)).setAttribute(keyCaptor.capture(), valCaptor.capture());
 		List<String> allKeys = keyCaptor.getAllValues();
@@ -64,6 +80,37 @@ public class CDK32LaunchControllerTest {
 		assertTrue(allVals.get(2).endsWith("--profile minishift start --vm-driver=virtualbox"));
 	}
 	
+	@Test
+	public void testSetupWithMinishiftHome() throws Exception {
+		
+		ILaunchConfigurationWorkingCopy wc = mock(ILaunchConfigurationWorkingCopy.class);
+		when(wc.getAttribute(any(String.class), any(String.class))).thenAnswer(AdditionalAnswers.returnsSecondArg());
+		String userName = "Drumpf";
+		IPath msHome = CDKTestActivator.getDefault().getStateLocation().append("test927");
+		msHome.toFile().mkdirs();
+		IServer server = mockServerWithMSHome(msHome);
+		ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+		Class<Map<String, String>> mapClass = (Class<Map<String, String>>)(Class)Map.class;
+		ArgumentCaptor<Map<String, String>> valCaptor = ArgumentCaptor.forClass(mapClass);
+		
+		CDKServer cdkServer = (CDKServer) server.loadAdapter(CDKServer.class, new NullProgressMonitor());
+		CDK3TestLaunchController controller = new CDK3TestLaunchController(server, cdkServer);
+		controller.setupLaunchConfiguration(wc, new NullProgressMonitor());
+		verify(wc, Mockito.times(2)).setAttribute(keyCaptor.capture(), valCaptor.capture());
+		List<String> allKeys = keyCaptor.getAllValues();
+		List<Map<String, String>> allVals = valCaptor.getAllValues();
+		
+		Map<String, String> latest = allVals.get(allVals.size()-1);
+		String val1 = latest.get("MINISHIFT_HOME");
+		assertEquals(msHome.toOSString(), val1);
+	}
+	private IServer mockServerWithMSHome(IPath home2) {
+		IServer server = mockServer();
+		String home = System.getProperty("user.home");
+		String defaultMinishiftHome = new File(home, CDKConstants.CDK_RESOURCE_DOTMINISHIFT).getAbsolutePath();
+		when(server.getAttribute(CDK32Server.MINISHIFT_HOME, defaultMinishiftHome)).thenReturn(home2.toOSString());
+		return server;
+	}
 	private IServer mockServer() {
 		IServer server = mock(IServer.class);
 		when(server.getAttribute(CDKServer.PROP_PASS_CREDENTIALS, false)).thenReturn(Boolean.TRUE);


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
