### PR TITLE
JBIDE-25858 - bad logic prevents ms binary loc being set in dl-rt

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/UnifiedMinishiftRuntimeDetector.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/UnifiedMinishiftRuntimeDetector.java
@@ -156,7 +156,7 @@ public class UnifiedMinishiftRuntimeDetector extends AbstractCDKRuntimeDetector 
 	
 	private boolean folderContainsMinishiftBinary(File f) {
 		File bin = getMinishiftBinary(f);
-		return bin != null && bin.exists() && bin.isFile() && bin.canExecute();
+		return bin != null && bin.exists() && bin.isFile();
 	}
 	
 	private File folderWhiteListBin(File folder) {
@@ -271,9 +271,9 @@ public class UnifiedMinishiftRuntimeDetector extends AbstractCDKRuntimeDetector 
 	private String getMinishiftLoc(RuntimeDefinition runtimeDefinition) {
 		String fromDef = (String) runtimeDefinition.getProperty(OVERRIDE_MINISHIFT_LOCATION);
 		if (doesNotExist(fromDef)) {
-			return fromDef;
+			return MinishiftBinaryUtility.getMinishiftLocation();
 		}
-		return MinishiftBinaryUtility.getMinishiftLocation();
+		return fromDef;
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
