### PR TITLE
JBIDE-25227- increase widget spacing so control decorator is visible

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/SelectProjectComponentBuilder.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/SelectProjectComponentBuilder.java
@@ -121,7 +121,7 @@ public class SelectProjectComponentBuilder {
 		browseProjectsButton.setText("Browse...");
 		GridDataFactory.fillDefaults()
 				.align(SWT.LEFT, SWT.CENTER)
-				.grab(false, false)
+				.indent(10, SWT.DEFAULT)
 				.applyTo(browseProjectsButton);
 		UIUtils.setDefaultButtonWidth(browseProjectsButton);
 		browseProjectsButton.addSelectionListener(selectionListener);

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
@@ -527,6 +527,7 @@ public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implem
 		browseSourceButton.setText("Browse...");
 		GridDataFactory.fillDefaults()
 				.align(SWT.FILL, SWT.CENTER)
+				.indent(10, SWT.DEFAULT)
 				.applyTo(browseSourceButton);		
 		browseSourceButton.addSelectionListener(onBrowseSource(browseSourceButton.getShell()));
 


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
