### PR TITLE
[JBIDE-25347] - cdk file kept open preventing delete from the command line

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/AbstractCDKRuntimeDetector.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/AbstractCDKRuntimeDetector.java
@@ -13,6 +13,7 @@ package org.jboss.tools.openshift.cdk.server.core.internal.detection;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Properties;
 
@@ -81,8 +82,8 @@ public abstract class AbstractCDKRuntimeDetector extends AbstractRuntimeDetector
 	protected Properties readProperties(File cdkFile) {
 		Properties props = new Properties();
 		if (cdkFile.exists()) {
-			try {
-				props.load(new FileInputStream(cdkFile));
+			try (InputStream is = new FileInputStream(cdkFile)){
+				props.load(is);
 			} catch (IOException ioe) {
 				// Ignore
 			}


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
