### PR TITLE
Rewrite OCBinary requirement to be configurable

### DIFF
--- a/itests/org.jboss.tools.openshift.ui.bot.test/pom.xml
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 
 	<properties>
 		<systemProperties>
-			-Dtest.configurations.dir=${configurations.dir} -Dopenshift.server=${openshift.server} -Dopenshift.username=${openshift.username} -Dopenshift.password=${openshift.password} -Dopenshift.token=${openshift.token} -Dopenshift.authmethod=${openshift.authmethod} -Dsecurestorage.password=${securestorage.password} -Dusage_reporting_enabled=false -Dopenshift.io.username=${openshift.io.username} -Dopenshift.io.password=${openshift.io.password}
+			-Dtest.configurations.dir=${configurations.dir} -Dopenshift.server=${openshift.server} -Dopenshift.username=${openshift.username} -Dopenshift.password=${openshift.password} -Dopenshift.token=${openshift.token} -Dopenshift.authmethod=${openshift.authmethod} -Dsecurestorage.password=${securestorage.password} -Dusage_reporting_enabled=false -Dopenshift.io.username=${openshift.io.username} -Dopenshift.io.password=${openshift.io.password} -Doc.linux.latest=${oc.linux.latest} -Doc.windows.latest=${oc.windows.latest} -Doc.mac.latest=${oc.mac.latest} -Doc.linux.1.1.64=${oc.linux.1.1.64} -Doc.windows.1.1.64=${oc.windows.1.1.64} -Doc.mac.1.1.64=${oc.mac.1.1.64}
 		</systemProperties>
 		<test.class>org.jboss.tools.openshift.ui.bot.test.OpenShift3StableBotTests</test.class>
 		<surefire.timeout>7200</surefire.timeout>
@@ -28,6 +28,14 @@
 		<github.username></github.username>
 		<github.password></github.password>
 		<securestorage.password></securestorage.password>
+		<oc.link.base>https://github.com/openshift/origin/releases/download</oc.link.base>
+		<oc.linux.1.1.64>${oc.link.base}/v1.1.0.1/openshift-origin-client-tools-v1.1.0.1-bf56e23-linux-64bit.tar.gz</oc.linux.1.1.64>
+		<oc.windows.1.1.64>${oc.link.base}/v1.1.0.1/openshift-origin-client-tools-v1.1.0.1-bf56e23-windows.zip</oc.windows.1.1.64>
+		<oc.mac.1.1.64>${oc.link.base}/v1.1.0.1/openshift-origin-client-tools-v1.1.0.1-bf56e23-mac.zip</oc.mac.1.1.64>
+		<oc.linux.latest>${oc.link.base}/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-linux-64bit.tar.gz</oc.linux.latest>
+		<oc.windows.latest>${oc.link.base}/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-windows.zip</oc.windows.latest>
+		<oc.mac.latest>${oc.link.base}/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-mac.zip</oc.mac.latest>
+		
 	</properties>
 
 	<build>

--- a/itests/org.jboss.tools.openshift.ui.bot.test/resources/oclinks.properties
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/resources/oclinks.properties
@@ -1,0 +1,6 @@
+oc.linux.1.1.64=https://github.com/openshift/origin/releases/download/v1.1.0.1/openshift-origin-client-tools-v1.1.0.1-bf56e23-linux-64bit.tar.gz
+oc.windows.1.1.64=https://github.com/openshift/origin/releases/download/v1.1.0.1/openshift-origin-client-tools-v1.1.0.1-bf56e23-windows.zip
+oc.mac.1.1.64=https://github.com/openshift/origin/releases/download/v1.1.0.1/openshift-origin-client-tools-v1.1.0.1-bf56e23-mac.zip
+oc.linux.latest=https://github.com/openshift/origin/releases/download/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-linux-64bit.tar.gz
+oc.mac.latest=https://github.com/openshift/origin/releases/download/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-mac.zip
+oc.windows.latest=https://github.com/openshift/origin/releases/download/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-windows.zip

