### PR TITLE
JBIDE-25922 - ensure runtime detection identifies identical adapters

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/UnifiedMinishiftRuntimeDetector.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/core/internal/detection/UnifiedMinishiftRuntimeDetector.java
@@ -172,11 +172,18 @@ public class UnifiedMinishiftRuntimeDetector extends AbstractCDKRuntimeDetector 
 	}
 	
 	private boolean minishiftHomeMatches(RuntimeDefinition def, IServer server) {
+		String serverMinishiftHome = server.getAttribute(CDK3Server.MINISHIFT_HOME, (String) null);
 		File loc = def.getLocation();
 		if( isValidMinishiftHome(loc)) {
-			String fromServer = server.getAttribute(CDK3Server.MINISHIFT_HOME, (String) null);
-			File fromServerFile = fromServer == null ? null : new File(fromServer);
+			File fromServerFile = serverMinishiftHome == null ? null : new File(serverMinishiftHome);
 			return loc.equals(fromServerFile);
+		} else if( folderContainsMinishiftBinary(loc)) {
+			// Check if the assumed minishift home that will be used on server creation matches the existing server
+			String folder = loc.getAbsolutePath();
+			File msHome = new File(folder, "MINISHIFT_HOME");
+			if(serverMinishiftHome != null && new File(serverMinishiftHome).equals(msHome)) {
+				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
