### PR TITLE
JBIDE-25514 remove maven-dependency-plugin...

### DIFF
--- a/tests/org.jboss.tools.openshift.io.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.io.test/pom.xml
@@ -20,7 +20,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version><!--$NO-MVN-MAN-VER$-->
                 <executions>
                     <execution>
                         <id>get-libs</id>

--- a/tests/org.jboss.tools.openshift.test/pom.xml
+++ b/tests/org.jboss.tools.openshift.test/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.7</version><!--$NO-MVN-MAN-VER$ -->
 				<executions>
 					<execution>
 						<id>get-libs</id>


### PR DESCRIPTION
JBIDE-25514 remove maven-dependency-plugin versions; inherit this from parent pom

Signed-off-by: nickboldt <nboldt@redhat.com>