### PR TITLE
[JBIDE-25818] use IResource#getNamespaceName to adapt to new client API

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/connection/Connection.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/connection/Connection.java
@@ -492,9 +492,9 @@ public class Connection extends ObservablePojo implements IRefreshable, IOpenShi
 	@Override
 	public <T extends IResource> T refresh(IResource resource) {
 		try {
-			return client.get(resource.getKind(), resource.getName(), resource.getNamespace());
+			return client.get(resource.getKind(), resource.getName(), resource.getNamespaceName());
 		} catch (UnauthorizedException e) {
-			return retryGet(e, resource.getKind(), resource.getName(), resource.getNamespace());
+			return retryGet(e, resource.getKind(), resource.getName(), resource.getNamespaceName());
 		}
 	}
 

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/DockerImageLabels.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/DockerImageLabels.java
@@ -146,7 +146,7 @@ public class DockerImageLabels {
 			return null;
 		}
 		DockerImageURI uri = trigger.getFrom();
-		return getImageStreamTag(uri, resource.getNamespace());
+		return getImageStreamTag(uri, resource.getNamespaceName());
 		//		String imageRef = getImageRef(dc, connection);
 		//		int imageDigestIndex = imageRef.indexOf(DOCKER_IMAGE_DIGEST_IDENTIFIER);
 		//		if (imageDigestIndex > 0) {
@@ -189,7 +189,7 @@ public class DockerImageLabels {
 		if (images.isEmpty()) {
 			throw new CoreException(OpenShiftCoreActivator.statusFactory()
 					.errorStatus(NLS.bind("No images found for deployment config {0} in project {1} on server {2}",
-							new Object[] { dc.getName(), dc.getNamespace(), connection.getHost() })));
+							new Object[] { dc.getName(), dc.getNamespaceName(), connection.getHost() })));
 		}
 		// TODO: handle if there are 2+ images
 		return images.iterator().next();

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -717,7 +717,7 @@ public class OpenShiftServerUtils {
 			return Collections.emptyList();
 		}
 		List<IPod> collection = new ArrayList<>();
