### PR TITLE
[JBIDE-26562] OSServerLauncher: dont join with maven switching job

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/ActivateMavenProfileJob.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/ActivateMavenProfileJob.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2016-2019 Red Hat Inc..
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Incorporated - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.openshift.core.server.behavior;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.osgi.util.NLS;
+import org.jboss.tools.foundation.core.plugin.log.StatusFactory;
+import org.jboss.tools.openshift.core.util.MavenProfile;
+import org.jboss.tools.openshift.internal.core.OpenShiftCoreActivator;
+
+/**
+ * @author Andre Dietisheim
+ */
+class ActivateMavenProfileJob extends Job {
+
+	public enum Action {
+		ACTIVATE,
+		DEACTIVATE
+	}
+
+	private final IProject project;
+	private Action action;
+
+	public ActivateMavenProfileJob(Action action, IProject project) {
+		super(NLS.bind("{0} maven profile \"openshift\" for project {1}", 
+				action == Action.ACTIVATE? "Activating" : "Deactivating", project.getName()));
+		this.action = action;
+		this.project = project;
+		// need to lock the whole workspace to prevent dead locks with other, concurrent
+		// jobs that escalate to the workspace lock.
+		setRule(ResourcesPlugin.getWorkspace().getRoot());
+	}
+
+	@Override
+	public IStatus run(IProgressMonitor monitor) {
+		try {
+			if (monitor.isCanceled()) {
+				return Status.CANCEL_STATUS;
+			}
+			MavenProfile profile = new MavenProfile(MavenProfile.OPENSHIFT_MAVEN_PROFILE, project);
+
+			switch(action) {
+			case ACTIVATE:
+				profile.activate(monitor);
+				break;
+			case DEACTIVATE:
+				profile.deactivate(monitor);
+				break;
+			default:
+				break;
+			}
+			return Status.OK_STATUS;
+		} catch (CoreException e) {
+			return StatusFactory.errorStatus(OpenShiftCoreActivator.PLUGIN_ID,
+					NLS.bind("Could not {0} maven profile {1}", 
+							this.action.toString().toLowerCase(), MavenProfile.OPENSHIFT_MAVEN_PROFILE));
+        }
+	}
+}


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
