### PR TITLE
Adjusting cdk server start up timeouts

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32IntegrationTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32IntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 @CleanOpenShiftExplorer
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32ServerAdapterProfilesTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32ServerAdapterProfilesTest.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
 @CleanOpenShiftExplorer
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		usernameProperty="developers.username",
 		passwordProperty="developers.password",
 		useExistingBinaryFromConfig=true,

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterAbstractTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterAbstractTest.java
@@ -256,8 +256,9 @@ public abstract class CDKServerAdapterAbstractTest extends CDKAbstractTest {
 		}
 		for (Server server : view.getServers()) {
 			log.info("Checking server " + server.getLabel().getName() +  " state: " + server.getLabel().getState());  
-			if (server.getLabel().getState().equals(ServerState.STARTED)) {
-				log.info("Stopping server"); 
+			if (server.getLabel().getState().equals(ServerState.STARTED) || 
+					server.getLabel().getState().equals(ServerState.STARTING)) {
+				log.info("Stopping server");
 				server.stop();
 				CDKUtils.collectConsoleOutput(log, false);
 			}

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterSetupCDKTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterSetupCDKTest.java
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKWrongCredentialsTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKWrongCredentialsTest.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 @CleanOpenShiftExplorer
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		usernameProperty="developers.username",
 		passwordProperty="developers.password",
 		useExistingBinaryFromConfig=true,

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryFailureTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryFailureTest.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlValidatorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlValidatorTest.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/CDK32ServerEditorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/CDK32ServerEditorTest.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(RedDeerSuite.class)
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/MinishiftServerEditorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/MinishiftServerEditorTest.java
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(RedDeerSuite.class)
 @ContainerRuntimeServer(
-		version = CDKVersion.MINISHIFT1261,
+		version = CDKVersion.MINISHIFT1280,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		createServerAdapter=false,

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/launch/CDKLaunchConfigurationTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/launch/CDKLaunchConfigurationTest.java
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(RedDeerSuite.class)
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionTest.java
@@ -19,7 +19,7 @@ import org.jboss.tools.cdk.reddeer.requirements.RemoveCDKServersRequirement.Remo
 
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK360,
+		version = CDKVersion.CDK370,
 		usernameProperty="developers.username",
 		passwordProperty="developers.password",
 		createServerAdapter=false)

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/CDK32DownloadRuntimeTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/CDK32DownloadRuntimeTest.java
@@ -35,7 +35,7 @@ public class CDK32DownloadRuntimeTest extends DownloadContainerRuntimeAbstractTe
   
   @Parameters(name="{0}")
   public static Collection<CDKVersion> data() {
-    return Arrays.asList(CDKVersion.CDK350);
+    return Arrays.asList(CDKVersion.CDK360);
   }
   
   @Override

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadContainerRuntimeDefaultSettingsTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadContainerRuntimeDefaultSettingsTest.java
@@ -27,12 +27,12 @@ public class DownloadContainerRuntimeDefaultSettingsTest extends DownloadContain
 	
 	@Test
 	public void testDownloadingCDK360RuntimeDefaults() {
-		downloadAndVerifyContainerRuntime(CDKVersion.CDK360, USERNAME, PASSWORD, "", "", true, true);
+		downloadAndVerifyContainerRuntime(CDKVersion.CDK370, USERNAME, PASSWORD, "", "", true, true);
 	}
 	
 	@Test
 	public void testDownloadingMinishiftRuntimeDefaults() {
-		downloadAndVerifyContainerRuntime(CDKVersion.MINISHIFT1261, "", "", "", "", true, true);
+		downloadAndVerifyContainerRuntime(CDKVersion.MINISHIFT1280, "", "", "", "", true, true);
 	}
 	
 }

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadLatestContainerRuntimeTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadLatestContainerRuntimeTest.java
@@ -35,7 +35,7 @@ public class DownloadLatestContainerRuntimeTest extends DownloadContainerRuntime
   
   @Parameters(name="{0}")
   public static Collection<CDKVersion> data() {
-    return Arrays.asList(CDKVersion.CDK311, CDKVersion.CDK360, CDKVersion.MINISHIFT1270);
+    return Arrays.asList(CDKVersion.CDK311, CDKVersion.CDK370, CDKVersion.MINISHIFT1280);
   }
   
   @Override

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadRuntimesWizardTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadRuntimesWizardTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  */
 public class DownloadRuntimesWizardTest extends DownloadContainerRuntimeAbstractTest {
 
-	private static final CDKVersion version = CDKVersion.CDK360;
+	private static final CDKVersion version = CDKVersion.CDK370;
 	
 	private static final String INVALID_CREDENTIALS = "credentials have failed to validate";
 	

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKVersion.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKVersion.java
@@ -29,6 +29,7 @@ public enum CDKVersion {
 	CDK340 	(CDKServerAdapterType.CDK32, "3.4.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.4.0-2-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
 	CDK350 	(CDKServerAdapterType.CDK32, "3.5.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.5.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
 	CDK360 	(CDKServerAdapterType.CDK32, "3.6.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.6.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
+	CDK370 	(CDKServerAdapterType.CDK32, "3.7.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.7.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
 	MINISHIFT1140 (CDKServerAdapterType.MINISHIFT17, "1.14.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.14.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1151 (CDKServerAdapterType.MINISHIFT17, "1.15.1", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.15.1-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1161 (CDKServerAdapterType.MINISHIFT17, "1.16.1", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.16.1-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
@@ -42,7 +43,8 @@ public enum CDKVersion {
 	MINISHIFT1240 (CDKServerAdapterType.MINISHIFT17, "1.24.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.24.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1250 (CDKServerAdapterType.MINISHIFT17, "1.25.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.25.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1261 (CDKServerAdapterType.MINISHIFT17, "1.26.1", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.26.1-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
-	MINISHIFT1270 (CDKServerAdapterType.MINISHIFT17, "1.27.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.27.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch());
+	MINISHIFT1270 (CDKServerAdapterType.MINISHIFT17, "1.27.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.27.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
+	MINISHIFT1280 (CDKServerAdapterType.MINISHIFT17, "1.28.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.28.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch());
 	
 	private final CDKServerAdapterType type;
 	private final String version;

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/ui/CDKServer.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/server/ui/CDKServer.java
@@ -88,9 +88,9 @@ public class CDKServer extends DefaultServer {
 		ServerState actualState = this.getLabel().getState();
 		MultipleWaitConditionHandler waitConditions = new MultipleWaitConditionHandler(
 				waitConditionMatrix);
-		TimePeriod timeout = TimePeriod.VERY_LONG;
+		TimePeriod timeout = TimePeriod.getCustom(900);
 		if (menuItem == CDKLabel.ServerContextMenu.RESTART) { 
-			timeout = TimePeriod.getCustom(480);
+			timeout = TimePeriod.getCustom(1020);
 		}
 		log.debug("Operate server's state from: + '" + actualState + "' to '" + menuItem + "'");  
 		select();
@@ -106,7 +106,7 @@ public class CDKServer extends DefaultServer {
 		// decide if we wait for SSL acceptance dialog
 		if ((actualState == ServerState.STOPPING || actualState == ServerState.STOPPED) 
 				&& !getCertificatedAccepted()) {
-			new WaitUntil(waitConditions, TimePeriod.getCustom(1800));
+			new WaitUntil(waitConditions, TimePeriod.getCustom(900));
 		}
 		new WaitUntil(new ServerHasState(this, resultState), timeout);
 		waitForProblemDialog(waitConditions, menuItem, TimePeriod.DEFAULT);


### PR DESCRIPTION
   - upversioning of cdk/minishift artifacts

Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
