### PR TITLE
[JBIDE-22773] - Openshift server adapter can't start with eap64-basic-s2i template on Windows: can't copy MANIFEST.MF reported

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/OpenShiftCoreMessages.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/OpenShiftCoreMessages.java
@@ -20,6 +20,11 @@ public class OpenShiftCoreMessages extends NLS {
 	public static String OCBinaryLocationIncompatibleErrorMessage;
 	public static String OCBinaryLocationDontExistsErrorMessage;
 	public static String NoOCBinaryLocationErrorMessage;
+	public static String RsyncNotFoundMessage;
+	public static String RsyncFstabNotFoundMessage;
+	public static String RsyncFstabNotFoundDetailedMessage;
+	public static String RsyncFstabInvalidMessage;
+	public static String RsyncFstabInvalidDetailedMessage;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/OpenShiftCoreMessages.properties
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/OpenShiftCoreMessages.properties
@@ -15,3 +15,9 @@ RunOnOpenshift=Run on Openshift
 OCBinaryLocationIncompatibleErrorMessage=OpenShift client version 1.1.1 or higher is required to avoid rsync issues. You may <a>download</a> and/or <a>configure</a> a newer version.
 OCBinaryLocationDontExistsErrorMessage=OpenShift client ({0}) does not exists. You may <a>download</a> and/or <a>configure</a> a new one.
 NoOCBinaryLocationErrorMessage=OpenShift client not configured. You may <a>download</a> and/or <a>configure</a> it.
+
+RsyncNotFoundMessage=rsync executable not found, check your environnment.
+RsyncFstabNotFoundMessage=etc/fstab file not found, check your environment.
+RsyncFstabNotFoundDetailedMessage=The file {0}/etc/fstab does not exist. On Windows systems, it's likely causing permissions issues, so we recommand to have one. See this article <a>https://tools.jboss.org/blog/rsync-windows-env.html</a> or <a>http://cygwin.com/cygwin-ug-net/using.html#mount-table</a> for more details. You can <a>refresh</a> this message once your environment is updated.
+RsyncFstabInvalidMessage=etc/fstab invalid, noacl is not set.
+RsyncFstabInvalidDetailedMessage=The file {0}/etc/fstab does not have the noacl flag set. On Windows systems, it's likely causing permissions issues, so we recommand to have it set. See this article <a>https://tools.jboss.org/blog/rsync-windows-env.html</a> or <a>http://cygwin.com/cygwin-ug-net/using.html#mount-table</a> for more details.  You can <a>refresh</a> this message once your environment is updated.

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/util/RSyncValidator.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/util/RSyncValidator.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc..
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Incorporated - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.openshift.internal.core.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.osgi.util.NLS;
+
+import org.jboss.tools.openshift.core.OpenShiftCoreMessages;
+
+/**
+ * Utility to validate rsync environment. On Linux, check if rsync is on the
+ * PATH. On Windows, check if rsync is on the PATH and if the fstab file has the
+ * noacl bit set.
+ */
+public class RSyncValidator {
+
+	public enum RsyncStatus {
+		RSYNC_NOT_FOUND(OpenShiftCoreMessages.RsyncNotFoundMessage), ETC_FSTAB_NOT_FOUND(
+				OpenShiftCoreMessages.RsyncFstabNotFoundMessage,
+				OpenShiftCoreMessages.RsyncFstabNotFoundDetailedMessage), ETC_FSTAB_INVALID(
+						OpenShiftCoreMessages.RsyncFstabInvalidMessage,
+						OpenShiftCoreMessages.RsyncFstabInvalidDetailedMessage), OK("");
+
+		private final String message;
+
+		private final String detailedMessage;
+
+		private RsyncStatus(String message, String detailedMessage) {
+			this.message = message;
+			this.detailedMessage = detailedMessage;
+		}
+
+		private RsyncStatus(String message) {
+			this(message, message);
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public String getDetailedMessage(String base) {
+			return NLS.bind(detailedMessage, base);
+		}
+	}
+
+	private static RSyncValidator INSTANCE;
+
+	public static RSyncValidator get() {
+		if (INSTANCE == null) {
+			INSTANCE = new RSyncValidator();
+		}
+		return INSTANCE;
+
+	}
+
+	private RsyncStatus status = RsyncStatus.OK;
+
+	private String rsyncPath;
+
+	private static final String ETC_FSTAB_LOCATION = "etc/fstab";
+
+	private RSyncValidator() {
+		try {
+			rsyncPath = getRSyncPath();
+			refresh();
+		} catch (IOException e) {
+			status = RsyncStatus.RSYNC_NOT_FOUND;
+		}
+	}
+
+	public void refresh() {
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			checkFstab();
+		}
+	}
+
+	public RsyncStatus getStatus() {
+		return status;
+	}
+
+	public String getBasePath() {
+		return (rsyncPath != null) ? Paths.get(rsyncPath).getParent().getParent().toString() : "";
+	}
+
+	private String getRSyncPath() throws IOException {
+		ProcessBuilder builder;
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			builder = new ProcessBuilder("where", "rsync.exe");
+		} else {
+			builder = new ProcessBuilder("which", "rsync");
+		}
+		Process process = builder.start();
+		String path;
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+			path = reader.readLine();
+		}
+		try {
+			if (process.waitFor() == 0) {
+				return path;
+			} else {
+				throw new IOException();
+			}
+		} catch (InterruptedException e) {
+			throw new IOException(e);
+		}
+	}
+
+	private void checkFstab() {
+		File f = new File(getBasePath(), ETC_FSTAB_LOCATION);
+		if (f.exists()) {
+			String line = null;
+			status = RsyncStatus.ETC_FSTAB_INVALID;
+			try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
+				while ((line = reader.readLine()) != null) {
+					if (!line.startsWith("#")) {
+						if (line.contains("cygdrive") && line.contains("noacl")) {
+							status = RsyncStatus.OK;
+						}
+					}
+				}
+			} catch (IOException e) {
+				status = RsyncStatus.ETC_FSTAB_INVALID;
+			}
+
+		} else {
+			status = RsyncStatus.ETC_FSTAB_NOT_FOUND;
+		}
+	}
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -27,6 +27,7 @@ import org.jboss.tools.openshift.common.core.utils.ProjectUtils;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.server.OpenShiftServerUtils;
 import org.jboss.tools.openshift.core.util.OpenShiftResourceUniqueId;
