### PR TITLE
New integration tests for CDK/minishift server adapter profiles feature

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/CDKAllTestsSuite.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/CDKAllTestsSuite.java
@@ -12,6 +12,7 @@ package org.jboss.tools.cdk.ui.bot.test;
 
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.cdk.ui.bot.test.server.adapter.CDK32IntegrationTest;
+import org.jboss.tools.cdk.ui.bot.test.server.adapter.CDK32ServerAdapterProfilesTest;
 import org.jboss.tools.cdk.ui.bot.test.server.adapter.CDKWrongCredentialsTest;
 import org.jboss.tools.cdk.ui.bot.test.server.adapter.openshift.CDKImageRegistryUrlDiscoveryFailureTest;
 import org.jboss.tools.cdk.ui.bot.test.server.adapter.openshift.CDKImageRegistryUrlDiscoveryTest;
@@ -58,6 +59,7 @@ import org.junit.runners.Suite;
 	CDKWrongCredentialsTest.class,
 	
 	// Integration test for creating/operating of CDK 3.2+ server adapter with multiple profiles set
+	CDK32ServerAdapterProfilesTest.class
 })
 /**
  * @author ondrej dockal

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/MinishiftAllTestsSuite.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/MinishiftAllTestsSuite.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.cdk.ui.bot.test;
 
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.tools.cdk.ui.bot.test.server.adapter.MinishiftServerAdapterProfilesTest;
 import org.jboss.tools.cdk.ui.bot.test.server.adapter.MinishiftServerAdapterTest;
 import org.jboss.tools.cdk.ui.bot.test.server.editor.MinishiftServerEditorTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.MinishiftServerWizardTest;
@@ -21,7 +22,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
 	MinishiftServerWizardTest.class,
 	MinishiftServerEditorTest.class,
-	MinishiftServerAdapterTest.class
+	MinishiftServerAdapterTest.class,
+	MinishiftServerAdapterProfilesTest.class
 })
 public class MinishiftAllTestsSuite {
 

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32ServerAdapterProfilesTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32ServerAdapterProfilesTest.java
@@ -1,0 +1,116 @@
+/******************************************************************************* 
+ * Copyright (c) 2018 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdk.ui.bot.test.server.adapter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.linuxtools.docker.reddeer.ui.DockerExplorerView;
+import org.eclipse.reddeer.common.logging.Logger;
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitUntil;
+import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
+import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
+import org.jboss.tools.cdk.reddeer.server.ui.CDKServer;
+import org.jboss.tools.cdk.reddeer.server.ui.CDKServersView;
+import org.jboss.tools.openshift.reddeer.requirement.CleanOpenShiftExplorerRequirement.CleanOpenShiftExplorer;
+import org.jboss.tools.openshift.reddeer.view.OpenShiftExplorerView;
+import org.jboss.tools.openshift.reddeer.view.resources.OpenShift3Connection;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test class for multiple server adapter profiles running at once
+ * @author odockal
+ *
+ */
+@CleanOpenShiftExplorer
+@RunWith(RedDeerSuite.class)
+public class CDK32ServerAdapterProfilesTest extends CDKServerAdapterAbstractTest {
+
+	private Server secondServer;
+	
+	private OpenShiftExplorerView view;
+	
+	private DockerExplorerView dockerView;
+	
+	private static final String DOCKER_DAEMON_CONNECTION = SERVER_ADAPTER_32;
+	
+	private static final Logger log = Logger.getLogger(CDK32ServerAdapterProfilesTest.class);
+	
+	@Override
+	protected String getServerAdapter() {
+		return SERVER_ADAPTER_32;
+	}
+	
+	protected static String getSecondServerAdapter() {
+		return SERVER_ADAPTER_32 + " " + MINISHIFT_PROFILE2;
+	}
+	
+	protected void setSecondCDKServer(Server server) {
+		this.secondServer = (CDKServer) server;
+	}
+	
+	protected Server getSecondCDKServer() {
+		return this.secondServer;
+	}
+	
+	@BeforeClass
+	public static void setupServerAdapterWithMultipleProfile() {
+		checkCDK32Parameters();
+		addNewCDK32Server(SERVER_ADAPTER_32, MINISHIFT_HYPERVISOR, CDK32_MINISHIFT, MINISHIFT_PROFILE);
+		addNewCDK32Server(getSecondServerAdapter(), MINISHIFT_HYPERVISOR, CDK32_MINISHIFT, MINISHIFT_PROFILE2);
+	}
+	
+	@Before
+	public void setupSecondAdapter() {
+		log.info("Open Servers view tab");
+		setServersView(new CDKServersView());
+		getServersView().open();
+		log.info("Getting server object from Servers View with name: " + getSecondServerAdapter());
+		setSecondCDKServer(getServersView().getServer(getSecondServerAdapter()));
+		new WaitUntil(new JobIsRunning(), TimePeriod.DEFAULT, false);
+		view = new OpenShiftExplorerView();
+		dockerView = new DockerExplorerView();
+	}
+
+	@Test
+	public void testCDK32ServerAdapterWithMultipleProfiles() {
+		// fisrt adapter start verification
+		startServerAdapter(() -> { skipRegistration(getCDKServer());}, false);
+		int conCount = view.getOpenShift3Connections().size();
+		int docCount = getDockerConnectionCreatedByCDK(dockerView, DOCKER_DAEMON_CONNECTION).size();
+		assertEquals("Expected only one OS connection, got " + conCount, 1, conCount);
+		assertEquals("Expected only one Docker connection, got " + docCount, 1, docCount);
+		// second adapter start verification
+		startServerAdapter(getSecondCDKServer(), 
+				() -> { skipRegistration(getCDKServer());
+				}, false);
+		// check counts of connections
+		conCount = view.getOpenShift3Connections().size();
+		docCount = getDockerConnectionCreatedByCDK(dockerView, DOCKER_DAEMON_CONNECTION).size();
+		assertEquals("Expected two OS connections, got " + conCount, 2, conCount);
+		assertEquals("Expectedtwo Docker connections, got " + docCount, 2, docCount);
+		// check functionality of connections
+		for (String docker : getDockerConnectionCreatedByCDK(dockerView, DOCKER_DAEMON_CONNECTION)) {
+			testDockerConnection(docker);
+		}
+		for (OpenShift3Connection conn : view.getOpenShift3Connections()) {
+			testOpenshiftConnection(conn);
+		}
+		// adapters stoping verification
+		stopServerAdapter();
+		stopServerAdapter(getSecondCDKServer());
+	}
+
+}

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterAbstractTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterAbstractTest.java
@@ -14,6 +14,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -589,6 +591,22 @@ public abstract class CDKServerAdapterAbstractTest extends CDKAbstractTest {
 			throw new OpenShiftToolsException("Could not find OpenShift connection for " + 
 					server + " and " + username);
 		}
