### PR TITLE
JBDS-4682 - return empty array instead of default impl null

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDKServer.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDKServer.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.security.storage.StorageException;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServerWorkingCopy;
+import org.eclipse.wst.server.core.ServerPort;
 import org.eclipse.wst.server.core.internal.Server;
 import org.eclipse.wst.server.core.model.ServerDelegate;
 import org.jboss.ide.eclipse.as.core.util.ServerNamingUtility;
@@ -192,5 +193,10 @@ public class CDKServer extends ServerDelegate {
 	public boolean skipUnregistration() {
 		return getServer().getAttribute(CDKServer.PROP_SKIP_UNREG, false);
 	}
+	
+	public ServerPort[] getServerPorts() {
+		return new ServerPort[0];
+	}
+
 
 }

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDKServer.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDKServer.java
@@ -194,6 +194,7 @@ public class CDKServer extends ServerDelegate {
 		return getServer().getAttribute(CDKServer.PROP_SKIP_UNREG, false);
 	}
 	
+	@Override
 	public ServerPort[] getServerPorts() {
 		return new ServerPort[0];
 	}


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
