### PR TITLE
Don't show OSIO icon if Analytics plugin is installed

### DIFF
--- a/plugins/org.jboss.tools.openshift.io.ui/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.io.ui/plugin.xml
@@ -28,6 +28,18 @@
                   icon="icons/osio-16x16.png"
                   label="%openshiftio.command.gettoken"
                   style="push">
+               <visibleWhen
+                     checkEnabled="false">
+                  <not>
+                     <with
+                           variable="org.eclipse.core.runtime.Platform">
+                        <test
+                              args="com.redhat.fabric8analytics.lsp.eclipse.ui"
+                              property="org.eclipse.core.runtime.isBundleInstalled">
+                        </test>
+                     </with>
+                  </not>
+               </visibleWhen>
             </command>
          </toolbar>
       </menuContribution>


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
