### PR TITLE
JBIDE-26014 - fix ui error when downloading minishift on windows

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/Minishift17ServerWizardFragment.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/cdk/server/ui/internal/Minishift17ServerWizardFragment.java
@@ -12,6 +12,7 @@ package org.jboss.tools.openshift.cdk.server.ui.internal;
 
 import java.io.File;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.wst.server.ui.wizard.IWizardHandle;
 import org.jboss.tools.openshift.cdk.server.core.internal.adapter.VersionUtil;
@@ -44,7 +45,8 @@ public class Minishift17ServerWizardFragment extends CDK32ServerWizardFragment {
 	@Override
 	protected void handleDownloadedFile(String newHome) {
 		if( !homeText.isDisposed()) {
-			File f = new File(newHome, "minishift");
+			String suffix = Platform.getOS().equals(Platform.OS_WIN32) ? "minishift.exe" : "minishift";
+			File f = new File(newHome, suffix);
 			if( f.exists())
 				f.setExecutable(true);
 			homeText.setText(f.getAbsolutePath());


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
