### PR TITLE
JBIDE-25262 - ensure server state can be stopped if minishift-home disappears

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
@@ -10,8 +10,12 @@
  ******************************************************************************/ 
 package org.jboss.tools.openshift.cdk.server.core.internal.adapter;
 
+import java.io.File;
+
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.openshift.cdk.server.core.internal.CDKConstants;
+import org.jboss.tools.openshift.common.core.utils.StringUtils;
 
 public class CDK3Server extends CDKServer {
 
@@ -63,5 +67,12 @@ public class CDK3Server extends CDKServer {
 	public String getPasswordEnvironmentKey() {
 		return getServer().getAttribute(CDKServer.PROP_PASS_ENV_VAR, CDKConstants.CDK3_ENV_SUB_PASS_KEY);
 	}
-	
+	public String getMinishiftHome() {
+		String home = System.getProperty("user.home");
+		String defaultMinishiftHome = new File(home, CDKConstants.CDK_RESOURCE_DOTMINISHIFT).getAbsolutePath();
+		String msHome = getServer().getAttribute(CDK3Server.MINISHIFT_HOME, defaultMinishiftHome);
+		if( StringUtils.isEmpty(msHome))
+			msHome = defaultMinishiftHome;
+		return msHome;
+	}
 }

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/AbstractCDKShutdownController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/AbstractCDKShutdownController.java
@@ -84,11 +84,7 @@ public abstract class AbstractCDKShutdownController extends AbstractSubsystemCon
 		getControllableBehavior().putSharedData(AbstractStartJavaServerLaunchDelegate.NEXT_STOP_REQUIRES_FORCE, val);
 	}
 	
-	
-	@Override
-	public void stop(boolean force) {
-		getBehavior().setServerStopping();
-
+	protected void pollState() {
 		IStatus state = PollThreadUtils.isServerStarted(getServer(), getCDKPoller(getServer()));
 		boolean started = state.isOK();
 		if( !started ) {
@@ -99,7 +95,19 @@ public abstract class AbstractCDKShutdownController extends AbstractSubsystemCon
 				return;
 			}
 		}
-		
+	}
+	
+	@Override
+	public void stop(boolean force) {
+		getBehavior().setServerStopping();
+		pollState();
+		if( getServer().getServerState() == IServer.STATE_STOPPED) {
+			return;
+		}
+		issueShutdownCommand();
+	}
+	
+	protected void issueShutdownCommand() {
 		try {
 			if( useTerminal() )
 				shutdownViaTerminal();


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
