### PR TITLE
[JBIDE-25382] - CDK32LaunchControllerTest fails on Windows

### DIFF
--- a/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/CDK32LaunchControllerTest.java
+++ b/tests/org.jboss.tools.openshift.cdk.server.test/src/org/jboss/tools/openshift/cdk/server/test/internal/CDK32LaunchControllerTest.java
@@ -59,7 +59,7 @@ public class CDK32LaunchControllerTest {
 		List<String> allKeys = keyCaptor.getAllValues();
 		List<String> allVals = valCaptor.getAllValues();
 		
-		assertTrue(allVals.get(0).endsWith(".metadata/.plugins/org.jboss.ide.eclipse.as.core"));
+		assertTrue(allVals.get(0).replace("\\", "/").endsWith(".metadata/.plugins/org.jboss.ide.eclipse.as.core"));
 		assertTrue(allVals.get(1).endsWith("/home/user/apps/minishift"));
 		assertTrue(allVals.get(2).endsWith("--profile minishift start --vm-driver=virtualbox"));
 	}


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
