### PR TITLE
[JBIDE-25166] - Resource wizard: using (formally valid) URL to non-existing/erroneous json does not show error message

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/resource/NewResourceWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/resource/NewResourceWizard.java
@@ -30,7 +30,6 @@ import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.connection.ConnectionsRegistryUtil;
 import org.jboss.tools.openshift.internal.common.ui.utils.OpenShiftUIUtils;
 import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
-import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 import org.jboss.tools.openshift.internal.ui.OpenshiftUIConstants;
 import org.jboss.tools.openshift.internal.ui.dialog.ResourceSummaryDialog;
 import org.jboss.tools.openshift.internal.ui.job.CreateResourceJob;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/resource/NewResourceWizard.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/resource/NewResourceWizard.java
@@ -47,6 +47,8 @@ public class NewResourceWizard extends Wizard implements IWorkbenchWizard {
 
 	private NewResourceWizardModel model;
 
+	private ResourcePayloadPage page;
+
 	public NewResourceWizard(NewResourceWizardModel model) {
 		setWindowTitle("New OpenShift resource");
 		setNeedsProgressMonitor(true);
@@ -73,7 +75,7 @@ public class NewResourceWizard extends Wizard implements IWorkbenchWizard {
 
 	@Override
 	public void addPages() {
-		addPage(new ResourcePayloadPage(this, model));
+		addPage(page = new ResourcePayloadPage(this, model));
 	}
 
 	@Override
@@ -105,7 +107,7 @@ public class NewResourceWizard extends Wizard implements IWorkbenchWizard {
 			IStatus status = runInWizard(createJob, createJob.getDelegatingProgressMonitor(), getContainer());
 			success = isSuccess(status);
 		} catch (InvocationTargetException | InterruptedException | IOException e) {
-			OpenShiftUIActivator.getDefault().getLogger().logError(e);
+			page.setErrorMessage(e.getClass().getName() + ": " + e.getLocalizedMessage());
 			success = false;
 		}
 		return success;


### PR DESCRIPTION
- Display error message if exception is thrown during content retrieval

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
