### PR TITLE
[JBIDE-25506] exclude .git, .npm when rsync'ing

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/.classpath
+++ b/plugins/org.jboss.tools.openshift.client/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-5.9.6-SNAPSHOT.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-6.0.0-SNAPSHOT.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/okhttp-3.3.1.jar"/>

--- a/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.4.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Bundle-ClassPath: lib/openshift-restclient-java-5.9.6-SNAPSHOT.jar,
+Bundle-ClassPath: lib/openshift-restclient-java-6.0.0-SNAPSHOT.jar,
  lib/okhttp-3.3.1.jar,
  lib/okhttp-ws-3.3.1.jar,
  lib/okio-1.8.0.jar,

--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -16,7 +16,7 @@
 			https://repository.jboss.org/nexus/content/repositories/snapshots/com/openshift/openshift-restclient-java/5.9.4.Final/
 			https://repository.jboss.org/nexus/service/local/repositories/releases/content/com/openshift/openshift-restclient-java/5.9.4.Final/openshift-restclient-java-5.9.4.Final.jar	
 		-->
-		<openshift-restclient-java.version>5.9.6-SNAPSHOT</openshift-restclient-java.version>
+		<openshift-restclient-java.version>6.0.0-SNAPSHOT</openshift-restclient-java.version>
 		<ok-http.version>3.3.1</ok-http.version>
 		<ok-http-ws.version>3.3.1</ok-http-ws.version>
 		<ok-io.version>1.8.0</ok-io.version>

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
@@ -32,6 +32,7 @@ import org.jboss.tools.openshift.internal.core.util.ResourceUtils;
 import com.openshift.restclient.OpenShiftException;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
 import com.openshift.restclient.capability.resources.IRSyncable;
 import com.openshift.restclient.capability.resources.IRSyncable.LocalPeer;
@@ -119,11 +120,14 @@ public class RSync {
 
 	protected OpenShiftBinaryOption[] getOptions() {
 		if (Platform.OS_WIN32.equals(Platform.getOS())) {
-			return new OpenShiftBinaryOption[] { OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER,
-					OpenShiftBinaryOption.SKIP_TLS_VERIFY, OpenShiftBinaryOption.NO_PERMS };
+			return new OpenShiftBinaryOption[] {
+					IRSyncable.exclude(".git", ".npm"),
+					IRSyncable.NO_PERMS,
+					IBinaryCapability.SKIP_TLS_VERIFY };
 		} else {
-			return new OpenShiftBinaryOption[] { OpenShiftBinaryOption.EXCLUDE_GIT_FOLDER,
-					OpenShiftBinaryOption.SKIP_TLS_VERIFY };
+			return new OpenShiftBinaryOption[] {
+					IRSyncable.exclude(".git", ".npm"),
+					IRSyncable.SKIP_TLS_VERIFY };
 		}
 	}
 

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
@@ -57,7 +57,7 @@ import org.jboss.tools.openshift.internal.core.server.debug.IDebugListener;
 import org.jboss.tools.openshift.internal.core.server.debug.OpenShiftDebugMode;
 import org.jboss.tools.openshift.internal.core.util.ResourceUtils;
 
-import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.capability.resources.IPortForwardable.PortPair;
 import com.openshift.restclient.model.IPod;
@@ -362,7 +362,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		}
 
 		if (mapPorts(podPorts, monitor)) {
-			PortForwardingUtils.startPortForwarding(pod, podPorts, OpenShiftBinaryOption.SKIP_TLS_VERIFY);
+			PortForwardingUtils.startPortForwarding(pod, podPorts, IBinaryCapability.SKIP_TLS_VERIFY);
 			if (PortForwardingUtils.isPortForwardingStarted(pod)) {
 				return debugPort.get().getLocalPort();
 			}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/PodLogsJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/PodLogsJob.java
@@ -33,7 +33,7 @@ import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 
 import com.openshift.restclient.OpenShiftException;
 import com.openshift.restclient.capability.CapabilityVisitor;
-import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.capability.resources.IPodLogRetrieval;
 import com.openshift.restclient.model.IPod;
 
@@ -164,7 +164,7 @@ public class PodLogsJob extends AbstractDelegatingMonitorJob {
 			final MessageConsoleStream os = console.newMessageStream();
 			os.setEncoding("UTF-8");
 			try {
-				final InputStream logs = capability.getLogs(true, key.container, OpenShiftBinaryOption.SKIP_TLS_VERIFY);
+				final InputStream logs = capability.getLogs(true, key.container, IBinaryCapability.SKIP_TLS_VERIFY);
 				byte[] data = new byte[256];
 				int read = 0;
 				while (running && (read = readSafely(logs, data)) != -1 && !os.isClosed()) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
@@ -28,7 +28,7 @@ import org.jboss.tools.openshift.internal.common.ui.console.ConsoleUtils;
 import org.jboss.tools.openshift.internal.core.portforwarding.PortForwardingUtils;
 import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 
-import com.openshift.restclient.capability.IBinaryCapability.OpenShiftBinaryOption;
+import com.openshift.restclient.capability.IBinaryCapability;
 import com.openshift.restclient.capability.resources.IPortForwardable;
 import com.openshift.restclient.model.IPod;
 
@@ -109,8 +109,8 @@ public class PortForwardingWizardModel extends ObservablePojo {
 			ConsoleUtils.registerConsoleListener(consoleListener);
 			ConsoleUtils.displayConsoleView(console);
 			stream.println("Starting port-forwarding...");
-			final IPortForwardable portForwardable = PortForwardingUtils.startPortForwarding(this.pod, this.ports,
-					OpenShiftBinaryOption.SKIP_TLS_VERIFY);
+			final IPortForwardable portForwardable = 
+					PortForwardingUtils.startPortForwarding(this.pod, this.ports, IBinaryCapability.SKIP_TLS_VERIFY);
 			portForwardable.getPortPairs().stream().forEach(port -> stream.println(NLS.bind("{0} {1} -> {2}",
 					new Object[] { port.getName(), port.getLocalPort(), port.getRemotePort() })));
 			stream.println("done.");


### PR DESCRIPTION
Signed-off-by: Andre Dietisheim <adietish@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
