### PR TITLE
[JBIDE-26151] - When creating a resource label, rule must be displayed first

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/ResourceLabelsPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/common/ResourceLabelsPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -199,8 +199,8 @@ public class ResourceLabelsPage extends AbstractOpenShiftWizardPage {
 			public void widgetSelected(SelectionEvent e) {
 				IKeyValueWizardModel<Label> dialogModel = new KeyValueWizardModelBuilder<Label>()
 						.windowTitle(RESOURCE_LABEL)
-						.title("Add Label")
-						.description("Add a resource label.")
+						.title("Add a resource label")
+						.description("A valid label must be 63 characters or less and must begin (and end) with an alphanumeric character.")
 						.keyLabel(LABEL_KEY)
 						.keyDescription(LabelKeyValidator.keyDescription)
 						.valueDescription(


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