-		List<IPod> pods = connection.getResources(ResourceKind.POD, resource.getNamespace());
+		List<IPod> pods = connection.getResources(ResourceKind.POD, resource.getNamespaceName());
 		List<IPod> servicePods = ResourceUtils.getPodsFor(resource, pods);
 		collection.addAll(pods);
 		collection.addAll(servicePods);

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenshiftJMXConnectionProvider.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenshiftJMXConnectionProvider.java
@@ -87,7 +87,7 @@ public class OpenshiftJMXConnectionProvider extends AbstractJBossJMXConnectionPr
 	protected String computeJolokiaURL(IServer server) {
 		IResource resource = OpenShiftServerUtils.getResource(server, new NullProgressMonitor());
 		if (resource != null) {
-			String projName = resource.getNamespace();
+			String projName = resource.getNamespaceName();
 			List<IPod> pods = ResourceUtils.getPodsFor(resource, resource.getProject().getResources(ResourceKind.POD));
 			if (!pods.isEmpty()) {
 				String podName = pods.get(0).getName();

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/util/OpenShiftResourceUniqueId.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/util/OpenShiftResourceUniqueId.java
@@ -26,15 +26,15 @@ public class OpenShiftResourceUniqueId {
 
 	public static String get(IResource resource) {
 		if (resource == null || StringUtils.isEmpty(resource.getName())
-				|| StringUtils.isEmpty(resource.getNamespace())) {
+				|| StringUtils.isEmpty(resource.getNamespaceName())) {
 			return null;
 		}
 
 		if (ResourceKind.SERVICE.equals(resource.getKind())) {
-			return new StringBuilder().append(resource.getNamespace()).append(UNIQUE_ID_PROJECT_NAME_DELIMITER)
+			return new StringBuilder().append(resource.getNamespaceName()).append(UNIQUE_ID_PROJECT_NAME_DELIMITER)
 					.append(resource.getName()).toString();
 		} else {
-			return new StringBuilder().append(resource.getNamespace()).append(UNIQUE_ID_PROJECT_NAME_DELIMITER)
+			return new StringBuilder().append(resource.getNamespaceName()).append(UNIQUE_ID_PROJECT_NAME_DELIMITER)
 					.append(resource.getKind()).append(UNIQUE_ID_PROJECT_NAME_DELIMITER).append(resource.getName())
 					.toString();
 		}

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/OpenShiftDebugMode.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/OpenShiftDebugMode.java
@@ -243,7 +243,7 @@ public class OpenShiftDebugMode {
 	protected IPod getExistingPod(IDeploymentConfig dc, Connection connection, IProgressMonitor monitor) {
 		monitor.subTask(NLS.bind("Retrieving existing pod for deployment config {0}.", dc.getName()));
 
-		List<IPod> allPods = connection.getResources(ResourceKind.POD, dc.getNamespace());
+		List<IPod> allPods = connection.getResources(ResourceKind.POD, dc.getNamespaceName());
 		// TODO: support multiple pods
 		return ResourceUtils.getPodsFor(dc, allPods).stream().findFirst().orElse(null);
 

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/RouteTimeout.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/RouteTimeout.java
@@ -121,13 +121,13 @@ public class RouteTimeout {
 		if (routeMonitor.isCanceled()) {
 			return null;
 		}
-		List<IService> services = connection.getResources(ResourceKind.SERVICE, resource.getNamespace());
+		List<IService> services = connection.getResources(ResourceKind.SERVICE, resource.getNamespaceName());
 		Collection<IService> matchingServices = ResourceUtils.getServicesFor(resource, services);
 		routeMonitor.worked(1);
 		if (routeMonitor.isCanceled()) {
 			return null;
 		}
-		List<IRoute> routes = connection.getResources(ResourceKind.ROUTE, resource.getNamespace());
+		List<IRoute> routes = connection.getResources(ResourceKind.ROUTE, resource.getNamespaceName());
 		// TODO: support multiple matching routes, for now only get first
 		Optional<IRoute> matchingRoute = matchingServices.stream()
 				.flatMap(service -> ResourceUtils.getRoutesFor(service, routes).stream()).findFirst();

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/util/NewPodDetectorJob.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/util/NewPodDetectorJob.java
@@ -100,7 +100,7 @@ public class NewPodDetectorJob extends Job {
 
 	private Collection<String> getOldPods(IReplicationController rc) {
 		Connection connection = ConnectionsRegistryUtil.getConnectionFor(rc);
-		List<IPod> allPods = connection.getResources(ResourceKind.POD, rc.getNamespace());
+		List<IPod> allPods = connection.getResources(ResourceKind.POD, rc.getNamespaceName());
 		return ResourceUtils.getPodsFor(rc, allPods).stream().filter(pod -> ResourceUtils.isRuntimePod(pod))
 				.map(p -> p.getName()).collect(Collectors.toList());
 	}

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/util/ResourceUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/util/ResourceUtils.java
@@ -1021,7 +1021,7 @@ public class ResourceUtils {
 		if (dcName != null) {
 			return getDeploymentConfigByName(dcName, service, connection);
 		} else {
-			String namespace = service.getNamespace();
+			String namespace = service.getNamespaceName();
 			IReplicationController rc = getReplicationControllerFor(service,
 					connection.getResources(ResourceKind.REPLICATION_CONTROLLER, namespace));
 			if (rc == null) {
@@ -1043,7 +1043,7 @@ public class ResourceUtils {
 		if (dcName != null) {
 			return getDeploymentConfigByName(dcName, rc, connection);
 		} else {
-			List<IDeploymentConfig> allDcs = connection.getResources(ResourceKind.DEPLOYMENT_CONFIG, rc.getNamespace());
+			List<IDeploymentConfig> allDcs = connection.getResources(ResourceKind.DEPLOYMENT_CONFIG, rc.getNamespaceName());
 			return allDcs.stream().filter(dc -> ResourceUtils.areRelated(rc, dc))
 					// TODO: what if several dc are found?
 					.findFirst().orElse(null);
@@ -1055,7 +1055,7 @@ public class ResourceUtils {
 		if (StringUtils.isBlank(dcName) || resource == null) {
 			return null;
 		}
-		return connection.getResource(ResourceKind.DEPLOYMENT_CONFIG, resource.getNamespace(), dcName);
+		return connection.getResource(ResourceKind.DEPLOYMENT_CONFIG, resource.getNamespaceName(), dcName);
 	}
 
 	/**

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dialog/SelectRouteDialog.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dialog/SelectRouteDialog.java
@@ -66,7 +66,7 @@ public class SelectRouteDialog extends ElementListSelectionDialog {
 				message.append("Server: ").append(connection.getUsername()).append(" ").append(connection.getHost())
 						.append(StringUtils.getLineSeparator());
 			}
-			message.append("Project: ").append(route.getNamespace()).append(StringUtils.getLineSeparator());
+			message.append("Project: ").append(route.getNamespaceName()).append(StringUtils.getLineSeparator());
 			//Add more space between server/project info and instruction.
 			message.append(StringUtils.getLineSeparator());
 		}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeleteResourcesHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/DeleteResourcesHandler.java
@@ -60,7 +60,7 @@ public class DeleteResourcesHandler extends AbstractHandler {
 					.cancelStatus(NLS.bind("Could not delete resources: No connection found for selected resource {0}",
 							selectedResource.getName()));
 		}
-		String namespace = selectedResource.getNamespace();
+		String namespace = selectedResource.getNamespaceName();
 		openDialog(connection, namespace, HandlerUtil.getActiveShell(event));
 
 		return null;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/EditDefaultRouteHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/EditDefaultRouteHandler.java
@@ -47,7 +47,7 @@ public class EditDefaultRouteHandler extends AbstractHandler {
 
 		IServiceWrapper service = UIUtils.getFirstElement(currentSelection, IServiceWrapper.class);
 		if (service != null) {
-			new RouteOpenerJob(service.getWrapped().getNamespace(), shell) {
+			new RouteOpenerJob(service.getWrapped().getNamespaceName(), shell) {
 				@Override
 				protected IStatus run(IProgressMonitor monitor) {
 					this.routes = service.getResourcesOfKind(ResourceKind.ROUTE).stream()

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/OpenInWebBrowserHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/OpenInWebBrowserHandler.java
@@ -65,7 +65,7 @@ public class OpenInWebBrowserHandler extends AbstractHandler {
 		}
 		IServiceWrapper service = UIUtils.getFirstElement(currentSelection, IServiceWrapper.class);
 		if (service != null) {
-			new RouteOpenerJob(service.getWrapped().getNamespace(), shell) {
+			new RouteOpenerJob(service.getWrapped().getNamespaceName(), shell) {
 				@Override
 				protected IStatus run(IProgressMonitor monitor) {
 					this.routes = service.getResourcesOfKind(ResourceKind.ROUTE).stream()

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/OpenInWebConsoleHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/OpenInWebConsoleHandler.java
@@ -73,7 +73,7 @@ public class OpenInWebConsoleHandler extends AbstractHandler {
 
 	protected String getWebConsoleUrl(Connection connection, IResource resource) {
 		StringBuilder url = new StringBuilder(connection.getHost()).append("/console");
-		String projectName = resource == null ? null : resource.getNamespace();
+		String projectName = resource == null ? null : resource.getNamespaceName();
 		if (projectName != null) {
 			url.append("/project/").append(projectName);
 		}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PodLogsHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PodLogsHandler.java
@@ -116,7 +116,7 @@ public class PodLogsHandler extends AbstractOpenShiftCliHandler {
 		if (build != null) {
 			final String buildName = build.getName();
 			Connection connection = ConnectionsRegistryUtil.safeGetConnectionFor(build);
-			List<IPod> pods = connection.getResources(ResourceKind.POD, build.getNamespace());
+			List<IPod> pods = connection.getResources(ResourceKind.POD, build.getNamespaceName());
 			for (IPod pod : pods) {
 				if (buildName.equals(pod.getAnnotation(OpenShiftAPIAnnotations.BUILD_NAME))) {
 					return pod;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/CreateResourceJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/CreateResourceJob.java
@@ -60,9 +60,9 @@ public class CreateResourceJob extends AbstractDelegatingMonitorJob {
 					if (resourceListener != null) {
 						Collection<IResource> resources;
 						if (resourceIn instanceof IList) {
-							resources = client.create((IList) resourceIn, project.getNamespace());
+							resources = client.create((IList) resourceIn, project.getNamespaceName());
 						} else {
-							resources = Collections.singletonList(client.create(resourceIn, project.getNamespace()));
+							resources = Collections.singletonList(client.create(resourceIn, project.getNamespaceName()));
 						}
 						resourceListener.accept(resources);
 					}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/DeployImageJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/DeployImageJob.java
@@ -235,7 +235,7 @@ public class DeployImageJob extends AbstractDelegatingMonitorJob implements IRes
 			imageChangeTrigger.setContainerName(name);
 			imageChangeTrigger.setFrom(new DockerImageURI(null, null, is.getName(), imageUri.getTag()));
 			imageChangeTrigger.setKind(ResourceKind.IMAGE_STREAM_TAG);
-			imageChangeTrigger.setNamespace(is.getNamespace());
+			imageChangeTrigger.setNamespace(is.getNamespaceName());
 		}
 		return dc;
 	}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/PodLogsJob.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/job/PodLogsJob.java
@@ -91,7 +91,7 @@ public class PodLogsJob extends AbstractDelegatingMonitorJob {
 
 	private String getMessageConsoleName() {
 		IPod pod = key.pod;
-		return NLS.bind("{0}\\{1}\\{2} log", new Object[] { pod.getNamespace(), pod.getName(), key.container });
+		return NLS.bind("{0}\\{1}\\{2} log", new Object[] { pod.getNamespaceName(), pod.getName(), key.container });
 	}
 
 	private static class Key {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ConnectionWrapper.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ConnectionWrapper.java
@@ -108,7 +108,7 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 					WatchManager.getInstance().startWatch(project, connection);
 					Collection<IResource> resources = new HashSet<>();
 					for (String kind : RESOURCE_KINDS) {
-						resources.addAll(getWrapped().getResources(kind, project.getNamespace()));
+						resources.addAll(getWrapped().getResources(kind, project.getNamespaceName()));
 					}
 					resources.forEach(r -> resourceCache.add(r));
 					projectWrapper.initWithResources(resources);
@@ -187,7 +187,7 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 
 	private ProjectWrapper findProjectWrapper(IResource resource) {
 		synchronized (projects) {
-			return projects.get(resource.getNamespace());
+			return projects.get(resource.getNamespaceName());
 		}
 	}
 
@@ -225,7 +225,7 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 
 	protected void handleAdd(ProjectWrapper projectWrapper, IResource newResource) {
 		resourceCache.add(newResource);
-		Collection<IResource> resources = resourceCache.getResources(newResource.getProject().getNamespace());
+		Collection<IResource> resources = resourceCache.getResources(newResource.getProject().getNamespaceName());
 		// relying in IResource#equals() definition
 		projectWrapper.updateWithResources(resources);
 	}
@@ -239,7 +239,7 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 				fireChanged();
 			}
 		} else if (projectWrapper != null) {
-			Collection<IResource> resources = resourceCache.getResources(oldResource.getNamespace());
+			Collection<IResource> resources = resourceCache.getResources(oldResource.getNamespaceName());
 			projectWrapper.updateWithResources(resources);
 		}
 	}
@@ -247,7 +247,7 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 	protected void handleUpdate(ProjectWrapper projectWrapper, IResource newResource) {
 		resourceCache.remove(newResource);
 		resourceCache.add(newResource);
-		Collection<IResource> resources = resourceCache.getResources(newResource.getNamespace());
+		Collection<IResource> resources = resourceCache.getResources(newResource.getNamespaceName());
 		// relying in IResource#equals() definition
 		projectWrapper.updateWithResources(resources);
 	}
@@ -267,14 +267,14 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 	}
 
 	void refresh(ProjectWrapper projectWrapper) {
-		resourceCache.flush(projectWrapper.getWrapped().getNamespace());
+		resourceCache.flush(projectWrapper.getWrapped().getNamespaceName());
 		IProject project = projectWrapper.getWrapped();
 		IOpenShiftConnection connection = projectWrapper.getParent().getWrapped();
 		WatchManager.getInstance().stopWatch(project, connection);
 		WatchManager.getInstance().startWatch(project, connection);
 		Collection<IResource> resources = new HashSet<>();
 		for (String kind : RESOURCE_KINDS) {
-			resources.addAll(getWrapped().getResources(kind, project.getNamespace()));
+			resources.addAll(getWrapped().getResources(kind, project.getNamespaceName()));
 		}
 		resources.forEach(r -> resourceCache.add(r));
 		projectWrapper.updateWithResources(resources);

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ResourceCache.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ResourceCache.java
@@ -127,7 +127,7 @@ class ResourceCache {
 	}
 
 	public String getNamespace(IResource resource) {
-		return resource.getNamespace();
+		return resource.getNamespaceName();
 	}
 
 	public IResource getCachedVersion(IResource resource) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/portforwading/PortForwardingWizardModel.java
@@ -58,7 +58,7 @@ public class PortForwardingWizardModel extends ObservablePojo {
 	}
 
 	public final String getPodName() {
-		return pod.getNamespace() + "\\" + pod.getName();
+		return pod.getNamespaceName() + "\\" + pod.getName();
 	}
 
 	public boolean getPortForwarding() {
@@ -152,7 +152,7 @@ public class PortForwardingWizardModel extends ObservablePojo {
 	}
 
 	private String getMessageConsoleName() {
-		return NLS.bind("Port forwarding to pod {0} ({1})", pod.getName(), pod.getNamespace());
+		return NLS.bind("Port forwarding to pod {0} ({1})", pod.getName(), pod.getNamespaceName());
 	}
 
 	/**

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/OpenShiftResourceDocumentProvider.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/OpenShiftResourceDocumentProvider.java
@@ -130,7 +130,7 @@ public class OpenShiftResourceDocumentProvider extends AbstractDocumentProvider 
 					}
 					IStatus error = OpenShiftUIActivator.statusFactory()
 							.errorStatus(NLS.bind("Could not update \"{0}\" for project \"{1}\" : {2}",
-									new String[] { resourceName, resource.getNamespace(), problem }), e);
+									new String[] { resourceName, resource.getNamespaceName(), problem }), e);
 					return error;
 				}
 				return Status.OK_STATUS;

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/OpenShiftResourceInput.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/OpenShiftResourceInput.java
@@ -52,7 +52,7 @@ public class OpenShiftResourceInput implements IStorageEditorInput {
 
 			@Override
 			public IPath getFullPath() {
-				return new Path(input.getNamespace()).append(input.getKind()).append(input.getName() + ".json");
+				return new Path(input.getNamespaceName()).append(input.getKind()).append(input.getName() + ".json");
 			}
 
 			@Override
@@ -63,7 +63,7 @@ public class OpenShiftResourceInput implements IStorageEditorInput {
 
 			@Override
 			public String getName() {
-				StringBuilder sb = new StringBuilder().append("[").append(input.getNamespace()).append("] ")
+				StringBuilder sb = new StringBuilder().append("[").append(input.getNamespaceName()).append("] ")
 						.append(StringUtils.humanize(input.getKind())).append(" : ").append(input.getName())
 						.append(".json");
 				return sb.toString();

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/ResourcePropertySource.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/property/ResourcePropertySource.java
@@ -82,7 +82,7 @@ public class ResourcePropertySource<T extends IResource> implements IPropertySou
 			case NAME:
 				return resource.getName();
 			case NAMESPACE:
-				return resource.getNamespace();
+				return resource.getNamespaceName();
 			case CREATED:
 				return resource.getCreationTimeStamp();
 			case RESOURCE_VERSION:

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/BuildConfigDetailViews.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/BuildConfigDetailViews.java
@@ -72,7 +72,7 @@ public class BuildConfigDetailViews extends AbstractStackedDetailViews {
 			IBuildConfig buildConfig = (IBuildConfig) value;
 
 			nameText.setText(buildConfig.getName());
-			namespaceText.setText(buildConfig.getNamespace());
+			namespaceText.setText(buildConfig.getNamespaceName());
 			String labels = org.jboss.tools.openshift.common.core.utils.StringUtils.toString(buildConfig.getLabels());
 			labels = org.apache.commons.lang.StringUtils.defaultString(labels); //replaces null by empty string
 			labelsText.setText(labels);

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorSection.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftServerEditorSection.java
@@ -625,7 +625,7 @@ public class OpenShiftServerEditorSection extends ServerEditorSection {
 			if (initialModel.openshiftResource != null) {
 				String kind = nullSafe(initialModel.openshiftResource.getKind()) + ":";
 				resourceKindLabel.setText(kind);
-				String namespaceAndName = nullSafe(initialModel.openshiftResource.getNamespace()) + "/"
+				String namespaceAndName = nullSafe(initialModel.openshiftResource.getNamespaceName()) + "/"
 						+ nullSafe(initialModel.openshiftResource.getName());
 				resourceText.setText(namespaceAndName);
 			} else {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ResourceDetailViews.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/ResourceDetailViews.java
@@ -104,7 +104,7 @@ public class ResourceDetailViews extends AbstractStackedDetailViews {
 			}
 
 			IResource resource = (IResource) value;
-			namespaceText.setText(resource.getNamespace());
+			namespaceText.setText(resource.getNamespaceName());
 			String labels = StringUtils.toString(resource.getLabels());
 			labels = org.apache.commons.lang.StringUtils.defaultString(labels); //replaces null by empty string
 			labelsText.setText(labels);

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/ApplicationSourceTreeItems.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/ApplicationSourceTreeItems.java
@@ -63,7 +63,7 @@ public class ApplicationSourceTreeItems implements IModelFactory, ICommonAttribu
 	}
 
 	private Collection<IApplicationSource> loadImageStreams(IProject project, Connection conn) {
-		final Collection<IImageStream> streams = conn.getResources(ResourceKind.IMAGE_STREAM, project.getNamespace());
+		final Collection<IImageStream> streams = conn.getResources(ResourceKind.IMAGE_STREAM, project.getNamespaceName());
 		try {
 			if (StringUtils.isNotBlank(conn.getClusterNamespace())) {
 				Collection<IImageStream> commonStreams = conn.getResources(ResourceKind.IMAGE_STREAM,

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromimage/ImageStreamApplicationSource.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromimage/ImageStreamApplicationSource.java
@@ -44,7 +44,7 @@ public class ImageStreamApplicationSource implements IApplicationSource {
 
 	@Override
 	public String getNamespace() {
-		return is.getNamespace();
+		return is.getNamespaceName();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromtemplate/TemplateApplicationSource.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/newapp/fromtemplate/TemplateApplicationSource.java
@@ -44,7 +44,7 @@ public class TemplateApplicationSource implements IApplicationSource {
 
 	@Override
 	public String getNamespace() {
-		return this.template.getNamespace();
+		return this.template.getNamespaceName();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/core/ServicePodsExist.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/condition/core/ServicePodsExist.java
@@ -62,7 +62,7 @@ public class ServicePodsExist extends AbstractWaitCondition {
 
 	private boolean hasDesiredReplicas(IService service) {
 		List<IReplicationController> allReplicationControllers = 
-				connection.getResources(ResourceKind.REPLICATION_CONTROLLER, service.getNamespace());
+				connection.getResources(ResourceKind.REPLICATION_CONTROLLER, service.getNamespaceName());
 		IReplicationController rc = ResourceUtils.getReplicationControllerFor(service, allReplicationControllers);
 		return rc != null 
 				&& rc.getDesiredReplicaCount() > 0;

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftServiceRequirement.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/requirement/OpenShiftServiceRequirement.java
@@ -219,7 +219,7 @@ public class OpenShiftServiceRequirement implements Requirement<RequiredService>
 				, TimePeriod.VERY_LONG);
 
 		// wait for replication controller to appear in UI
-		List<IReplicationController> rcs = connection.getResources(ResourceKind.REPLICATION_CONTROLLER, service.getNamespace());
+		List<IReplicationController> rcs = connection.getResources(ResourceKind.REPLICATION_CONTROLLER, service.getNamespaceName());
 		IReplicationController serviceRc = ResourceUtils.getReplicationControllerFor(service, rcs);
 		assertThat(serviceRc, not(nullValue()));
 		new WaitUntil(
@@ -315,7 +315,7 @@ public class OpenShiftServiceRequirement implements Requirement<RequiredService>
 				|| connection == null) {
 			return null;
 		}
-		List<IReplicationController> rcs = connection.getResources(ResourceKind.REPLICATION_CONTROLLER, service.getNamespace());
+		List<IReplicationController> rcs = connection.getResources(ResourceKind.REPLICATION_CONTROLLER, service.getNamespaceName());
 		IReplicationController rc = ResourceUtils.getReplicationControllerFor(service, rcs);
 		return rc;
 	}

--- a/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeResourceUtils.java
+++ b/test-framework/org.jboss.tools.openshift.reddeer/src/org/jboss/tools/openshift/reddeer/utils/v3/OpenShift3NativeResourceUtils.java
@@ -113,7 +113,7 @@ public class OpenShift3NativeResourceUtils {
 	public static Collection<IPod> getPods(IService service, Connection connection) {
 		assertNotNull(connection);
 		
-		List<IPod> allPods = connection.getResources(ResourceKind.POD, service.getNamespace());
+		List<IPod> allPods = connection.getResources(ResourceKind.POD, service.getNamespaceName());
 		return ResourceUtils.getPodsFor(service, allPods);
 	}
  }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/debug/OpenShiftDebugModeTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/debug/OpenShiftDebugModeTest.java
@@ -656,12 +656,12 @@ public class OpenShiftDebugModeTest {
 		doReturn(selectors).when(dc).getReplicaSelector();
 		IService service1 = createService("service1", project, new HashMap<String, String>()); // doesnt match dc
 		IService service2 = createService("service2", project, selectors); // matches dc
-		when(connection.getResources(ResourceKind.SERVICE, project.getNamespace()))
+		when(connection.getResources(ResourceKind.SERVICE, project.getNamespaceName()))
 				.thenReturn(Arrays.asList(service1, service2));
 
 		IRoute route1 = createRoute("route1", project, "service42"); // matches inexistent service
 		IRoute route2 = createRoute("route2", project, "service2"); // matches service2
-		when(connection.getResources(ResourceKind.ROUTE, project.getNamespace()))
+		when(connection.getResources(ResourceKind.ROUTE, project.getNamespaceName()))
 				.thenReturn(Arrays.asList(route1, route2));
 		return route2;
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/internal/ui/models/ConnectionWrapperTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/internal/ui/models/ConnectionWrapperTest.java
@@ -38,7 +38,7 @@ public class ConnectionWrapperTest {
 	public void prepareData() throws Exception {
 	    this.project = mock(IProject.class);
         when(project.getName()).thenReturn(NAMESPACE);
-        when(project.getNamespace()).thenReturn(NAMESPACE);
+        when(project.getNamespaceName()).thenReturn(NAMESPACE);
         
 		IOpenShiftConnection connection = mock(IOpenShiftConnection.class);
 		when(connection.isDefaultHost()).thenReturn(true);
@@ -55,7 +55,7 @@ public class ConnectionWrapperTest {
 
 		this.resource = mock(IBuildConfig.class);
 		when(this.resource.getKind()).thenReturn(ResourceKind.BUILD_CONFIG);
-		when(this.resource.getNamespace()).thenReturn(NAMESPACE);
+		when(this.resource.getNamespaceName()).thenReturn(NAMESPACE);
 		when(this.resource.getProject()).thenReturn(project);
 
 		this.watchListener = new WatchListenerTestable(WatchManager.getInstance(), project, connection, ResourceKind.BUILD_CONFIG, 0,

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/internal/ui/models/ProjectWrapperTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/internal/ui/models/ProjectWrapperTest.java
@@ -34,7 +34,7 @@ public class ProjectWrapperTest {
 		this.connectionWrapper = new ConnectionWrapper(mock(OpenshiftUIModel.class), connection);
 
 		this.project = mock(IProject.class);
-		when(project.getNamespace()).thenReturn("namespace");
+		when(project.getNamespaceName()).thenReturn("namespace");
 		this.projectWrapper = new ProjectWrapper(connectionWrapper, project);
 		WatchManager.getInstance()._getWatches().clear();
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/explorer/OpenShiftExplorerLabelProviderTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/explorer/OpenShiftExplorerLabelProviderTest.java
@@ -241,7 +241,7 @@ public class OpenShiftExplorerLabelProviderTest {
 
 		IProject project = givenAResource(IProject.class, ResourceKind.PROJECT);
 		when(project.getName()).thenReturn(displayName);
-		when(project.getNamespace()).thenReturn(namespace);
+		when(project.getNamespaceName()).thenReturn(namespace);
 
 		assertEquals(project.getName(), provider.getStyledText(project).getString());
 	}
@@ -253,7 +253,7 @@ public class OpenShiftExplorerLabelProviderTest {
 
 		IProject project = givenAResource(IProject.class, ResourceKind.PROJECT);
 		when(project.getDisplayName()).thenReturn(displayName);
-		when(project.getNamespace()).thenReturn(namespace);
+		when(project.getNamespaceName()).thenReturn(namespace);
 
 		assertEquals(project.getDisplayName() + " " + project.getName(), provider.getStyledText(project).getString());
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/handler/OpenInWebConsoleHandlerTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/handler/OpenInWebConsoleHandlerTest.java
@@ -67,7 +67,7 @@ public class OpenInWebConsoleHandlerTest {
 	public void test(DataPair dataPair) {
 		IResource resourceMock = dataPair.getResource();
 		if (resourceMock != null) {
-			when(resourceMock.getNamespace()).thenReturn("namespace");
+			when(resourceMock.getNamespaceName()).thenReturn("namespace");
 			when(resourceMock.getName()).thenReturn("qwerty");
 			when(resourceMock.getLabels()).thenReturn(new HashMap<String, String>() {
 				{

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/CreateApplicationFromImageJobTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/CreateApplicationFromImageJobTest.java
@@ -92,7 +92,7 @@ public class CreateApplicationFromImageJobTest {
 	public void testStubDeploymentConfig() {
 		IImageStream is = mock(IImageStream.class);
 		when(is.getName()).thenReturn("aISname");
-		when(is.getNamespace()).thenReturn("anamespace");
+		when(is.getNamespaceName()).thenReturn("anamespace");
 
 		IDeploymentConfig stub = mock(IDeploymentConfig.class);
 		when(stub.getName()).thenReturn(APP_NAME);

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/CreateResourceJobTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/CreateResourceJobTest.java
@@ -93,7 +93,7 @@ public class CreateResourceJobTest {
 		resources.add(status);
 
 		when(resourceFactory.create(input)).thenReturn(resource);
-		when(client.create(resource, project.getNamespace())).thenReturn(status);
+		when(client.create(resource, project.getNamespaceName())).thenReturn(status);
 
 		IStatus result = job.runMe();
 
@@ -111,7 +111,7 @@ public class CreateResourceJobTest {
 		resources.add(resource);
 
 		when(resourceFactory.create(input)).thenReturn(resource);
-		when(client.create(resource, project.getNamespace())).thenReturn(resource);
+		when(client.create(resource, project.getNamespaceName())).thenReturn(resource);
 
 		IStatus result = job.runMe();
 

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/DeployImageJobTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/job/DeployImageJobTest.java
@@ -196,7 +196,7 @@ public class DeployImageJobTest {
 		IImageStream is = whenStubbingTheImageStream();
 		assertNotNull("Exp. an IS to be returned", is);
 		assertEquals(IMAGE_STREAM_NAME, is.getName());
-		assertEquals(project.getName(), is.getNamespace());
+		assertEquals(project.getName(), is.getNamespaceName());
 		assertEquals(DOCKER_TAG, is.getDockerImageRepository());
 	}
 
@@ -206,7 +206,7 @@ public class DeployImageJobTest {
 		IImageStream is = whenStubbingTheImageStream(DOCKER_TAG_DIFF_REPO);
 		assertNotNull("Exp. an IS to be returned", is);
 		assertEquals(IMAGE_STREAM_NAME, is.getName());
-		assertEquals(ICommonAttributes.COMMON_NAMESPACE, is.getNamespace());
+		assertEquals(ICommonAttributes.COMMON_NAMESPACE, is.getNamespaceName());
 		assertEquals(DOCKER_TAG, is.getDockerImageRepository());
 	}
 
@@ -218,7 +218,7 @@ public class DeployImageJobTest {
 		IImageStream is = whenStubbingTheImageStream();
 		assertNotNull("Exp. an IS to be returned", is);
 		assertEquals(RESOURCE_NAME, is.getName());
-		assertEquals(project.getName(), is.getNamespace());
+		assertEquals(project.getName(), is.getNamespaceName());
 		assertEquals(1, is.getTags().size());
 		assertEquals(DOCKER_TAG.toString(), is.getTags().iterator().next().getFrom().getName());
 	}
@@ -238,7 +238,7 @@ public class DeployImageJobTest {
 
 	private IImageStream givenAnImageStreamTo(String namespace, DockerImageURI uri) {
 		IImageStream is = mock(IImageStream.class);
-		when(is.getNamespace()).thenReturn(namespace);
+		when(is.getNamespaceName()).thenReturn(namespace);
 		when(is.getName()).thenReturn(IMAGE_STREAM_NAME);
 		when(is.getDockerImageRepository()).thenReturn(uri);
 
@@ -290,7 +290,7 @@ public class DeployImageJobTest {
 		assertEquals(ResourceKind.IMAGE_STREAM_TAG, imageChangeTrigger.getKind());
 		assertEquals("Exp. the trigger to point to the imagestream name",
 				new DockerImageURI(null, null, is.getName(), DOCKER_TAG.getTag()), imageChangeTrigger.getFrom());
-		assertEquals("Exp. the trigger to point to the imagestream name", is.getNamespace(),
+		assertEquals("Exp. the trigger to point to the imagestream name", is.getNamespaceName(),
 				imageChangeTrigger.getNamespace());
 	}
 

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/RefreshTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/RefreshTest.java
@@ -104,9 +104,7 @@ public class RefreshTest {
 		@SuppressWarnings("unchecked")
 		T instance = (T) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { klazz }, handler);
 		handler.stub((proxy, method, args) -> project).when(instance.getProject());
-		;
-		handler.stub((proxy, method, args) -> project.getNamespace()).when(instance.getNamespace());
-		;
+		handler.stub((proxy, method, args) -> project.getNamespaceName()).when(instance.getNamespaceName());
 		stubResource(handler, instance, kind, name, version);
 
 		return instance;
@@ -117,9 +115,7 @@ public class RefreshTest {
 		IProject instance = (IProject) Proxy.newProxyInstance(getClass().getClassLoader(),
 				new Class<?>[] { IProject.class }, handler);
 		handler.stub((proxy, method, args) -> instance).when(instance.getProject());
-		;
-		handler.stub((proxy, method, args) -> name).when(instance.getNamespace());
-		;
+		handler.stub((proxy, method, args) -> name).when(instance.getNamespaceName());
 		stubResource(handler, instance, ResourceKind.PROJECT, name, version);
 		return instance;
 	}
@@ -127,13 +123,10 @@ public class RefreshTest {
 	private <T extends IResource> void stubResource(StubInvocationHandler handler, T instance, String kind, String name,
 			int version) {
 		handler.stub((proxy, method, args) -> ResourceEquality.equals(proxy, args[0])).when(instance.equals(null));
-		;
 		handler.stub((proxy, method, args) -> ResourceEquality.hashCode(proxy)).when(instance.hashCode());
-		;
 		handler.stub((proxy, method, args) -> name).when(instance.getName());
 		handler.stub((proxy, method, args) -> kind).when(instance.getKind());
 		handler.stub((proxy, method, args) -> String.valueOf(version)).when(instance.getResourceVersion());
-		;
 	}
 
 	private class OpenshiftUIModelTestable extends OpenshiftUIModel {

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/ResourceEquality.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/models/ResourceEquality.java
@@ -15,12 +15,12 @@ public class ResourceEquality {
 			return false;
 		}
 		IResource other = (IResource) right;
-		return thiz.getNamespace().equals(other.getNamespace()) && thiz.getKind().equals(other.getKind())
+		return thiz.getNamespaceName().equals(other.getNamespaceName()) && thiz.getKind().equals(other.getKind())
 				&& thiz.getName().equals(other.getName());
 	}
 
 	public static int hashCode(Object left) {
 		IResource thiz = (IResource) left;
-		return thiz.getName().hashCode() ^ thiz.getNamespace().hashCode();
+		return thiz.getName().hashCode() ^ thiz.getNamespaceName().hashCode();
 	}
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/portforwarding/PortForwardingWizardModelTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/portforwarding/PortForwardingWizardModelTest.java
@@ -48,14 +48,14 @@ public class PortForwardingWizardModelTest {
 		Set<IPort> ports = new HashSet<>();
 		ports.add(port);
 
-		when(pod.getNamespace()).thenReturn("anamespace");
+		when(pod.getNamespaceName()).thenReturn("anamespace");
 		when(pod.getContainerPorts()).thenReturn(ports);
 		this.model = new PortForwardingWizardModel(pod);
 	}
 
 	@Test
 	public void testGetPodName() {
-		assertEquals(pod.getNamespace() + "\\" + pod.getName(), model.getPodName());
+		assertEquals(pod.getNamespaceName() + "\\" + pod.getName(), model.getPodName());
 	}
 
 	@Test

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/property/ResourcePropertySourceTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/property/ResourcePropertySourceTest.java
@@ -44,7 +44,7 @@ public class ResourcePropertySourceTest {
 		annotations.put("efg", "def");
 
 		when(resource.getName()).thenReturn("aname");
-		when(resource.getNamespace()).thenReturn("anamespace");
+		when(resource.getNamespaceName()).thenReturn("anamespace");
 		when(resource.getKind()).thenReturn("akind");
 		when(resource.getLabels()).thenReturn(labels);
 		when(resource.getAnnotations()).thenReturn(annotations);

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/util/ResourceMocks.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/util/ResourceMocks.java
@@ -481,7 +481,7 @@ public class ResourceMocks {
 	public static void mockGetResourceProperties(String name, IProject project, IResource resource) {
 		doReturn(name).when(resource).getName();
 		if (project != null) {
-			doReturn(project.getName()).when(resource).getNamespace();
+			doReturn(project.getName()).when(resource).getNamespaceName();
 			doReturn(project).when(resource).getProject();
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Andre Dietisheim <adietish@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
