### PR TITLE
JBIDE-25215 ServerAdapterFromResourceTest fix

### DIFF
--- a/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/OpenShift3StableBotTests.java
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/OpenShift3StableBotTests.java
@@ -14,6 +14,7 @@ import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.openshift.ui.bot.test.application.v3.adapter.CreateServerAdapterTest;
 import org.jboss.tools.openshift.ui.bot.test.application.v3.adapter.ImportApplicationWizardGitTest;
 import org.jboss.tools.openshift.ui.bot.test.application.v3.adapter.ImportApplicationWizardTest;
+import org.jboss.tools.openshift.ui.bot.test.application.v3.adapter.ServerAdapterFromResourceTest;
 import org.jboss.tools.openshift.ui.bot.test.application.v3.adapter.ServerAdapterWizardHandlingTest;
 import org.jboss.tools.openshift.ui.bot.test.application.v3.advanced.CreateResourcesTest;
 import org.jboss.tools.openshift.ui.bot.test.application.v3.advanced.EditResourceLimitsTest;
@@ -78,6 +79,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	// Server adapter
 	ServerAdapterWizardHandlingTest.class,
 	CreateServerAdapterTest.class,
+	ServerAdapterFromResourceTest.class,
 	
 })
 public class OpenShift3StableBotTests extends AbstractBotTests {

--- a/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/adapter/ServerAdapterFromResourceTest.java
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/adapter/ServerAdapterFromResourceTest.java
@@ -87,7 +87,7 @@ public class ServerAdapterFromResourceTest extends AbstractTest  {
 		explorer = new OpenShiftExplorerView();
 		explorer.open();
 		project = explorer.getOpenShift3Connection().getProject(DatastoreOS3.TEST_PROJECT);
-		project.getService(OpenShiftResources.NODEJS_SERVICE).select();
+		project.getServicesWithName(OpenShiftResources.NODEJS_SERVICE).get(0).select();
 		
 		new ContextMenuItem(OpenShiftLabel.ContextMenu.IMPORT_APPLICATION).select();
 		new WaitUntil(new ShellIsAvailable(OpenShiftLabel.Shell.IMPORT_APPLICATION));
@@ -103,8 +103,14 @@ public class ServerAdapterFromResourceTest extends AbstractTest  {
 			LOGGER.debug("No existing project found, importing");
 		}
 		
-		appWizard.selectExistingBuildConfiguration(OpenShiftResources.NODEJS_APP_DEPLOYMENT_CONFIG);
-		appWizard.finish();
+		try {
+			appWizard.finish();
+		} catch (WaitTimeoutExpiredException ex) {
+			//When running test in suite, it needs to be selected correct build config(in OpenShift instance could be more build configs)
+			appWizard.selectExistingBuildConfiguration(OpenShiftResources.NODEJS_APP_DEPLOYMENT_CONFIG);
+			appWizard.finish();
+		}
+		
 		new WaitUntil(new OpenShiftResourceExists(Resource.DEPLOYMENT, OpenShiftResources.NODEJS_APP_REPLICATION_CONTROLLER, ResourceState.UNSPECIFIED, DatastoreOS3.TEST_PROJECT), TimePeriod.LONG);
 	}	
 	

--- a/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/CreateResourcesTest.java
+++ b/itests/org.jboss.tools.openshift.ui.bot.test/src/org/jboss/tools/openshift/ui/bot/test/application/v3/advanced/CreateResourcesTest.java
@@ -124,7 +124,7 @@ public class CreateResourcesTest extends AbstractTest  {
 
 		new DefaultShell(OpenShiftLabel.Shell.NEW_RESOURCE);
 
-		assertTrue("Selected project has not been selected for new resource creationg.",
+		assertTrue("Selected project has not been selected for new resource creation.",
 				new LabeledCombo(OpenShiftLabel.TextLabels.PROJECT).getSelection().equals(testProject));
 
 		new LabeledText(OpenShiftLabel.TextLabels.RESOURCE_LOCATION).setText(pathToResource);


### PR DESCRIPTION
Signed-off-by: Josef Kopriva <jkopriva@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