--- a/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/common/OCBinaryLocationTest.java
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/common/OCBinaryLocationTest.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.ui.bot.test.common;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
@@ -27,7 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-@OCBinary
+@OCBinary(cleanup=false, setOCInPrefs=true)
 public class OCBinaryLocationTest {
 	
 	private WorkbenchPreferenceDialog dialog;
@@ -43,8 +44,13 @@ public class OCBinaryLocationTest {
 	}
 	
 	@Test
+	public void testOClocationSetByRequirement() {
+		assertTrue(page.getOCLocation().getText().contains("binaries/oc"));
+	}
+	
+	@Test
 	public void testSetValidOCLocation() {
-		page.setOCLocation(OpenShiftCommandLineToolsRequirement.getOCLocation());
+		page.setOCLocation(OpenShiftCommandLineToolsRequirement.getDefaultOCLocation());
 		
 		try {
 			new WaitUntil(new ControlIsEnabled(new PushButton(OpenShiftLabel.Button.APPLY)), 
@@ -68,7 +74,6 @@ public class OCBinaryLocationTest {
 	
 	@After
 	public void closeDialog() {
-		page.clearOCLocation();
 		dialog.cancel();
 	}
 }

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/preference/page/OpenShift3PreferencePage.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/preference/page/OpenShift3PreferencePage.java
@@ -36,7 +36,7 @@ public class OpenShift3PreferencePage extends PreferencePage {
 	 * @param path path to oc binary
 	 */
 	public void setOCLocation(String path) {
-		new LabeledText(OpenShiftLabel.TextLabels.OC_LOCATION).setText(path);
+		getOCLocation().setText(path);
 	}
 	
 	/**
@@ -44,6 +44,10 @@ public class OpenShift3PreferencePage extends PreferencePage {
 	 */
 	public void clearOCLocation() {
 		setOCLocation("");
+	}
+	
+	public LabeledText getOCLocation() {
+		return new LabeledText(OpenShiftLabel.TextLabels.OC_LOCATION);
 	}
 }
 

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftCommandLineToolsRequirement.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftCommandLineToolsRequirement.java
@@ -18,85 +18,206 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Properties;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.reddeer.common.logging.Logger;
 import org.eclipse.reddeer.junit.requirement.Requirement;
+import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.jboss.tools.openshift.reddeer.exception.OpenShiftToolsException;
+import org.jboss.tools.openshift.reddeer.preference.page.OpenShift3PreferencePage;
 import org.jboss.tools.openshift.reddeer.requirement.OpenShiftCommandLineToolsRequirement.OCBinary;
+import org.jboss.tools.openshift.reddeer.utils.DatastoreOS3;
 import org.jboss.tools.openshift.reddeer.utils.FileHelper;
+import org.jboss.tools.openshift.reddeer.utils.SystemProperties;
+import org.jboss.tools.openshift.reddeer.utils.TestUtils;
 
 /**
  * Requirement to download and extract OpenShift command line tools binary which is necessary 
- * for some functionality of OpenShift tools.
+ * for some functionality of OpenShift and CDK tools. 
+ * Loads up properties file with links to different oc versions.
  *  
  * @author mlabuda@redhat.com
  * @author adietish@redhat.com
+ * @author odockal@redhat.com
  *
  */
 public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinary> {
 
+	private static final Logger LOGGER = new Logger(OpenShiftCommandLineToolsRequirement.class);
 	private static final String CLIENT_TOOLS_DESTINATION = "binaries";
 	private static final String SUFFIX_TAR_GZ = ".tar.gz";
 	private static final String SUFFIX_ZIP = ".zip";
-	
-	private static final Logger LOGGER = new Logger(OpenShiftCommandLineToolsRequirement.class);
+	private static final Properties properties = TestUtils.readPropertiesFile(TestUtils.getProjectAbsolutePath("resources" + File.separator + "oclinks.properties"));
+	private WorkbenchPreferenceDialog dialog;
+	private OpenShift3PreferencePage page;
+	private String pathToOC;
+	private OCBinary binary;
 	
 	@Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface OCBinary {
+		/**
+		 * Decides whether existing oc on pathToOC path will be used.
+		 * Is in exclusion with downloadNewestOC.
+		 * @return false is default value
+		 */
+		boolean ocExists() default false;
+		
+		/**
+		 * Path to existing oc, ie. one that is configured within minishift setup-cdk
+		 * @return path to existing oc
+		 */
+		String pathToOC() default StringUtils.EMPTY;
+		
+		/**
+		 * Sets if default oc version or newest will be downloaded
+		 * @return true or false
+		 */
+		boolean latestOC() default true;
+		
+		/**
+		 * If set to true, given oc will be set into 
+		 * Preferences -> JBoss Tools -> OpenShift 3 -> oc executable location field
+		 * @return true or false
+		 */
+		boolean setOCInPrefs() default false;
+		
+		/**
+		 * Will delete downloaded  and copied oc if set to true, is not used when ocExists=true.
+		 * Setting cleanup to false will result in keeping extracted and copied oc in predefined folder.
+		 * Note that requirement is not able to find out version of such oc and
+		 * could use the one already in folder instead of downloading new/old one as required.
+		 * @return default true to delete resources - oc, false otherwise
+		 */
+		boolean cleanup() default true;
     }
+	
+	/**
+	 * Returns string representation of path to proper oc
+	 * @return
+	 */
+	public String getPathToOC() {
+		return this.pathToOC;
+	}
 
 	@Override
 	public void fulfill() {
-		if (!OCBinaryFile.get().getFile().exists()) {
-			// symlink does not exist or exists but points to inexistent file
-			File downloadedOCBinary = downloadAndExtractOpenShiftClient();
-			createSymlink(downloadedOCBinary);
+		if (!binary.ocExists()) {
+			if (!OCBinaryFile.get().getFile().exists()) {
+				String url = getDownloadLink(binary.latestOC());
+				LOGGER.info("OC binary will be downloaded from " + url);
+				File downloadedOCBinary = downloadAndExtractOpenShiftClient(url);
+				// windows has problem with previously defined symlinks, we will used copied oc from extracted 
+				// createSymLink method was used
+				this.pathToOC = copyOCFromExtractedFolder(downloadedOCBinary);
+			} else {
+				this.pathToOC = OCBinaryFile.get().getFile().getAbsolutePath();
+				LOGGER.info("Binary is already downloaded at " + getPathToOC());
+			}
 		} else {
-			LOGGER.info("Binary is already downloaded.");
+			LOGGER.info("External OC binary will be used");
+			File oc = new File(binary.pathToOC());
+			if (oc.exists()) {
+				LOGGER.info("OC binary is at " + oc.getAbsolutePath());
+				this.pathToOC = oc.getAbsolutePath();
+			} else {
+				throw new OpenShiftToolsException("Given path to OC binary does not exist: " + binary.pathToOC());
+			}
+		}
+		if (binary.setOCInPrefs()) {
+			setOCToPreferences(getPathToOC());
 		}
 	}
-
-	private void createSymlink(File downloadedOCBinary) {
+	
+	private String copyOCFromExtractedFolder(File downloadedOCBinary) {
 		try {
-			Files.deleteIfExists(Paths.get(OCBinaryFile.get().getFile().toURI()));
-			Files.createSymbolicLink(OCBinaryFile.get().getFile().toPath(), Paths.get(downloadedOCBinary.getAbsolutePath()));
+			return Files.copy(Paths.get(downloadedOCBinary.getAbsolutePath()),
+					OCBinaryFile.get().getFile().toPath(),
+					StandardCopyOption.REPLACE_EXISTING).toAbsolutePath().toString();
 		} catch (IOException e) {
-			throw new OpenShiftToolsException(NLS.bind("Could not symlink {0} to {1}:\n{2}", 
+			throw new OpenShiftToolsException(NLS.bind("Could not copy {0} to {1}:\n{2}", 
 					new Object[] { OCBinaryFile.get().getFile().getAbsolutePath(), downloadedOCBinary.getAbsolutePath(), e }));
 		}
 	}
 
 	@Override
-	public void setDeclaration(OCBinary declaration) {}
+	public void setDeclaration(OCBinary declaration) {
+		this.binary = declaration;
+	}
 
 	@Override
-	public void cleanUp() {}
+	public void cleanUp() {
+		setOCToPreferences("");
+		if (!binary.ocExists() && binary.cleanup()) {
+			deleteOnPathIfExists(getPathToOC());
+		}
+	}
 	
-	public static String getOCLocation() {
+	private void deleteOnPathIfExists(String path) {
+		try {
+			URI uri = new File(path).toURI();
+			LOGGER.info("Going to delete URI resources on path: " + uri.getPath());
+			Files.deleteIfExists(Paths.get(uri));
+		} catch (IOException e) {
+			LOGGER.error(e.getMessage());
+			throw new OpenShiftToolsException("Deleting files on path " + path + " was not successful, cause: " + e.getMessage());
+		}		
+	}
+
+	@Override
+	public OCBinary getDeclaration() {
+		return this.binary;
+	}
+	
+	private void setOCToPreferences(String path) {
+		openDialogAndSelectPage();
+		setOCLocation(path);
+		closeDialog();
+	}
+	
+	private void openDialogAndSelectPage() {
+		dialog = new WorkbenchPreferenceDialog();
+		page = new OpenShift3PreferencePage(dialog);
+		
+		dialog.open();
+		dialog.select(page);
+	}
+	
+	private void setOCLocation(String location) {
+		page.setOCLocation(location);
+		page.apply();
+	}
+	
+	private void closeDialog() {
+		dialog.cancel();
+	}
+	
+	public static String getDefaultOCLocation() {
 		return OCBinaryFile.get().getFile().getAbsolutePath();
 	}
 	
-	private File downloadAndExtractOpenShiftClient() {
+	private File downloadAndExtractOpenShiftClient(String url) {
 		LOGGER.info("Creating directory binaries");
 		File outputDirectory = new File(CLIENT_TOOLS_DESTINATION);
 		FileHelper.createDirectory(outputDirectory);
 
-		String fileName = downloadArchive(getDownloadLink());
+		String fileName = downloadArchive(url);
 		String extractedDirectory = extractArchive(fileName, outputDirectory);
 
 		if (StringUtils.isEmpty(extractedDirectory)
 			|| !(new File(extractedDirectory).exists())) {
 				throw new OpenShiftToolsException("Cannot extract archive " + fileName + ". "
-						+ "Archive does not extract into a single root folder.");
+						+ "Archive does not extract into a single root folder");
 		}
 
 		return new File(extractedDirectory, OCBinaryFile.get().getName());
@@ -112,17 +233,20 @@ public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinar
 			URL downloadUrl = new URL(downloadLink);
 			fileName = getFileName(downloadUrl.getPath());
 			if (new File(fileName).exists()) {
+				LOGGER.info(fileName + " already exists, it will not be downloaded");
 				return fileName;
 			}
 			try (FileOutputStream fileOutputStream = new FileOutputStream(fileName);
 					ReadableByteChannel readableByteChannel = Channels.newChannel(downloadUrl.openStream())) {
-				LOGGER.info("Downloading OpenShift binary.");
+				LOGGER.info("Downloading OpenShift binary");
 				fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
 			} catch (IOException ex) {
-				throw new OpenShiftToolsException("Cannot download OpenShift binary.\n" + ex.getMessage());
+				// clean up after unsuccessful downloading
+				deleteOnPathIfExists(fileName);
+				throw new OpenShiftToolsException("Cannot download OpenShift binary\n" + ex.getMessage());
 			}
 		} catch (MalformedURLException e) {
-			throw new OpenShiftToolsException(NLS.bind("Could not download \"{0}\". Invalid url.", downloadLink));
+			throw new OpenShiftToolsException(NLS.bind("Could not download \"{0}\". Invalid url", downloadLink));
 		}
 		return fileName;
 	}
@@ -132,14 +256,22 @@ public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinar
 			return null;
 		}
 
-		LOGGER.info(NLS.bind("Extracting OpenShift archive {0}.", fileName));
+		LOGGER.info(NLS.bind("Extracting OpenShift archive {0}", fileName));
 		String extractedDirectory = null;
 		if (fileName.endsWith(SUFFIX_ZIP)) {
 			extractedDirectory = StringUtils.chomp(fileName, SUFFIX_ZIP);
-			FileHelper.unzipFile(new File(fileName), outputDirectory);
+			if (!new File(extractedDirectory + File.separator + OCBinaryFile.get().getName()).exists()) {
+				FileHelper.unzipFile(new File(fileName), outputDirectory);
+			} else {
+				LOGGER.info("OC in path " + extractedDirectory + " already exists");
+			}
 		} else if (fileName.endsWith(SUFFIX_TAR_GZ)) {
 			extractedDirectory = StringUtils.chomp(fileName, SUFFIX_TAR_GZ);
-			FileHelper.extractTarGz(new File(fileName), outputDirectory);
+			if (!new File(extractedDirectory + File.separator + OCBinaryFile.get().getName()).exists()) {
+				FileHelper.extractTarGz(new File(fileName), outputDirectory);
+			} else {
+				LOGGER.info("OC in path " + extractedDirectory + " already exists");
+			}
 		}
 
 		return extractedDirectory;
@@ -150,61 +282,47 @@ public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinar
 		return Paths.get(CLIENT_TOOLS_DESTINATION, pathParts[pathParts.length - 1]).toString();
 	}
 	
-	private String getDownloadLink() {
+	private String getDownloadLink(boolean newOC) {
 		if (Platform.OS_LINUX.equals(Platform.getOS())) {
-			if (Platform.getOSArch().equals(Platform.ARCH_X86)) {
-				return ClientVersion.LINUX_1_3_32.getDownloadLink();
-			} else { 
-				return ClientVersion.LINUX_1_3_64.getDownloadLink();
-			}
+			return newOC ? ClientVersion.LINUX_LATEST.getDownloadLink() : ClientVersion.LINUX_1_1_64.getDownloadLink();
 		} else if (Platform.getOS().startsWith(Platform.OS_WIN32) && Platform.getOSArch().equals(Platform.ARCH_X86_64)){
-			return ClientVersion.WINDOWS_1_3_64.getDownloadLink();
+			return newOC ? ClientVersion.WINDOWS_LATEST.getDownloadLink() : ClientVersion.WINDOWS_1_1_64.getDownloadLink();
 		} else if (Platform.OS_MACOSX.equals(Platform.getOS())){
-			return ClientVersion.MAC_1_3.getDownloadLink();
+			return newOC ? ClientVersion.MAC_LATEST.getDownloadLink() : ClientVersion.MAC_1_1_64.getDownloadLink();
 		} else {
 			return null;
 		}
 	}
 	
 	public enum ClientVersion {
-		LINUX_1_1_32("https://github.com/openshift/origin/releases/download/"
-				+ "v1.1/openshift-origin-v1.1-ac7a99a-linux-386.tar.gz"),
-		LINUX_1_1_64("https://github.com/openshift/origin/releases/download/"
-				+ "v1.1/openshift-origin-v1.1-ac7a99a-linux-amd64.tar.gz"),
-		WINDOWS_1_1_64("https://github.com/openshift/origin/releases/download/"
-				+ "v1.1/openshift-origin-v1.1-ac7a99a-windows-amd64.zip"),
-		
-		LINUX_1_2_32("https://github.com/openshift/origin/releases/download/"
-				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-linux-32bit.tar.gz"),
-		LINUX_1_2_64("https://github.com/openshift/origin/releases/download/"
-				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-linux-64bit.tar.gz"),
-		WINDOWS_1_2_64("https://github.com/openshift/origin/releases/download/"
-				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-windows.zip"),
-		MAC_1_2("https://github.com/openshift/origin/releases/download/" 
-				+ "v1.2.0/openshift-origin-client-tools-v1.2.0-2e62fab-mac.zip"),
-		
-		LINUX_1_3_32("https://github.com/openshift/origin/releases/download/"
-				+ "v1.3.2/openshift-origin-client-tools-v1.3.2-ac1d579-linux-32bit.tar.gz"),
-		LINUX_1_3_64("https://github.com/openshift/origin/releases/download/"
-				+ "v1.3.2/openshift-origin-client-tools-v1.3.2-ac1d579-linux-64bit.tar.gz"),
-		WINDOWS_1_3_64("https://github.com/openshift/origin/releases/download/"
-				+ "v1.3.2/openshift-origin-client-tools-v1.3.2-ac1d579-windows.zip"),
-		MAC_1_3("https://github.com/openshift/origin/releases/download/"
-				+ "v1.3.2/openshift-origin-client-tools-v1.3.2-ac1d579-mac.zip");
+		LINUX_1_1_64(DatastoreOS3.KEY_OC_LINUX_1_1_64),
+		WINDOWS_1_1_64(DatastoreOS3.KEY_OC_WINDOWS_1_1_64),
+		MAC_1_1_64(DatastoreOS3.KEY_OC_MAC_1_1_64),
+
+		LINUX_LATEST(DatastoreOS3.KEY_OC_LINUX_LATEST),
+		MAC_LATEST(DatastoreOS3.KEY_OC_MAC_LATEST),
+		WINDOWS_LATEST(DatastoreOS3.KEY_OC_WINDOWS_LATEST);
 		
 		String url;
+		String keyName;
 		
-		private ClientVersion(String url) {
-			this.url = url;
+		ClientVersion(String keyName) {
+			this.keyName = keyName;
+			this.url = SystemProperties.getRequiredProperty(this.keyName, properties.getProperty(this.keyName, ""), "Searched property " + keyName + " is not passed,"
+					+ " please add it in form -D" + keyName + "=linkToOC");
+		}
+		
+		public String getKeyName() {
+			return keyName;
 		}
 		
 		public String getDownloadLink() {
 			return url;
-		}		
+		}
 	}
 
 	public enum OCBinaryFile {
-		LINUX("oc"), 
+		LINUX("oc"),
 		MAC("oc"),
 		WINDOWS("oc.exe");
 
@@ -234,10 +352,5 @@ public class OpenShiftCommandLineToolsRequirement implements Requirement<OCBinar
 			}
 
 		}
-	}
-
-	@Override
-	public OCBinary getDeclaration() {
-		return null;
 	}
 }

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/DatastoreOS3.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/DatastoreOS3.java
@@ -35,6 +35,12 @@ public class DatastoreOS3 {
 	private static final String KEY_TOKEN = "openshift.token";
 	public static final String KEY_PASSWORD = "openshift.password";
 	public static final String KEY_NEXUS_MIRROR = "openshift.nexus.mirror";
+	public static final String KEY_OC_LINUX_1_1_64 = "oc.linux.1.1.64";
+	public static final String KEY_OC_WINDOWS_1_1_64 = "oc.windows.1.1.64";
+	public static final String KEY_OC_MAC_1_1_64 = "oc.mac.1.1.64";
+	public static final String KEY_OC_LINUX_LATEST = "oc.linux.latest";
+	public static final String KEY_OC_WINDOWS_LATEST = "oc.windows.latest";
+	public static final String KEY_OC_MAC_LATEST = "oc.mac.latest";
 	
 	static {
 		AuthenticationMethod authMethod = AuthenticationMethod.safeValueOf(

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/OpenShiftLabel.java
@@ -283,7 +283,7 @@ public class OpenShiftLabel {
 		
 		// Labels
 		public static final String LABEL = "Label:";
-		public static final String OC_LOCATION = "'oc' executable location";
+		public static final String OC_LOCATION = "'oc" + (TestUtils.getOS().contains("windows") ? ".exe" : "") + "' executable location";
 		public static final String VALUE = "Value:";
 		public static final String REMOTE_REQUEST_TIMEOUT = "Remote requests timeout (in seconds):";
 		public static final String FIND_FREE_PORTS = "Find free local ports for remote ports";

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/TestUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/TestUtils.java
@@ -11,9 +11,11 @@
 package org.jboss.tools.openshift.reddeer.utils;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Properties;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.api.Git;
@@ -45,7 +47,7 @@ public class TestUtils {
 		dialog.open();
 		dialog.select(page);
 		if (setUp) {
-			page.setOCLocation(OpenShiftCommandLineToolsRequirement.getOCLocation());
+			page.setOCLocation(OpenShiftCommandLineToolsRequirement.getDefaultOCLocation());
 		} else {
 			page.clearOCLocation();
 		}
@@ -109,6 +111,10 @@ public class TestUtils {
 		}
 	}
 	
+	public static String getOS() {
+		return System.getProperty("os.name").toLowerCase();
+	}
+	
 	public static void cleanupGitFolder(String appname) {
 		File gitDir = new File(System.getProperty("user.home") + File.separatorChar + "git");
 		cleanupGitFolder(gitDir, appname);
@@ -141,6 +147,40 @@ public class TestUtils {
 			return defaultValue;
 		}
 		return value;
+	}
+	
+	/**
+	 * Provide resource absolute path in project directory
+	 * @param path - resource relative path
+	 * @return resource absolute path
+	 */
+	public static String getProjectAbsolutePath(String... path) {
+
+		// Construct path
+		StringBuilder builder = new StringBuilder();
+		for (String fragment : path) {
+			builder.append("/" + fragment);
+		}
+
+		String filePath = System.getProperty("user.dir");
+		File file = new File(filePath + builder.toString());
+		if (!file.exists()) {
+			throw new RedDeerException("Resource file does not exists within project path "
+					+ filePath + builder.toString());
+		}
+
+		return file.getAbsolutePath();
+	}
+	
+	public static Properties readPropertiesFile(String filePath) {
+		Properties properties = new Properties();
+		File file = new File(filePath);
+		try (FileInputStream fis = new FileInputStream(file)) {
+			properties.load(fis);
+		} catch (IOException exc) {
+			exc.printStackTrace();
+		}
+		return properties;
 	}
 
 	/**


### PR DESCRIPTION
   - Downloaded oc is copied from extracted folder instead of being symlinked
   - OCBinary takes multiple parameters, bool: cleanup, setInPrefs, ocExists, downloadNewestOC
   - String param: pathToOC

Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
