### PR TITLE
jbide-25551: disable formatter until Oxygen.3 release in March 2018

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 					<!-- skipFormatting disables both format and validate goals, 
 					think of it as a switch for the whole plugin;
 					To apply from terminal use -Dformatter.skip=false -->
-					<!-- <skipFormatting>true</skipFormatting> --> 
+					<skipFormatting>true</skipFormatting>
 						<directories>
 							<directory>src</directory>
 						</directories>


### PR DESCRIPTION
after trying a workaround described here https://github.com/revelc/formatter-maven-plugin/issues/260: wrap javadocs with html into @formatter:off/on, i decided to disable the plugin by now, because this workaround didn't help for some reason.

So we need to wait for `org.eclipse.jdt.core` release of version equal or above 3.14.0 in March 2018. 
