### PR TITLE
JBIDE-25396 Overwrite registry URL confirmation dialog change from MessageBox class to MessageDialog

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/AdvancedConnectionEditor.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/connection/AdvancedConnectionEditor.java
@@ -40,6 +40,8 @@ import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.databinding.fieldassist.ControlDecorationSupport;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.osgi.util.NLS;
@@ -51,7 +53,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.jboss.tools.common.databinding.ObservablePojo;
@@ -308,13 +309,12 @@ public class AdvancedConnectionEditor extends BaseDetailsView implements IAdvanc
 				// Verify with user
 				String title = "Overwrite registry URL?";
 				String msg = "Are you sure you want to change the registry URL from " + oldVal + " to " + newVal + "?";
-				MessageBox mb = new MessageBox(shell, SWT.OK | SWT.CANCEL);
-				mb.setText(title);
-				mb.setMessage(msg);
+				MessageDialog dialog = new MessageDialog(shell, title, null, 
+						msg, MessageDialog.CONFIRM, new String[] {"OK", "Cancel"}, 0);
 				String old = registryURLObservable.getValue().toString().trim();
-				if(old.isEmpty() || mb.open() == SWT.OK ) {
+				if(old.isEmpty() || dialog.open() == IDialogConstants.OK_ID ) {
 					registryURLObservable.setValue(ret.getMessage());
-				} 
+				}
 			}
 		} else {
 			String title = "Registry URL not found";


### PR DESCRIPTION
Change of implementation of MessageBox (using built-in dialogs) dialog to MessageDialog class that comes from JFace layer and can be operated with RedDeer framework.

Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
