### PR TITLE
JBIDE-26339 - Update cdk.itests to use minishift 1.24

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/CDKAllTestsSuite.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/CDKAllTestsSuite.java
@@ -20,19 +20,16 @@ import org.jboss.tools.cdk.ui.bot.test.server.adapter.openshift.CDKImageRegistry
 import org.jboss.tools.cdk.ui.bot.test.server.adapter.openshift.CDKImageRegistryUrlValidatorTest;
 import org.jboss.tools.cdk.ui.bot.test.server.editor.CDK32ServerEditorTest;
 import org.jboss.tools.cdk.ui.bot.test.server.editor.CDK3ServerEditorTest;
-import org.jboss.tools.cdk.ui.bot.test.server.editor.MinishiftServerEditorTest;
 import org.jboss.tools.cdk.ui.bot.test.server.editor.launch.CDKLaunchConfigurationTest;
 import org.jboss.tools.cdk.ui.bot.test.server.runtime.CDK32RuntimeDetectionDevstudioStartUpTest;
 import org.jboss.tools.cdk.ui.bot.test.server.runtime.CDK32RuntimeDetectionTest;
 import org.jboss.tools.cdk.ui.bot.test.server.runtime.CDK3RuntimeDetectionTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.CDK32ServerWizardTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.CDK3ServerWizardTest;
-import org.jboss.tools.cdk.ui.bot.test.server.wizard.MinishiftServerWizardTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.download.CDK32DownloadRuntimeTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.download.CDK3DownloadRuntimeTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.download.DownloadContainerRuntimeDefaultSettingsTest;
 import org.jboss.tools.cdk.ui.bot.test.server.wizard.download.DownloadRuntimesWizardTest;
-import org.jboss.tools.cdk.ui.bot.test.server.wizard.download.MinishiftDownloadRuntimeTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -49,19 +46,16 @@ import org.junit.runners.Suite;
 	// Wizard tests by server adapter type
 	CDK3ServerWizardTest.class,
 	CDK32ServerWizardTest.class,
-	MinishiftServerWizardTest.class,
 	
 	// Downloading and installation of CDK/Minishift runtimes via new server wizard
 	CDK3DownloadRuntimeTest.class,
 	CDK32DownloadRuntimeTest.class,
-	MinishiftDownloadRuntimeTest.class,
 	DownloadContainerRuntimeDefaultSettingsTest.class,
 	DownloadRuntimesWizardTest.class,
 	
 	// Server editor tests by server adapter type
 	CDK3ServerEditorTest.class,
 	CDK32ServerEditorTest.class,
