### PR TITLE
Extending timeouts in CDK itests pom.xml

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/pom.xml
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/pom.xml
@@ -66,8 +66,9 @@
 				<configuration>
                     <appArgLine>-pluginCustomization ${requirementsDirectory}/pluginCustomization.ini</appArgLine>
 					<useUIThread>false</useUIThread>
-					<surefire.timeout>7200</surefire.timeout>
-					<forkedProcessTimeoutInSeconds>7200</forkedProcessTimeoutInSeconds>
+					<surefire.timeout>9600</surefire.timeout>
+					<surefire.itests.timeout>9600</surefire.itests.timeout>
+					<forkedProcessTimeoutInSeconds>9600</forkedProcessTimeoutInSeconds>
 					<testSuite>org.jboss.tools.cdk.ui.bot.test</testSuite>
 					<testClass>${suiteClass}</testClass>
 					<skip>${skipITests}</skip>


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
