### PR TITLE
JBIDE-25918 Setup cdk to be called only for CDK based adapters

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/adapter/controllers/CDK3LaunchController.java
@@ -12,7 +12,9 @@ package org.jboss.tools.openshift.cdk.server.core.internal.adapter.controllers;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
@@ -282,7 +284,7 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 		beh.setServerStarting();
 		String minishiftLoc = launchGetMinishiftBinary(s, beh);
 		CDKServer cdkServer = (CDKServer) s.loadAdapter(CDKServer.class, new NullProgressMonitor());
-		if( cdkServer instanceof CDK3Server) {
+		if( cdkServer instanceof CDK3Server && isCDKBasedServer(s)) {
 			launchCheckSetupCDK(s, cdkServer, beh);
 		}
 		
@@ -372,5 +374,11 @@ public class CDK3LaunchController extends AbstractCDKLaunchController
 			// Ignore and continue
 		}
 
+	}
+	
+	private boolean isCDKBasedServer(IServer server) {
+		String typeId = server.getServerType().getId();
+		List<String> types = Arrays.asList(CDK3Server.MINISHIFT_BASED_CDKS);
+		return types.contains(typeId);
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
