### PR TITLE
DebugLaunchConfigs NPE on workspace shutdown

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
@@ -289,7 +289,10 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 
 			@Override
 			public void onDebugChange(DebugContext context, IProgressMonitor monitor) throws CoreException {
-				DebugLaunchConfigs.get().terminateRemoteDebugger(getServer());
+				DebugLaunchConfigs configs = DebugLaunchConfigs.get();
+				if( configs != null ) {
+					configs.terminateRemoteDebugger(getServer());
+				}
 				unMapPortForwarding(context.getPod());
 			}
 
@@ -389,6 +392,9 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		monitor.subTask("Attaching remote debugger...");
 		ILaunch ret = null;
 		DebugLaunchConfigs launchConfigs = DebugLaunchConfigs.get();
+		if( launchConfigs == null ) {
+			throw toCoreException(NLS.bind("Could not modify launch config for server {0}", server.getName()));
+		}
 		ILaunchConfiguration debuggerLaunchConfig = launchConfigs.getRemoteDebuggerLaunchConfiguration(server);
 		ILaunchConfigurationWorkingCopy workingCopy = getLaunchConfigWorkingCopy(server, launchConfigs,
 				debuggerLaunchConfig);

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
@@ -393,7 +393,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		ILaunch ret = null;
 		DebugLaunchConfigs launchConfigs = DebugLaunchConfigs.get();
 		if( launchConfigs == null ) {
-			throw toCoreException(NLS.bind("Could not modify launch config for server {0}", server.getName()));
+			throw toCoreException(NLS.bind("Could not get launch config for server {0} to attach remote debugger", server.getName()));
 		}
 		ILaunchConfiguration debuggerLaunchConfig = launchConfigs.getRemoteDebuggerLaunchConfiguration(server);
 		ILaunchConfigurationWorkingCopy workingCopy = getLaunchConfigWorkingCopy(server, launchConfigs,

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftShutdownController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftShutdownController.java
@@ -44,7 +44,11 @@ public class OpenShiftShutdownController extends AbstractSubsystemController
 		OpenShiftServerBehaviour behavior = getBehavior();
 		behavior.setServerStopping();
 		try {
-			DebugLaunchConfigs.get().terminateRemoteDebugger(behavior.getServer());
+			DebugLaunchConfigs configs = DebugLaunchConfigs.get();
+			if( configs != null ) { 
+				configs.terminateRemoteDebugger(behavior.getServer());
+			}
+			// configs should only be null if workspace is shutting down, so set server to stopped anyway
 			behavior.setServerStopped();
 		} catch (CoreException ce) {
 			log(IStatus.ERROR, "Error shutting down server", ce);

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/DebugLaunchConfigs.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/DebugLaunchConfigs.java
@@ -41,12 +41,16 @@ public class DebugLaunchConfigs {
 	private ILaunchManager launchManager;
 
 	public static DebugLaunchConfigs get() {
-		return get(DebugPlugin.getDefault().getLaunchManager());
+		if( DebugPlugin.getDefault() != null ) 
+			return get(DebugPlugin.getDefault().getLaunchManager());
+		return null;
 	}
 
 	/** For testing purposes **/
 	public static DebugLaunchConfigs get(ILaunchManager launchManager) {
-		return new DebugLaunchConfigs(launchManager);
+		if( launchManager != null )
+			return new DebugLaunchConfigs(launchManager);
+		return null;
 	}
 
 	private DebugLaunchConfigs(ILaunchManager launchManager) {


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
