### PR TITLE
JBIDE-25908 - allow setup-cdk to be run more conveniently during launch

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
@@ -12,9 +12,7 @@ package org.jboss.tools.openshift.cdk.server.core.internal.adapter;
 
 import java.io.File;
 
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.openshift.cdk.server.core.internal.CDKConstants;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
 

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/CDK3Server.java
@@ -12,6 +12,7 @@ package org.jboss.tools.openshift.cdk.server.core.internal.adapter;
 
 import java.io.File;
 
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.tools.openshift.cdk.server.core.internal.CDKConstants;
@@ -79,4 +80,23 @@ public class CDK3Server extends CDKServer {
 		return (version.startsWith("3.0.") || version.startsWith("3.1."));
 	}
 
+	/**
+	 * Subclasses may override if the structure of the minishift home folder changes in future versions
+	 * @return
+	 */
+	public boolean isCDKInitialized() {
+		String home = getMinishiftHome();
+		File homeF = new File(home);
+		if (homeF.exists() && homeF.isDirectory()) {
+			File cdk = new File(homeF, "cdk");
+			File config = new File(homeF, "config");
+			File cache = new File(homeF, "cache");
+			File configJSON = new File(config, "config.json");
+			if (cdk.exists() && config.exists() && cache.exists() && configJSON.exists()) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
 }

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
@@ -29,10 +29,11 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.ServerUtil;
@@ -224,20 +225,21 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 			retmain[0] = -1;
 			String home = cdk3.getMinishiftHome();
 			Display.getDefault().syncExec(() -> {
-				MessageBox messageBox = new MessageBox(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
+				Shell sh = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 				String msgText = "Your CDK installation has not been properly initialized. Would you like us to run setup-cdk for you?";
 				String msg = NLS.bind(msgText, home);
-				messageBox.setMessage(msg);
-				messageBox.setText("Warning: CDK has not been properly initialized!");
-				retmain[0] = messageBox.open();
+				MessageDialog messageDialog = new MessageDialog(sh, "Warning: CDK has not been properly initialized!", null, msg, MessageDialog.WARNING, 
+						new String[] {IDialogConstants.OK_LABEL, IDialogConstants.CANCEL_LABEL}, 0);
+				retmain[0] = messageDialog.open();
 			});
-			if( retmain[0] == SWT.OK) {
+			if( retmain[0] == IDialogConstants.OK_ID) {
 				Job j = new SetupCDKJob(s, null, true);
 				j.schedule();
 				
 				try {
 					j.join();
 				} catch (InterruptedException e) {
+					// Ignore and finish up ASAP
 				}
 			}
 			if( !cdk3.isCDKInitialized()) { 

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
@@ -22,12 +22,18 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.IDebugEventSetListener;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.ServerUtil;
 import org.eclipse.wst.server.core.internal.Server;
@@ -48,6 +54,7 @@ import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDK3Server;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDKServer;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDKServerBehaviour;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.MinishiftPoller;
+import org.jboss.tools.openshift.cdk.server.ui.internal.view.SetupCDKJob;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
 import org.jboss.tools.openshift.internal.common.core.util.CommandLocationLookupStrategy;
 
@@ -187,19 +194,16 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 		}
 	}
 
-	@Override
-	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
-			throws CoreException {
+	private IServer launchGetServer(ILaunchConfiguration configuration) throws CoreException {
 		final IServer s = ServerUtil.getServer(configuration);
 		if (s == null) {
 			throw new CoreException(
 					CDKCoreActivator.statusFactory().errorStatus("Unable to locate server from launch configuration."));
 		}
-
-		final ControllableServerBehavior beh = (ControllableServerBehavior) JBossServerBehaviorUtils
-				.getControllableBehavior(configuration);
-		beh.setServerStarting();
-
+		return s;
+	}
+	
+	private String launchGetMinishiftBinary(IServer s, ControllableServerBehavior beh) throws CoreException {
 		String minishiftLoc = MinishiftBinaryUtility.getMinishiftLocation(s);
 		if (minishiftLoc == null || !(new File(minishiftLoc).exists())) {
 			beh.setServerStopped();
@@ -210,8 +214,76 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 					.errorStatus("Expected location of minishift command does not exist: " + minishiftLoc
 							+ "\nPlease set a correct value in the server editor."));
 		}
+		return minishiftLoc;
+	}
+	
+	private void launchCheckSetupCDK(IServer s, CDKServer cdkServer, ControllableServerBehavior beh) throws CoreException {
+		CDK3Server cdk3 = (CDK3Server)cdkServer;
+		if( !cdk3.isCDKInitialized()) {
+			int[] retmain = new int[1];
+			retmain[0] = -1;
+			String home = cdk3.getMinishiftHome();
+			Display.getDefault().syncExec(() -> {
+				MessageBox messageBox = new MessageBox(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
+				String msgText = "Your CDK installation has not been properly initialized. Would you like us to run setup-cdk for you?";
+				String msg = NLS.bind(msgText, home);
+				messageBox.setMessage(msg);
+				messageBox.setText("Warning: CDK has not been properly initialized!");
+				retmain[0] = messageBox.open();
+			});
+			if( retmain[0] == SWT.OK) {
+				Job j = new SetupCDKJob(s, null, true);
+				j.schedule();
+				
+				try {
+					j.join();
+				} catch (InterruptedException e) {
+				}
+			}
+			if( !cdk3.isCDKInitialized()) { 
+				beh.setServerStopped();
+				throw new CoreException(CDKCoreActivator.statusFactory().errorStatus(
+						"The server cannot be started until the CDK has been initialized."));
+			}
+		}
+	}
+	
+	private Process launchCreateProcess(IServer s, ControllableServerBehavior beh, 
+			String args, IDebugEventSetListener listener) throws CoreException {
 
+		Process p = null;
+		try {
+			CDKServer cdk = (CDKServer)getServer().loadAdapter(CDKServer.class, new NullProgressMonitor());
+			p = new CDKLaunchUtility().callMinishiftConsole(s, args, getStartupLaunchName(s), cdk.skipRegistration());
+		} catch (IOException ioe) {
+			CDKCoreActivator.pluginLog().logError(ioe);
+			beh.setServerStopped();
+			DebugPlugin.getDefault().removeDebugEventListener(listener);
+			throw new CoreException(new Status(IStatus.ERROR, CDKCoreActivator.PLUGIN_ID, ioe.getMessage(), ioe));
+		}
+
+		if (p == null) {
+			beh.setServerStopped();
+			DebugPlugin.getDefault().removeDebugEventListener(listener);
+			throw new CoreException(
+					new Status(IStatus.ERROR, CDKCoreActivator.PLUGIN_ID, "Call to minishift up has failed."));
+		}
+		return p;
+	}
+	
+	@Override
+	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
+			throws CoreException {
+		final IServer s = launchGetServer(configuration);
+		final ControllableServerBehavior beh = (ControllableServerBehavior) JBossServerBehaviorUtils
+				.getControllableBehavior(configuration);
+		beh.setServerStarting();
+		String minishiftLoc = launchGetMinishiftBinary(s, beh);
 		CDKServer cdkServer = (CDKServer) s.loadAdapter(CDKServer.class, new NullProgressMonitor());
+		if( cdkServer instanceof CDK3Server) {
+			launchCheckSetupCDK(s, cdkServer, beh);
+		}
+		
 		boolean passCredentials = cdkServer.passCredentials();
 		boolean skipReg = cdkServer.skipRegistration();
 		if (passCredentials && !skipReg) {
@@ -233,27 +305,9 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 		DebugPlugin.getDefault().addDebugEventListener(debug);
 		beh.putSharedData(AbstractStartJavaServerLaunchDelegate.DEBUG_LISTENER, debug);
 
-		Process p = null;
-		try {
-			CDKServer cdk = (CDKServer)getServer().loadAdapter(CDKServer.class, new NullProgressMonitor());
-			p = new CDKLaunchUtility().callMinishiftConsole(s, args, getStartupLaunchName(s), cdk.skipRegistration());
-		} catch (IOException ioe) {
-			CDKCoreActivator.pluginLog().logError(ioe);
-			beh.setServerStopped();
-			DebugPlugin.getDefault().removeDebugEventListener(debug);
-			throw new CoreException(new Status(IStatus.ERROR, CDKCoreActivator.PLUGIN_ID, ioe.getMessage(), ioe));
-		}
-
-		if (p == null) {
-			beh.setServerStopped();
-			DebugPlugin.getDefault().removeDebugEventListener(debug);
-			throw new CoreException(
-					new Status(IStatus.ERROR, CDKCoreActivator.PLUGIN_ID, "Call to minishift up has failed."));
-		}
-
+		Process p = launchCreateProcess(s, beh, args, debug);
 		IProcess process = addProcessToLaunch(p, launch, s, false, minishiftLoc);
 		beh.putSharedData(AbstractStartJavaServerLaunchDelegate.PROCESS, process);
-
 	}
 
 	private void handleCredentialsDuringLaunch(IServer s, CDKServer cdkServer, ControllableServerBehavior beh)

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/CDKActionProvider.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/CDKActionProvider.java
@@ -10,15 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.cdk.server.ui.internal.view;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IMenuManager;
@@ -27,13 +22,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.MessageBox;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -54,10 +43,8 @@ import org.eclipse.wst.server.ui.internal.view.servers.AbstractServerAction;
 import org.jboss.ide.eclipse.as.core.server.UnitedServerListener;
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.ControllableServerBehavior;
 import org.jboss.tools.openshift.cdk.server.core.internal.CDKCoreActivator;
-import org.jboss.tools.openshift.cdk.server.core.internal.MinishiftBinaryUtility;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDK3Server;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDKServer;
-import org.jboss.tools.openshift.cdk.server.core.internal.adapter.controllers.CDKLaunchUtility;
 import org.jboss.tools.openshift.cdk.server.core.internal.listeners.CDKDockerUtility;
 import org.jboss.tools.openshift.cdk.server.core.internal.listeners.CDKOpenshiftUtility;
 import org.jboss.tools.openshift.cdk.server.core.internal.listeners.ServiceManagerEnvironment;
@@ -106,55 +93,28 @@ public class CDKActionProvider extends CommonActionProvider {
 		@Override
 		public void run() {
 			IServer s = getServerFromSelection();
-			if (s != null && shouldRun(s)) {
+			if (shouldRun(s)) {
 				run2(s);
 			}
 		}
-
-		public boolean shouldRun() {
-			IServer s = getServerFromSelection();
-			return (s != null && shouldRun(s));
+		
+		private boolean shouldRun() {
+			return shouldRun(getServerFromSelection());
+		}
+		
+		private boolean shouldRun(IServer server) {
+			if( server == null )
+				return false;
+			
+			String typeId = server.getServerType().getId();
+			List<String> types = Arrays.asList(CDK3Server.MINISHIFT_BASED_CDKS);
+			return types.contains(typeId);
 		}
 
 		private void run2(IServer server) {
-			CDK3Server cdk3 = (CDK3Server) server.loadAdapter(CDK3Server.class, new NullProgressMonitor());
-			if (cdk3 != null) {
-				String home = cdk3.getMinishiftHome();
-				if( new File(home).exists()) {
-					Shell s = actionSite.getViewSite().getShell();
-					MessageBox messageBox = new MessageBox(s,SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
-					
-					String msgText = "Setup CDK will delete all existing contents of {0}. Are you sure you want to continue?";
-					String msg = NLS.bind(msgText, home);
-					messageBox.setMessage(msg);
-					messageBox.setText("Warning: Folder already exists!");
-					
-					int ret = messageBox.open();
-					if( ret != SWT.OK) {
-						return;
-					}
-				}
-			}
-			
-			
-			String cmd = MinishiftBinaryUtility.getMinishiftLocation(server);
-			String args = "setup-cdk --force";
-			try {
-				ILaunchConfiguration lc = server.getLaunchConfiguration(true, new NullProgressMonitor());
-				ILaunchConfigurationWorkingCopy lc2 = new CDKLaunchUtility().createExternalToolsLaunch(server, args,
-						new Path(cmd).lastSegment(), lc, cmd, true);
-				lc2.launch("run", new NullProgressMonitor());
-			} catch (CoreException ce) {
-				CDKCoreActivator.pluginLog().logError(ce);
-			}
+			new SetupCDKJob(server, actionSite.getViewSite().getShell(), true).schedule();
 		}
-
-		private boolean shouldRun(IServer server) {
-			String typeId = server.getServerType().getId();
-			List<String> types = Arrays.asList(CDK3Server.MINISHIFT_BASED_CDKS);
-			return types.contains(typeId) && !isCDKInitialized(server);
-		}
-
+		
 		private IServer getServerFromSelection() {
 			IStructuredSelection selection = (IStructuredSelection) sp.getSelection();
 			if (selection.getFirstElement() instanceof IServer) {
@@ -226,23 +186,6 @@ public class CDKActionProvider extends CommonActionProvider {
 		}
 	}
 
-	private boolean isCDKInitialized(IServer server) {
-		CDK3Server cdk3 = (CDK3Server) server.loadAdapter(CDK3Server.class, new NullProgressMonitor());
-		if (cdk3 != null) {
-			String home = cdk3.getMinishiftHome();
-			File homeF = new File(home);
-			if (homeF.exists() && homeF.isDirectory()) {
-				File cdk = new File(homeF, "cdk");
-				File config = new File(homeF, "config");
-				File cache = new File(homeF, "cache");
-				File configJSON = new File(config, "config.json");
-				if (cdk.exists() && config.exists() && cache.exists() && configJSON.exists()) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
 
 	private boolean acceptsServer(IServer s) {
 		// For now lets just do cdk servers, but we can change this if we wanted it

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/SetupCDKJob.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/SetupCDKJob.java
@@ -1,0 +1,169 @@
+package org.jboss.tools.openshift.cdk.server.ui.internal.view;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.DebugEvent;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.IDebugEventSetListener;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.wst.server.core.IServer;
+import org.jboss.tools.openshift.cdk.server.core.internal.CDKCoreActivator;
+import org.jboss.tools.openshift.cdk.server.core.internal.MinishiftBinaryUtility;
+import org.jboss.tools.openshift.cdk.server.core.internal.adapter.CDK3Server;
+import org.jboss.tools.openshift.cdk.server.core.internal.adapter.controllers.CDKLaunchUtility;
+
+public class SetupCDKJob extends Job {
+
+	private IServer server;
+	private Shell shell;
+	private boolean wait;
+
+	public SetupCDKJob(IServer server) {
+		this(server, null);
+	}
+
+	public SetupCDKJob(IServer server, Shell shell) {
+		this(server, shell, false);
+	}
+
+	public SetupCDKJob(IServer server, Shell shell, boolean wait) {
+		super("Setup CDK");
+		this.server = server;
+		this.shell = shell;
+		this.wait = wait;
+	}
+
+	@Override
+	protected IStatus run(IProgressMonitor monitor) {
+		CDK3Server cdk3 = (CDK3Server) server.loadAdapter(CDK3Server.class, new NullProgressMonitor());
+		if (cdk3 != null) {
+			if (!promptRun(cdk3)) {
+				return Status.CANCEL_STATUS;
+			}
+
+			if (!wait) {
+				launchSetup(server);
+			} else {
+				Object waiting = new Object();
+				WaitingLaunchListener listener = new WaitingLaunchListener(waiting);
+				DebugPlugin.getDefault().addDebugEventListener(listener);
+				ILaunch launch = launchSetup(server);
+				listener.setLaunchAndWait(launch);
+				DebugPlugin.getDefault().removeDebugEventListener(listener);
+			}
+		}
+		return Status.OK_STATUS;
+	}
+
+	private boolean promptRun(CDK3Server cdk3) {
+		String home = cdk3.getMinishiftHome();
+		final int[] retmain = new int[1];
+		if (new File(home).exists()) {
+			Display.getDefault().syncExec(() -> {
+				if( shell == null )
+					shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+				MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
+				String msgText = "Setup CDK will delete all existing contents of {0}. Are you sure you want to continue?";
+				String msg = NLS.bind(msgText, home);
+				messageBox.setMessage(msg);
+				messageBox.setText("Warning: Folder already exists!");
+				retmain[0] = messageBox.open();
+			});
+			if (retmain[0] != SWT.OK) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private ILaunch launchSetup(IServer server) {
+		String cmd = MinishiftBinaryUtility.getMinishiftLocation(server);
+		String args = "setup-cdk --force";
+		try {
+			ILaunchConfiguration lc = server.getLaunchConfiguration(true, new NullProgressMonitor());
+			ILaunchConfigurationWorkingCopy lc2 = new CDKLaunchUtility().createExternalToolsLaunch(server, args,
+					new Path(cmd).lastSegment(), lc, cmd, true);
+			return lc2.launch("run", new NullProgressMonitor());
+		} catch (CoreException ce) {
+			CDKCoreActivator.pluginLog().logError(ce);
+		}
+		return null;
+	}
+
+	private static class WaitingLaunchListener implements IDebugEventSetListener {
+		private Object waiting;
+		private ArrayList<DebugEvent> cachedDebugEvents;
+		private ILaunch launch;
+		private IProcess myProcess;
+
+		
+		public WaitingLaunchListener(Object waiting) {
+			this.waiting = waiting;
+			cachedDebugEvents = new ArrayList<DebugEvent>();
+		}
+
+		public void setLaunchAndWait(ILaunch launch) {
+			this.launch = launch;
+			this.myProcess = launch.getProcesses()[0];
+			synchronized (waiting) {
+				if( checkAllCachedEvents()) {
+					return;
+				}
+				try {
+					waiting.wait();
+				} catch (InterruptedException ie) {
+					// ignore
+				}
+			}
+		}
+
+		private boolean checkAllCachedEvents() {
+			synchronized(waiting) {
+				for(DebugEvent e : cachedDebugEvents) {
+					if (myProcess.equals(e.getSource()) && e.getKind() == DebugEvent.TERMINATE) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+		
+		@Override
+		public void handleDebugEvents(DebugEvent[] events) {
+			if (events != null) {
+				int size = events.length;
+				synchronized(waiting) {
+					if( myProcess != null ) {
+						for (int i = 0; i < size; i++) {
+							if (myProcess.equals(events[i].getSource()) && events[i].getKind() == DebugEvent.TERMINATE) {
+								waiting.notify();
+							}
+						}
+					} else {
+						cachedDebugEvents.addAll(Arrays.asList(events));
+					}
+				}
+			}
+		}
+
+	}
+
+}

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/SetupCDKJob.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/SetupCDKJob.java
@@ -21,9 +21,7 @@ import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.wst.server.core.IServer;
@@ -86,7 +84,8 @@ public class SetupCDKJob extends Job {
 				String title = "Warning: Folder already exists!";
 				String msgText = "Setup CDK will delete all existing contents of {0}. Are you sure you want to continue?";
 				String msg = NLS.bind(msgText, home);
-				MessageDialog messageDialog = new MessageDialog(shell, title, null, msg, MessageDialog.WARNING, new String[] {"OK", "Cancel"}, 0);
+				MessageDialog messageDialog = new MessageDialog(shell, title, null, msg, MessageDialog.WARNING, 
+						new String[] {IDialogConstants.OK_LABEL, IDialogConstants.CANCEL_LABEL}, 0);
 				retmain[0] = messageDialog.open();
 			});
 			if (retmain[0] != IDialogConstants.OK_ID) {
@@ -124,15 +123,14 @@ public class SetupCDKJob extends Job {
 
 		public void setLaunchAndWait(ILaunch launch) {
 			this.launch = launch;
-			this.myProcess = launch.getProcesses()[0];
+			this.myProcess = this.launch.getProcesses()[0];
 			synchronized (waiting) {
-				if( checkAllCachedEvents()) {
-					return;
-				}
-				try {
-					waiting.wait();
-				} catch (InterruptedException ie) {
-					// ignore
+				while( !checkAllCachedEvents()) {
+					try {
+						waiting.wait();
+					} catch (InterruptedException ie) {
+						// ignore
+					}
 				}
 			}
 		}

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/SetupCDKJob.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/view/SetupCDKJob.java
@@ -18,6 +18,8 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
@@ -80,14 +82,14 @@ public class SetupCDKJob extends Job {
 			Display.getDefault().syncExec(() -> {
 				if( shell == null )
 					shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-				MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
+				
+				String title = "Warning: Folder already exists!";
 				String msgText = "Setup CDK will delete all existing contents of {0}. Are you sure you want to continue?";
 				String msg = NLS.bind(msgText, home);
-				messageBox.setMessage(msg);
-				messageBox.setText("Warning: Folder already exists!");
-				retmain[0] = messageBox.open();
+				MessageDialog messageDialog = new MessageDialog(shell, title, null, msg, MessageDialog.WARNING, new String[] {"OK", "Cancel"}, 0);
+				retmain[0] = messageDialog.open();
 			});
-			if (retmain[0] != SWT.OK) {
+			if (retmain[0] != IDialogConstants.OK_ID) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