+import org.jboss.tools.openshift.internal.core.util.RSyncValidator.RsyncStatus;
 import org.jboss.tools.openshift.internal.common.ui.utils.DataBindingUtils;
 import org.jboss.tools.openshift.internal.ui.treeitem.ObservableTreeItem;
 
@@ -51,7 +52,7 @@ public class OpenShiftServerEditorModel extends ServerSettingsWizardPageModel {
 	private IObservableValue<String> debugPortValueObservable;
 
 	public OpenShiftServerEditorModel(IServerWorkingCopy server, ServerEditorSection section, Connection connection) {
-		super(null, null, null, connection, server, Status.OK_STATUS);
+		super(null, null, null, connection, server, Status.OK_STATUS, RsyncStatus.OK);
 		this.section = section;
 
 		initChangelisteners(server, section);
@@ -95,7 +96,8 @@ public class OpenShiftServerEditorModel extends ServerSettingsWizardPageModel {
 			boolean useImageDebugPortKey, String debugPortKey, boolean useImageDebugPortValue, String debugPortValue) {
 		update(connection, connections, deployProject, projects, sourcePath, podPath, isUseInferredPodPath, resource,
 				resourceItems, route, isSelectDefaultRoute, routesByProject, getOCBinaryStatus(), useImageDevmodeKey,
-				devmodeKey, useImageDebugPortKey, debugPortKey, useImageDebugPortValue, debugPortValue);
+				devmodeKey, useImageDebugPortKey, debugPortKey, useImageDebugPortValue, debugPortValue,
+				getRsyncStatus());
 		firePropertyChange(PROPERTY_OVERRIDE_PROJECT, this.overrideProject, this.overrideProject = overrideProject);
 	}
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ServerSettingsWizardPage.java
@@ -139,6 +139,7 @@ import com.openshift.restclient.model.route.IRoute;
  * @author Jeff Maury
  */
 public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implements ICompletable {
+	private static final int LINK_DEFAULT_WIDTH = 600;
 	private static final String DOWNLOAD_LINK_TEXT = "download";
 	private static final String REFRESH_LINK_TEXT = "refresh";
 	private static final int RESOURCE_PANEL_WIDTH = 800;
@@ -372,7 +373,7 @@ public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implem
 				}
 			}
 		});
