### PR TITLE
[JBIDE-26153] - When creating an OpenShift project, rule must be displayed first

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ProjectNameValidator.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/validator/ProjectNameValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -25,10 +25,12 @@ import org.eclipse.osgi.util.NLS;
 //TODO Refactor to merge base into ResourceNameValidator
 public class ProjectNameValidator extends LabelValueValidator {
 
-	public static final String projectNameDescription = "A valid project name must be 63 characters or less but at least 2 characters, excluding \"..\".\n"
-			+ "It may only contain lower-case letters, numbers, and dashes. It may not start or end with a dash.";
+	public static final String PROJECT_NAME_RULE = "It may only contain lowercase letters, numbers, and dashes. It may not start or end with a dash.";
 
-	private Pattern PROJECT_NAME_PATTERN = Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?");
+	public static final String projectNameDescription = "A valid project name must be 63 characters or less but at least 2 characters, excluding \"..\".\n"
+			+ PROJECT_NAME_RULE;
+
+	private static final Pattern PROJECT_NAME_PATTERN = Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?");
 
 	private String message;
 
@@ -58,8 +60,7 @@ public class ProjectNameValidator extends LabelValueValidator {
 		}
 
 		if (!PROJECT_NAME_PATTERN.matcher(param).matches()) {
-			return ValidationStatus.error(
-					"Project name may only contain lower-case letters, numbers, and dashes. It may not start or end with a dash");
+			return ValidationStatus.error(PROJECT_NAME_RULE);
 		}
 		if (unavailableNames != null && unavailableNames.contains(param)) {
 			return ValidationStatus.error("A project with the same name already exists");

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/NewProjectWizardPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/project/NewProjectWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -42,7 +42,7 @@ public class NewProjectWizardPage extends AbstractOpenShiftWizardPage {
 	private NewProjectWizardModel model;
 
 	public NewProjectWizardPage(NewProjectWizardModel model, IWizard wizard) {
-		this("New OpenShift Project", "Please provide name, display name and description", model, wizard);
+		this("New OpenShift Project", "Please provide name, display name and description.\nProject names may only contains lowercase letters, numbers or dashes. They may not start or end with a dash.", model, wizard);
 	}
 
 	protected NewProjectWizardPage(String title, String description, NewProjectWizardModel model, IWizard wizard) {


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
