### PR TITLE
[JBIDE-25121] - Connection wizard: Image Registry URL is not decorated when not valid (and validation seems weird)

### DIFF
--- a/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/connection/v3/CreateNewConnectionTest.java
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/connection/v3/CreateNewConnectionTest.java
@@ -23,13 +23,17 @@ import org.eclipse.reddeer.core.exception.CoreLayerException;
 import org.eclipse.reddeer.junit.execution.annotation.RunIf;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.eclipse.reddeer.swt.api.Browser;
+import org.eclipse.reddeer.swt.condition.ControlIsEnabled;
 import org.eclipse.reddeer.swt.condition.ShellIsAvailable;
 import org.eclipse.reddeer.swt.impl.browser.InternalBrowser;
 import org.eclipse.reddeer.swt.impl.button.CancelButton;
+import org.eclipse.reddeer.swt.impl.button.FinishButton;
 import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.eclipse.reddeer.swt.impl.button.YesButton;
 import org.eclipse.reddeer.swt.impl.combo.LabeledCombo;
+import org.eclipse.reddeer.swt.impl.label.DefaultLabel;
 import org.eclipse.reddeer.swt.impl.shell.DefaultShell;
+import org.eclipse.reddeer.swt.impl.text.DefaultText;
 import org.eclipse.reddeer.swt.impl.text.LabeledText;
 import org.jboss.tools.common.reddeer.label.IDELabel.ServerType;
 import org.jboss.tools.common.reddeer.utils.StackTraceUtils;
@@ -119,8 +123,26 @@ public class CreateNewConnectionTest {
 
 		new CancelButton().click();
 	}
+	
+	@Test
+	public void invalidRegistryURLShouldReportErrorMessage() {
+		openConnectionWizardAndSetDefaultServer();
+		new LabeledCombo(OpenShiftLabel.TextLabels.PROTOCOL).setSelection(AuthenticationMethod.BASIC.toString());
+		new LabeledText(OpenShiftLabel.TextLabels.USERNAME).setText(DatastoreOS3.USERNAME);
+		new LabeledText(OpenShiftLabel.TextLabels.PASSWORD).setText(DatastoreOS3.PASSWORD);
+		new PushButton(OpenShiftLabel.Button.ADVANCED_OPEN).click();
+		new LabeledText(OpenShiftLabel.TextLabels.IMAGE_REGISTRY_URL).setText("invalidURL");
+		new WaitUntil(new ControlIsEnabled(new CancelButton()), TimePeriod.DEFAULT);
+		new WaitUntil(new ControlIsEnabled(new DefaultText(" Please provide a valid image registry (HTTP/S) URL.")), TimePeriod.DEFAULT);
+		new CancelButton().click();
+	}
 
 	private void openConnectionWizardAndSetDefaultServerOAuth() {
+		openConnectionWizardAndSetDefaultServer();
+		new LabeledCombo(OpenShiftLabel.TextLabels.PROTOCOL).setSelection(AuthenticationMethod.OAUTH.toString());
+	}
+
+	private void openConnectionWizardAndSetDefaultServer() {
 		OpenShiftExplorerView openShiftExplorerView = new OpenShiftExplorerView();
 		openShiftExplorerView.open();
 		openShiftExplorerView.openConnectionShell();
@@ -128,7 +150,6 @@ public class CreateNewConnectionTest {
 		new LabeledCombo(OpenShiftLabel.TextLabels.SERVER_TYPE)
 				.setSelection(OpenShiftLabel.Others.OPENSHIFT3);
 		new LabeledCombo(OpenShiftLabel.TextLabels.SERVER).setText(DatastoreOS3.SERVER);
-		new LabeledCombo(OpenShiftLabel.TextLabels.PROTOCOL).setSelection(AuthenticationMethod.OAUTH.toString());
 	}
 
 	private void login(final InternalBrowser internalBrowser) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/AdvancedConnectionEditor.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/AdvancedConnectionEditor.java
@@ -133,11 +133,14 @@ public class AdvancedConnectionEditor extends BaseDetailsView implements IAdvanc
 				UIUtils.setDefaultButtonWidth(registryDiscover);
 				
 				registryURLObservable = WidgetProperties.text(SWT.Modify).observeDelayed(DELAY, txtRegistry);
-				ValueBindingBuilder.bind(registryURLObservable)
+				Binding registryURLBinding = ValueBindingBuilder.bind(registryURLObservable)
 					.validatingAfterConvert(new URLValidator(VALIDATOR_URL_TYPE, true))
 					.converting(new TrimTrailingSlashConverter())
 					.to(BeanProperties.value(AdvancedConnectionEditorModel.PROP_REGISTRY_URL).observe(model))
 					.in(dbc);
+				ControlDecorationSupport
+					.create(registryURLBinding, SWT.LEFT | SWT.TOP);
+
 				
                 Label lblNamespace = new Label(advancedComposite, SWT.NONE);
                 lblNamespace.setText("Cluster namespace:");

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
@@ -235,6 +235,7 @@ public class OpenShiftLabel {
 		public static final String TOKEN = "Token";
 		public static final String RETRIEVE_TOKEN = "Enter a token or retrieve a new one.";
 		public static final String LINK_RETRIEVE = "retrieve";
+		public static final String IMAGE_REGISTRY_URL = "Image Registry URL:";
 
 		// Domain related
 		public static final String DOMAIN_NAME = "Domain Name:";


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
