### PR TITLE
Fix for org.apache.commons vulnerable dependency in

### DIFF
--- a/test-framework/org.jboss.tools.openshift.reddeer/pom.xml
+++ b/test-framework/org.jboss.tools.openshift.reddeer/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.16</version>
+			<version>1.18</version>
 		</dependency>
 	</dependencies>
 	


### PR DESCRIPTION
org.jboss.tools.openshift.reddeer (changing version from 1.16 to 1.18)

Signed-off-by: Josef Kopriva <jkopriva@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