-	MinishiftServerEditorTest.class,
 	CDKLaunchConfigurationTest.class,
 	
 	

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterAbstractTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterAbstractTest.java
@@ -147,17 +147,7 @@ public abstract class CDKServerAdapterAbstractTest extends CDKAbstractTest {
 	
 	public void startServerAdapter(Server server, Runnable cond, boolean rethrow) {
 		log.info("Starting server adapter");
-		try {
-			ServerOperationHandler.getInstance().handleOperation(() -> server.start(), cond, rethrow);
-		} catch (AssertionError err) {
-			// prevent test to fail when everything seems to be working
-			if (err.getMessage().contains("The VM may not have been registered successfully") &&
-					err.getMessage().contains("The CDK VM is up and running")) {
-				log.info("Expected assertion error due to JBIDE-26333, causes test to fail, though functionality should be ok.");
-			} else {
-				throw err;
-			}
-		}
+		ServerOperationHandler.getInstance().handleOperation(() -> server.start(), cond, rethrow);
 		assertEquals(ServerState.STARTED, server.getLabel().getState());
 		setCertificateAccepted(true);
 	}

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/MinishiftServerAdapterTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/MinishiftServerAdapterTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
  */
 @CleanOpenShiftExplorer
 @ContainerRuntimeServer(
-		version = CDKVersion.MINISHIFT1210,
+		version = CDKVersion.MINISHIFT1240,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		useExistingBinaryInProperty="minishift")

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/CDK32ServerEditorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/CDK32ServerEditorTest.java
@@ -63,7 +63,7 @@ public class CDK32ServerEditorTest extends CDKServerEditorAbstractTest {
 	
 	@BeforeClass
 	public static void setupCDK32ServerEditorTest() {
-		MINISHIFT_PATH = serverRequirement.getServerAdapter().getMinishiftBinary().toAbsolutePath().toString();;
+		MINISHIFT_PATH = serverRequirement.getServerAdapter().getMinishiftBinary().toAbsolutePath().toString();
 	}
 	
 	@Before

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/MinishiftServerEditorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/MinishiftServerEditorTest.java
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(RedDeerSuite.class)
 @ContainerRuntimeServer(
-		version = CDKVersion.MINISHIFT1210,
+		version = CDKVersion.MINISHIFT1240,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		createServerAdapter=false,
@@ -62,7 +62,7 @@ public class MinishiftServerEditorTest extends CDKServerEditorAbstractTest {
 	
 	@BeforeClass
 	public static void setupCDK3ServerEditorTest() {
-		MINISHIFT_PATH = serverRequirement.getServerAdapter().getMinishiftBinary().toAbsolutePath().toString();;
+		MINISHIFT_PATH = serverRequirement.getServerAdapter().getMinishiftBinary().toAbsolutePath().toString();
 	}
 	
 	@Override

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionDevstudioStartUpTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionDevstudioStartUpTest.java
@@ -15,8 +15,14 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.eclipse.reddeer.common.condition.AbstractWaitCondition;
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitUntil;
+import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
+import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.jboss.tools.cdk.reddeer.core.enums.CDKServerAdapterType;
 import org.jboss.tools.cdk.reddeer.utils.CDKUtils;
 import org.junit.Test;
@@ -35,13 +41,40 @@ public class CDK32RuntimeDetectionDevstudioStartUpTest {
 
 	@Test
 	public void testCDK32PresentAfterDevstudioStart() {
+		new WaitUntil(new JobIsRunning(), TimePeriod.MEDIUM, false);
+		new WaitWhile(new JobIsRunning(), TimePeriod.DEFAULT, false);
+		new WaitUntil(new ServerAdapterTypeExists(CDKServerAdapterType.CDK32), TimePeriod.DEFAULT);
 		List<Server> servers = CDKUtils.getAllServers();
 		assertFalse("There are no servers in Servers View", servers.isEmpty());
 		assertTrue("There should be just one server present but there are " + servers.size(), 
 				CDKUtils.getAllServers().size() == 1);
-		for (Server server : servers) {
-			assertTrue("Given server " + server.getLabel().getName() + " is supposed to be of " + CDKServerAdapterType.CDK32.serverType(),
-					CDKUtils.isServerOfType(server, CDKServerAdapterType.CDK32.serverType()));
+		Server server = servers.get(0);
+		assertTrue("Given server " + server.getLabel().getName() +
+				" is supposed to be of " + CDKServerAdapterType.CDK32.serverType(),
+				CDKUtils.isServerOfType(server, CDKServerAdapterType.CDK32.serverType()));
+	}
+	
+	private class ServerAdapterTypeExists extends AbstractWaitCondition {
+
+		ServersView2 view;
+		
+		CDKServerAdapterType type;
+		
+		public ServerAdapterTypeExists(CDKServerAdapterType type) {
+			this.type = type;
+			view = new ServersView2();
+			view.open();
 		}
+		
+		@Override
+		public boolean test() {
+			for (Server server : view.getServers()) {
+				if (CDKUtils.isServerOfType(server, type.serverType())) {
+					return true;
+				}
+			}
+			return false;
+		}
+		
 	}
 }

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionTest.java
@@ -15,11 +15,14 @@ import org.jboss.tools.cdk.reddeer.core.enums.CDKVersion;
 import org.jboss.tools.cdk.reddeer.core.server.ServerAdapter;
 import org.jboss.tools.cdk.reddeer.requirements.ContainerRuntimeServerRequirement;
 import org.jboss.tools.cdk.reddeer.requirements.ContainerRuntimeServerRequirement.ContainerRuntimeServer;
+import org.jboss.tools.cdk.reddeer.requirements.RemoveCDKServersRequirement.RemoveCDKServers;
 
+@RemoveCDKServers
 @ContainerRuntimeServer(
 		version = CDKVersion.CDK350,
 		usernameProperty="developers.username",
-		passwordProperty="developers.password")
+		passwordProperty="developers.password",
+		createServerAdapter=false)
 public class CDK32RuntimeDetectionTest extends CDKRuntimeDetectionTemplate {
 
 	@InjectRequirement

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK3RuntimeDetectionTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK3RuntimeDetectionTest.java
@@ -15,11 +15,14 @@ import org.jboss.tools.cdk.reddeer.core.enums.CDKVersion;
 import org.jboss.tools.cdk.reddeer.core.server.ServerAdapter;
 import org.jboss.tools.cdk.reddeer.requirements.ContainerRuntimeServerRequirement;
 import org.jboss.tools.cdk.reddeer.requirements.ContainerRuntimeServerRequirement.ContainerRuntimeServer;
+import org.jboss.tools.cdk.reddeer.requirements.RemoveCDKServersRequirement.RemoveCDKServers;
 
+@RemoveCDKServers
 @ContainerRuntimeServer(
 		version = CDKVersion.CDK311,
 		usernameProperty="developers.username",
-		passwordProperty="developers.password")
+		passwordProperty="developers.password",
+		createServerAdapter=false)
 public class CDK3RuntimeDetectionTest extends CDKRuntimeDetectionTemplate {
 
 	@InjectRequirement

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDKRuntimeDetectionTemplate.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDKRuntimeDetectionTemplate.java
@@ -30,7 +30,6 @@ import org.eclipse.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
 import org.jboss.tools.cdk.reddeer.core.enums.CDKVersion;
 import org.jboss.tools.cdk.reddeer.core.runtime.Runtime;
 import org.jboss.tools.cdk.reddeer.core.server.ServerAdapter;
-import org.jboss.tools.cdk.reddeer.requirements.RemoveCDKServersRequirement.RemoveCDKServers;
 import org.jboss.tools.cdk.reddeer.server.ui.runtime.RuntimeDetectionPreferencePage;
 import org.jboss.tools.cdk.reddeer.server.ui.runtime.SearchingForRuntimesDialog;
 import org.jboss.tools.cdk.reddeer.utils.CDKUtils;
@@ -45,7 +44,6 @@ import org.junit.runner.RunWith;
  * @author odockal
  *
  */
-@RemoveCDKServers
 @RunWith(RedDeerSuite.class)
 public abstract class CDKRuntimeDetectionTemplate extends CDKAbstractTest {
 

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/CDK3DownloadRuntimeTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/CDK3DownloadRuntimeTest.java
@@ -21,31 +21,32 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 /**
  * Class covers runtime download test for CDK 3.x versions
+ * 
  * @author odockal
  *
  */
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 public class CDK3DownloadRuntimeTest extends DownloadContainerRuntimeAbstractTest {
 
-  private CDKVersion version;
-  
-  public CDK3DownloadRuntimeTest(CDKVersion version) {
-    this.version = version;
-  }
-  
-  @Parameters(name="{0}")
-  public static Collection<CDKVersion> data() {
-    return Arrays.asList(CDKVersion.CDK311);
-  }
-  
-  @Override
-  protected String getServerAdapter() {
-    return SERVER_ADAPTER_3;
-  }
-  
-  @Test
-  public void testDownloadingCDK3XRuntime() {
-    downloadAndVerifyCDKRuntime(version, USERNAME, PASSWORD);
-  }
-	
+	private CDKVersion version;
+
+	public CDK3DownloadRuntimeTest(CDKVersion version) {
+		this.version = version;
+	}
+
+	@Parameters(name = "{0}")
+	public static Collection<CDKVersion> data() {
+		return Arrays.asList(CDKVersion.CDK311);
+	}
+
+	@Override
+	protected String getServerAdapter() {
+		return SERVER_ADAPTER_3;
+	}
+
+	@Test
+	public void testDownloadingCDK3XRuntime() {
+		downloadAndVerifyCDKRuntime(version, USERNAME, PASSWORD);
+	}
+
 }

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadContainerRuntimeDefaultSettingsTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadContainerRuntimeDefaultSettingsTest.java
@@ -32,7 +32,7 @@ public class DownloadContainerRuntimeDefaultSettingsTest extends DownloadContain
 	
 	@Test
 	public void testDownloadingMinishiftRuntimeDefaults() {
-		downloadAndVerifyContainerRuntime(CDKVersion.MINISHIFT1210, "", "", "", "", true, true);
+		downloadAndVerifyContainerRuntime(CDKVersion.MINISHIFT1240, "", "", "", "", true, true);
 	}
 	
 }

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadLatestContainerRuntimeTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadLatestContainerRuntimeTest.java
@@ -35,7 +35,7 @@ public class DownloadLatestContainerRuntimeTest extends DownloadContainerRuntime
   
   @Parameters(name="{0}")
   public static Collection<CDKVersion> data() {
-    return Arrays.asList(CDKVersion.CDK311, CDKVersion.CDK350, CDKVersion.MINISHIFT1210);
+    return Arrays.asList(CDKVersion.CDK311, CDKVersion.CDK350, CDKVersion.MINISHIFT1240);
   }
   
   @Override

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/MinishiftDownloadRuntimeTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/MinishiftDownloadRuntimeTest.java
@@ -20,7 +20,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 /**
- * Class covers runtime download test for Minishift 1.14, 1.15.1, 1.16.1, 1.17.0
+ * Class covers runtime download test for Minishift 1.14, 1.15.1, 1.16.1, 1.17.0, etc.
  * 
  * @author odockal
  *
@@ -36,7 +36,7 @@ public class MinishiftDownloadRuntimeTest extends DownloadContainerRuntimeAbstra
 
 	@Parameters(name = "{0}")
 	public static Collection<CDKVersion> data() {
-		return Arrays.asList(CDKVersion.MINISHIFT1210);
+		return Arrays.asList(CDKVersion.MINISHIFT1240);
 	}
 
 	@Override

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKServerAdapterType.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKServerAdapterType.java
@@ -27,7 +27,7 @@ public enum CDKServerAdapterType {
 	private final String serverType;
 	private final String serverTypeName;
 	
-	CDKServerAdapterType(String runtimeTypeName, String type,String name) {
+	CDKServerAdapterType(String runtimeTypeName, String type, String name) {
 		this.runtimeTypeName = runtimeTypeName;
 		this.serverType = type;
 		this.serverTypeName = name;

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKVersion.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKVersion.java
@@ -35,7 +35,10 @@ public enum CDKVersion {
 	MINISHIFT1180 (CDKServerAdapterType.MINISHIFT17, "1.18.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.18.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1190 (CDKServerAdapterType.MINISHIFT17, "1.19.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.19.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1200 (CDKServerAdapterType.MINISHIFT17, "1.20.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.20.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
-	MINISHIFT1210 (CDKServerAdapterType.MINISHIFT17, "1.21.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.21.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch());
+	MINISHIFT1210 (CDKServerAdapterType.MINISHIFT17, "1.21.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.21.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
+	MINISHIFT1220 (CDKServerAdapterType.MINISHIFT17, "1.22.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.22.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
+	MINISHIFT1230 (CDKServerAdapterType.MINISHIFT17, "1.23.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.23.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
+	MINISHIFT1240 (CDKServerAdapterType.MINISHIFT17, "1.24.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.24.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch());
 	
 	private final CDKServerAdapterType type;
 	private final String version;


### PR DESCRIPTION
   - Add another release minishift version
   - Make CDKRuntimeDetectionTest robust

Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