+	}
+	
+	/**
+	 * Returns lists of filtered docker connections names 
+	 * @param view DockerExplorerView object
+	 * @param name string name parameter to filter docker connections
+	 * @return list of string of docker connections names fulfilling condition
+	 */
+	public List<String> getDockerConnectionCreatedByCDK(DockerExplorerView view, String name) {
+		List<String> list = new ArrayList<>();
+		for (String item : view.getDockerConnectionNames()) {
+			if (item.contains(name)) {
+				list.add(item);
+			}
+		}
+		return list;
 	}
 	
 	/**

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/MinishiftServerAdapterProfilesTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/MinishiftServerAdapterProfilesTest.java
@@ -1,0 +1,116 @@
+/******************************************************************************* 
+ * Copyright (c) 2018 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.cdk.ui.bot.test.server.adapter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.linuxtools.docker.reddeer.ui.DockerExplorerView;
+import org.eclipse.reddeer.common.logging.Logger;
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitUntil;
+import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
+import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
+import org.jboss.tools.cdk.reddeer.server.ui.CDKServer;
+import org.jboss.tools.cdk.reddeer.server.ui.CDKServersView;
+import org.jboss.tools.openshift.reddeer.requirement.CleanOpenShiftExplorerRequirement.CleanOpenShiftExplorer;
+import org.jboss.tools.openshift.reddeer.view.OpenShiftExplorerView;
+import org.jboss.tools.openshift.reddeer.view.resources.OpenShift3Connection;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test class for Minishift server adapter using multiple profiles
+ * @author odockal
+ *
+ */
+@CleanOpenShiftExplorer
+@RunWith(RedDeerSuite.class)
+public class MinishiftServerAdapterProfilesTest extends CDKServerAdapterAbstractTest {
+
+	private Server secondServer;
+	
+	private OpenShiftExplorerView view;
+	
+	private DockerExplorerView dockerView;
+	
+	private static final String DOCKER_DAEMON_CONNECTION = SERVER_ADAPTER_MINISHIFT;
+	
+	private static final Logger log = Logger.getLogger(CDK32ServerAdapterProfilesTest.class);
+	
+	@Override
+	protected String getServerAdapter() {
+		return SERVER_ADAPTER_MINISHIFT;
+	}
+	
+	protected static String getSecondServerAdapter() {
+		return SERVER_ADAPTER_MINISHIFT + " " + MINISHIFT_PROFILE2;
+	}
+	
+	protected void setSecondCDKServer(Server server) {
+		this.secondServer = (CDKServer) server;
+	}
+	
+	protected Server getSecondCDKServer() {
+		return this.secondServer;
+	}
+	
+	@BeforeClass
+	public static void setupServerAdapterWithMultipleProfile() {
+		checkMinishiftParameters();
+		addNewMinishiftServer(SERVER_ADAPTER_MINISHIFT, MINISHIFT_HYPERVISOR, MINISHIFT, MINISHIFT_PROFILE);
+		addNewMinishiftServer(getSecondServerAdapter(), MINISHIFT_HYPERVISOR, MINISHIFT, MINISHIFT_PROFILE2);
+	}
+	
+	@Before
+	public void setupSecondAdapter() {
+		log.info("Open Servers view tab");
+		setServersView(new CDKServersView());
+		getServersView().open();
+		log.info("Getting server object from Servers View with name: " + getSecondServerAdapter());
+		setSecondCDKServer(getServersView().getServer(getSecondServerAdapter()));
+		new WaitUntil(new JobIsRunning(), TimePeriod.DEFAULT, false);
+		view = new OpenShiftExplorerView();
+		dockerView = new DockerExplorerView();
+	}
+
+	@Test
+	public void testMinishiftServerAdapterWithMultipleProfiles() {
+		// fisrt adapter start verification
+		startServerAdapter(() -> { skipRegistration(getCDKServer());}, false);
+		int conCount = view.getOpenShift3Connections().size();
+		int docCount = getDockerConnectionCreatedByCDK(dockerView, DOCKER_DAEMON_CONNECTION).size();
+		assertEquals("Expected only one OS connection, got " + conCount, 1, conCount);
+		assertEquals("Expected only one Docker connection, got " + docCount, 1, docCount);
+		// second adapter start verification
+		startServerAdapter(getSecondCDKServer(), 
+				() -> { skipRegistration(getCDKServer());
+				}, false);
+		// check counts of connections
+		conCount = view.getOpenShift3Connections().size();
+		docCount = getDockerConnectionCreatedByCDK(dockerView, DOCKER_DAEMON_CONNECTION).size();
+		assertEquals("Expected two OS connections, got " + conCount, 2, conCount);
+		assertEquals("Expectedtwo Docker connections, got " + docCount, 2, docCount);
+		// check functionality of connections
+		for (String docker : getDockerConnectionCreatedByCDK(dockerView, DOCKER_DAEMON_CONNECTION)) {
+			testDockerConnection(docker);
+		}
+		for (OpenShift3Connection conn : view.getOpenShift3Connections()) {
+			testOpenshiftConnection(conn);
+		}
+		// adapters stoping verification
+		stopServerAdapter();
+		stopServerAdapter(getSecondCDKServer());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
