### PR TITLE
[JBIDE-26043] - Two paths to OC client in properties view for OpenShift connection

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/ICommonAttributes.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/ICommonAttributes.java
@@ -47,7 +47,7 @@ public interface ICommonAttributes {
 		{
 			put(CLUSTER_NAMESPACE_KEY, "Cluster Namespace");
 			put(IMAGE_REGISTRY_URL_KEY, "Registry URL");
-			put(OC_LOCATION_KEY, "OC client path");
+			put(OC_LOCATION_KEY, "");
 			put(OC_OVERRIDE_KEY, "");
 		}
 	};


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
