### PR TITLE
[JBIDE-26380] lookup connection via resource when tailing pod log

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/AbstractOpenShiftCliHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/AbstractOpenShiftCliHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -38,11 +39,16 @@ import org.eclipse.ui.progress.UIJob;
 import org.jboss.tools.foundation.ui.util.BrowserUtility;
 import org.jboss.tools.openshift.common.core.connection.IConnection;
 import org.jboss.tools.openshift.core.OpenShiftCoreMessages;
+import org.jboss.tools.openshift.core.connection.Connection;
+import org.jboss.tools.openshift.core.connection.ConnectionsRegistryUtil;
 import org.jboss.tools.openshift.internal.common.core.job.JobChainBuilder;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.core.ocbinary.OCBinary;
 import org.jboss.tools.openshift.internal.core.ocbinary.OCBinaryValidationJob;
 import org.jboss.tools.openshift.internal.core.ocbinary.OCBinaryValidator;
 import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
+
+import com.openshift.restclient.model.IResource;
 
 /**
  * 
@@ -52,8 +58,6 @@ import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
 public abstract class AbstractOpenShiftCliHandler extends AbstractHandler {
 
 	protected abstract void handleEvent(ExecutionEvent event);
-
-	protected abstract IConnection getConnection(ExecutionEvent event);
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
@@ -141,4 +145,19 @@ public abstract class AbstractOpenShiftCliHandler extends AbstractHandler {
 			widgetSelected(e);
 		}
 	}
+
+	protected IConnection getConnection(ExecutionEvent event) {
+        Connection connection = null;
+		IResource resource = getSelectedElement(event, IResource.class);
+		if (resource != null) {
+			connection = ConnectionsRegistryUtil.safeGetConnectionFor(resource);
+		}
+		return connection;
+	}
+
+	protected <T> T getSelectedElement(ExecutionEvent event, Class<T> klass) {
+		ISelection selection = UIUtils.getCurrentSelection(event);
+		return UIUtils.getFirstElement(selection, klass);
+	}
+
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PodLogsHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PodLogsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2016 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -18,18 +18,15 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.jboss.tools.openshift.common.core.connection.IConnection;
 import org.jboss.tools.openshift.core.OpenShiftAPIAnnotations;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.connection.ConnectionsRegistryUtil;
-import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.ui.job.PodLogsJob;
 
 import com.openshift.restclient.ResourceKind;
@@ -39,7 +36,8 @@ import com.openshift.restclient.model.IPod;
 
 /**
  * @author jeff.cantrill
- * @author Jeff Maury
+ * @contributor Jeff Maury
+ * @contributor Andre Dietisheim
  */
 public class PodLogsHandler extends AbstractOpenShiftCliHandler {
 	private static final String[] STATES = new String[] { "Running", "Succeeded", "Failed", "Completed", "Error" };
@@ -122,19 +120,5 @@ public class PodLogsHandler extends AbstractOpenShiftCliHandler {
 
 	protected void showDialog(ExecutionEvent event, String title, String message) {
 		MessageDialog.openError(HandlerUtil.getActiveShell(event), title, message);
-	}
-
-	@Override
-	protected IConnection getConnection(ExecutionEvent event) {
-		IBuild build = getSelectedElement(event, IBuild.class);
-		if (build != null) {
-			return ConnectionsRegistryUtil.safeGetConnectionFor(build);
-		}
-		return null;
-	}
-
-	protected <T> T getSelectedElement(ExecutionEvent event, Class<T> klass) {
-		ISelection selection = UIUtils.getCurrentSelection(event);
-		return UIUtils.getFirstElement(selection, klass);
 	}
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PortForwardingHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/PortForwardingHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -17,10 +17,7 @@ import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.jboss.tools.openshift.common.core.connection.IConnection;
 import org.jboss.tools.openshift.common.ui.wizard.OkButtonWizardDialog;
-import org.jboss.tools.openshift.core.connection.Connection;
-import org.jboss.tools.openshift.core.connection.ConnectionsRegistryUtil;
 import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
 import org.jboss.tools.openshift.internal.ui.portforwading.PortForwardingWizard;
 import org.jboss.tools.openshift.internal.ui.portforwading.PortForwardingWizardModel;
@@ -29,6 +26,7 @@ import com.openshift.restclient.model.IPod;
 
 /**
  * @author jeff.cantrill
+ * @contributor Andre Dietisheim
  */
 public class PortForwardingHandler extends AbstractOpenShiftCliHandler {
 
@@ -50,16 +48,5 @@ public class PortForwardingHandler extends AbstractOpenShiftCliHandler {
 		dialog.setMinimumPageSize(700, 400);
 		dialog.create();
 		dialog.open();
-	}
-
-	@Override
-	protected IConnection getConnection(ExecutionEvent event) {
-		ISelection selection = UIUtils.getCurrentSelection(event);
-		final IPod pod = UIUtils.getFirstElement(selection, IPod.class);
-		Connection connection = null;
-		if (pod != null) {
-			connection = ConnectionsRegistryUtil.safeGetConnectionFor(pod);
-		}
-		return connection;
 	}
 }


### PR DESCRIPTION
(was: lookup via pod)

Signed-off-by: Andre Dietisheim <adietish@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
