### PR TITLE
jbide-25765: DateTimeParseException due to java 9 migration

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/DateTimeUtils.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/DateTimeUtils.java
@@ -12,8 +12,11 @@ package org.jboss.tools.openshift.internal.common.ui.utils;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -53,9 +56,11 @@ public class DateTimeUtils {
 		DateTimeFormatter dtf = DateTimeFormatter.ISO_INSTANT;
 		if (timezone != null) {
 		    dtf = dtf.withZone(timezone.toZoneId());
+		} else {
+		    dtf = dtf.withZone(ZoneOffset.UTC);
 		}
 		ZonedDateTime zonedDateTime = ZonedDateTime.parse(value, dtf);
-		return zonedDateTime.format(DateTimeFormatter.ofPattern("dd/MM/yy h:mm:ss a VV"));
+        return zonedDateTime.format(DateTimeFormatter.ofPattern("dd/MM/yy h:mm:ss a VV"));
 	}
 
 	public static Date parse(String value) throws ParseException {

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/ui/utils/DateTimeUtilsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/common/ui/utils/DateTimeUtilsTest.java
@@ -55,9 +55,15 @@ public class DateTimeUtilsTest {
 	}
 
 	@Test
-	public void testFormatSince() {
+	public void testFormatSinceWithTimeZone() {
 		String date = "2015-11-11T20:32:37Z";
 		assertEquals("11/11/15 3:32:37 PM -05:00", formatSince(date, TimeZone.getTimeZone("EST")));
 	}
+	
+	@Test
+    public void testFormatSince() {
+        String date = "2018-03-01T14:52:48Z";
+        assertEquals("01/03/18 2:52:48 PM Z", formatSince(date));
+    }
 
 }


### PR DESCRIPTION
Signed-off-by: Dmitrii Bocharov <dbocharo@redhat.com>
