### PR TITLE
[JBIDE-25514]- Build to not allow goal dependency:tree

### DIFF
--- a/tests/org.jboss.tools.openshift.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.test/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.7</version><!--$NO-MVN-MAN-VER$ -->
 				<executions>
 					<execution>
 						<id>get-libs</id>


### PR DESCRIPTION
- Fix in org.jboss.tools.openshift.test

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
