### PR TITLE
[JBIDE-25743] - Permissions errors on Windows when rsyncing to Online OpenShift environments

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
@@ -18,7 +18,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.concurrent.Executors;
 
-import org.eclipse.core.internal.runtime.PlatformURLFragmentConnection;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Red Hat Inc..
+ * Copyright (c) 2016-2018 Red Hat Inc..
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.concurrent.Executors;
 
+import org.eclipse.core.internal.runtime.PlatformURLFragmentConnection;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.ide.eclipse.as.core.server.IServerConsoleWriter;
@@ -102,7 +104,7 @@ public class RSync {
 			@Override
 			public IRSyncable visit(IRSyncable rsyncable) {
 				final InputStream syncStream = rsyncable.sync(new PodPeer(podPath, pod), new LocalPeer(destinationPath),
-						OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER, OpenShiftBinaryOption.SKIP_TLS_VERIFY);
+						getOptions());
 				asyncWriteLogs(syncStream, consoleWriter);
 				try {
 					rsyncable.await();
@@ -116,6 +118,16 @@ public class RSync {
 		}, null);
 	}
 
+	protected OpenShiftBinaryOption[] getOptions() {
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			return new OpenShiftBinaryOption[] { OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER,
+					OpenShiftBinaryOption.SKIP_TLS_VERIFY, OpenShiftBinaryOption.NO_PERMS };
+		} else {
+			return new OpenShiftBinaryOption[] { OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER,
+					OpenShiftBinaryOption.SKIP_TLS_VERIFY };
+		}
+	}
+
 	private void syncDirectoryToPod(final IPod pod, final File source, final String podPath,
 			final IServerConsoleWriter consoleWriter) throws IOException {
 		String sourcePath = sanitizePath(source.getAbsolutePath());
@@ -123,7 +135,7 @@ public class RSync {
 			@Override
 			public IRSyncable visit(IRSyncable rsyncable) {
 				final InputStream syncStream = rsyncable.sync(new LocalPeer(sourcePath), new PodPeer(podPath, pod),
-						OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER, OpenShiftBinaryOption.SKIP_TLS_VERIFY);
+						getOptions());
 				asyncWriteLogs(syncStream, consoleWriter);
 				try {
 					rsyncable.await();
@@ -140,8 +152,10 @@ public class RSync {
 	 * Asynchronously writes the logs from the 'rsync' command, provided by the
 	 * given {@code syncStream} into the given {@code outputStream}.
 	 * 
-	 * @param syncStream the {@link InputStream} to read from
-	 * @param outputStream the {@link OutputStream} to write into
+	 * @param syncStream
+	 *            the {@link InputStream} to read from
+	 * @param outputStream
+	 *            the {@link OutputStream} to write into
 	 */
 	private void asyncWriteLogs(final InputStream syncStream, final IServerConsoleWriter consoleWriter) {
 		Executors.newSingleThreadExecutor().execute(() -> {
@@ -173,7 +187,7 @@ public class RSync {
 		if (path.endsWith(slash) || path.endsWith(slash + ".")) { //$NON-NLS-1$ //$NON-NLS-2$
 			return path;
 		}
-		return path + slash; //$NON-NLS-1$
+		return path + slash; // $NON-NLS-1$
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