-		GridDataFactory.fillDefaults().hint(600, SWT.DEFAULT).applyTo(link);
+		GridDataFactory.fillDefaults().hint(LINK_DEFAULT_WIDTH, SWT.DEFAULT).applyTo(link);
 		MultiValidator validator = new MultiValidator() {
 
 			@Override
@@ -442,7 +443,7 @@ public class ServerSettingsWizardPage extends AbstractOpenShiftWizardPage implem
 						}
 					}
 				}).in(dbc);
-		GridDataFactory.fillDefaults().hint(600, SWT.DEFAULT).applyTo(link);
+		GridDataFactory.fillDefaults().hint(LINK_DEFAULT_WIDTH, SWT.DEFAULT).applyTo(link);
 		link.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/NewApplicationWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v10.html
@@ -41,6 +41,7 @@ import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.connection.ConnectionsRegistryUtil;
 import org.jboss.tools.openshift.core.server.OpenShiftServerUtils;
 import org.jboss.tools.openshift.core.util.OpenShiftResourceUniqueId;
+import org.jboss.tools.openshift.internal.core.util.RSyncValidator;
 import org.jboss.tools.openshift.internal.common.core.UsageStats;
 import org.jboss.tools.openshift.internal.common.core.job.JobChainBuilder;
 import org.jboss.tools.openshift.internal.common.ui.utils.OpenShiftUIUtils;
@@ -123,12 +124,11 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 	@Override
 	public void addPages() {
 		/*
-		 * list --> template params -------------------------------> labels -> done
-		 *   |                                                    |
-		 *    ----> buildconfig -> deployconfig -> serviceconfig -|
+		 * list --> template params -------------------------------> labels -> done | |
+		 * ----> buildconfig -> deployconfig -> serviceconfig -|
 		 */
 
-		//app from image
+		// app from image
 		BuildConfigPage bcPage = new BuildConfigPage(this, fromImageModel) {
 			@Override
 			public boolean isPageComplete() {
@@ -150,13 +150,13 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 
 		};
 
-		//app from template
+		// app from template
 		TemplateParametersPage paramPage = new TemplateParametersPage(this, fromTemplateModel) {
 
 			@Override
 			public boolean isPageComplete() {
 				return isTemplateFlow() ?
-				//force visiting parameters page
+				// force visiting parameters page
 				getContainer() != null && !(getContainer().getCurrentPage() instanceof ApplicationSourceListPage)
 						&& super.isPageComplete() : true;
 			}
@@ -222,7 +222,7 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 					Display.getDefault().syncExec(createJob.getSummaryRunnable(getShell()));
 					OpenShiftUIUtils.showOpenShiftExplorer();
 					if (model.getEclipseProject() != null) {
-						//No need to import the project from git, it's already here
+						// No need to import the project from git, it's already here
 						return;
 					}
 					Collection<IResource> resources = createJob.getResources();
@@ -309,7 +309,8 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 					IServerWorkingCopy server = OpenShiftServerUtils.create(OpenShiftResourceUniqueId.get(service));
 					ServerSettingsWizardPageModel serverModel = new ServerSettingsWizardPageModel(service, route,
 							project, connection, server,
-							OCBinary.getInstance().getStatus(connection, new NullProgressMonitor()));
+							OCBinary.getInstance().getStatus(connection, new NullProgressMonitor()),
+							RSyncValidator.get().getStatus());
 					serverModel.loadResources();
 					serverModel.updateServer();
 					server.setAttribute(OpenShiftServerUtils.SERVER_START_ON_CREATION, false);
@@ -355,7 +356,7 @@ public class NewApplicationWizard extends Wizard implements IWorkbenchWizard, IC
 	public void setConnection(Connection connection) {
 		model.setConnection(connection);
 		if (model == null || fromImageModel == null) {
-			//wizard is disposed by canceling the creation of a required project;
+			// wizard is disposed by canceling the creation of a required project;
 			return;
 		}
 		fromImageModel.setConnection(connection);


### PR DESCRIPTION
- Add check for rsync environment

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
