### PR TITLE
[JBIDE-25514] - Build to not allow goal dependency:tree

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -45,7 +45,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.7</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>get-libs</id>

--- a/plugins/org.jboss.tools.openshift.express.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.express.client/pom.xml
@@ -24,7 +24,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.7</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>get-libs</id>

--- a/plugins/org.jboss.tools.openshift.io.core/pom.xml
+++ b/plugins/org.jboss.tools.openshift.io.core/pom.xml
@@ -19,7 +19,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version><!--$NO-MVN-MAN-VER$-->
                 <executions>
                     <execution>
                         <id>get-libs</id>

--- a/plugins/org.jboss.tools.openshift.ui/pom.xml
+++ b/plugins/org.jboss.tools.openshift.ui/pom.xml
@@ -19,7 +19,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.7</version><!--$NO-MVN-MAN-VER$-->
                 <executions>
                     <execution>
                         <id>get-libs</id>


### PR DESCRIPTION
- Removed version of maven-dependency-plugin as its given by parent

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
