### PR TITLE
[JBIDE-25700] dont preserve permissions when rsync'ing

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/RSync.java
@@ -20,7 +20,6 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.ide.eclipse.as.core.server.IServerConsoleWriter;
@@ -118,19 +117,6 @@ public class RSync {
 		}, null);
 	}
 
-	protected OpenShiftBinaryOption[] getOptions() {
-		if (Platform.OS_WIN32.equals(Platform.getOS())) {
-			return new OpenShiftBinaryOption[] {
-					IRSyncable.exclude(".git", ".npm"),
-					IRSyncable.NO_PERMS,
-					IBinaryCapability.SKIP_TLS_VERIFY };
-		} else {
-			return new OpenShiftBinaryOption[] {
-					IRSyncable.exclude(".git", ".npm"),
-					IRSyncable.SKIP_TLS_VERIFY };
-		}
-	}
-
 	private void syncDirectoryToPod(final IPod pod, final File source, final String podPath,
 			final IServerConsoleWriter consoleWriter) throws IOException {
 		String sourcePath = sanitizePath(source.getAbsolutePath());
@@ -149,6 +135,13 @@ public class RSync {
 				return rsyncable;
 			}
 		}, null);
+	}
+
+	protected OpenShiftBinaryOption[] getOptions() {
+		return new OpenShiftBinaryOption[] {
+				IRSyncable.exclude(".git", ".npm"),
+				IRSyncable.NO_PERMS,
+				IBinaryCapability.SKIP_TLS_VERIFY };
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Andre Dietisheim <adietish@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
