### PR TITLE
[JBDS-4777] Extract docker image uri from container spec

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015-2017 Red Hat Inc..
+ * Copyright (c) 2015-2019 Red Hat Inc..
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -565,8 +565,9 @@ public class OpenShiftServerUtils {
 	 * @param resource the resource to derive the pod and docker image from
 	 * @param server the server to derive the openshift connection from
 	 * @return
+	 * @throws CoreException 
 	 */
-	public static String loadPodPath(IResource resource, IServer server, IProgressMonitor monitor) {
+	public static String loadPodPath(IResource resource, IServer server, IProgressMonitor monitor) throws CoreException {
 		DockerImageLabels metaData = DockerImageLabels.getInstance(resource, getBehaviour(server));
 		return metaData.getPodPath(monitor);
 	}

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/PodDeploymentPathMetadata.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/PodDeploymentPathMetadata.java
@@ -53,10 +53,9 @@ public class PodDeploymentPathMetadata {
 
 	private String getPodPath(String imageMetaData) {
 		String podPath = null;
-		if ((podPath = matchFirstGroup(imageMetaData, PATTERN_REDHAT_DEPLOYMENTS_DIR)) == null) {
-			if ((podPath = matchFirstGroup(imageMetaData, PATTERN_JBOSS_DEPLOYMENTS_DIR)) == null) {
-				podPath = matchFirstGroup(imageMetaData, PATTERN_WOKRING_DIR);
-			}
+		if ((podPath = matchFirstGroup(imageMetaData, PATTERN_REDHAT_DEPLOYMENTS_DIR)) == null
+				&& (podPath = matchFirstGroup(imageMetaData, PATTERN_JBOSS_DEPLOYMENTS_DIR)) == null) {
+			podPath = matchFirstGroup(imageMetaData, PATTERN_WOKRING_DIR);
 		}
 
 		return podPath;

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftLaunchController.java
@@ -251,7 +251,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		return true;
 	}
 
-	protected boolean waitForDockerImageLabelsReady(DockerImageLabels metadata, IProgressMonitor monitor) {
+	protected boolean waitForDockerImageLabelsReady(DockerImageLabels metadata, IProgressMonitor monitor) throws CoreException {
 		monitor.subTask("Waiting for docker image to become available...");
 		long timeout = System.currentTimeMillis() + WAIT_FOR_DOCKERIMAGELABELS_TIMEOUT;
 		while (!metadata.load(monitor)) {
@@ -285,7 +285,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		}
 	}
 
-	protected DebugContext createDebugContext(OpenShiftServerBehaviour beh, IProgressMonitor monitor) {
+	protected DebugContext createDebugContext(OpenShiftServerBehaviour beh, IProgressMonitor monitor) throws CoreException {
 		monitor.subTask("Initialising debugging...");
 
 		DockerImageLabels imageLabels = getDockerImageLabels(beh, monitor);
@@ -299,7 +299,7 @@ public class OpenShiftLaunchController extends AbstractSubsystemController
 		return new DebugContext(beh.getServer(), devmodeKey, debugPortKey, debugPort);
 	}
 
-	private DockerImageLabels getDockerImageLabels(OpenShiftServerBehaviour beh, IProgressMonitor monitor) {
+	private DockerImageLabels getDockerImageLabels(OpenShiftServerBehaviour beh, IProgressMonitor monitor) throws CoreException {
 		IResource resource = OpenShiftServerUtils.getResource(beh.getServer(), monitor);
 		DockerImageLabels metadata = DockerImageLabels.getInstance(resource, beh);
 		waitForDockerImageLabelsReady(metadata, monitor);

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftPublishController.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/behavior/OpenShiftPublishController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc..
+ * Copyright (c) 2016-2019 Red Hat Inc..
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -122,7 +122,7 @@ public class OpenShiftPublishController extends StandardFileSystemPublishControl
 		}
 	}
 
-	protected void loadPodPathIfEmpty(final IResource resource, IProgressMonitor monitor) {
+	protected void loadPodPathIfEmpty(final IResource resource, IProgressMonitor monitor) throws CoreException {
 		// If the pod path is not set on the project yet, we can do that now
 		// to make future fetches faster
 		String podPath = OpenShiftServerUtils.getPodPath(getServer());

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/DebugContext.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/server/debug/DebugContext.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.wst.server.core.IServer;
 
 import com.openshift.restclient.model.IPod;
@@ -65,14 +64,14 @@ public class DebugContext {
 	 * @return
 	 */
 	public DebugContext(IServer server, String devmodeKey, String debugPortKey, String debugPort) {
-		Assert.isNotNull(server, "Could not find server to set dev mode / debugging on.");
-		Assert.isNotNull(devmodeKey, "Could not find key to enable dev mode with.");
-		Assert.isNotNull(debugPortKey, "Could not find key to enable debugging with.");
-		Assert.isNotNull(debugPort, "Could not find debugging port.");
+		assertNotNull(server, "Could not find server to set dev mode / debugging on.");
+		assertNotNull(devmodeKey, "Could not find key to enable dev mode with.");
+		assertNotNull(debugPortKey, "Could not find key to enable debugging with.");
+		assertNotNull(debugPort, "Could not find debugging port.");
 
 		this.server = server;
 		this.devmodeKey = devmodeKey;
-		this.debugPortKey = debugPortKey;
+		this.debugPortKey = debugPortKey;	
 		this.debugPort = getDebugPort(debugPort);
 	}
 
@@ -146,6 +145,12 @@ public class DebugContext {
 			return Integer.parseInt(debugPort);
 		} catch (NumberFormatException e) {
 			return NO_DEBUG_PORT;
+		}
+	}
+	
+	void assertNotNull(Object object, String message) {
+		if (object == null) {
+			throw new IllegalArgumentException(message);
 		}
 	}
 }

--- a/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/launcher/NodeDebugLauncher.java
+++ b/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/launcher/NodeDebugLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Red Hat Inc..
+ * Copyright (c) 2016-2019 Red Hat Inc..
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -95,7 +95,7 @@ public final class NodeDebugLauncher {
 		}
 	}
 
-	private static String getPodPath(IServer server, IProgressMonitor monitor) {
+	private static String getPodPath(IServer server, IProgressMonitor monitor) throws CoreException {
 		IResource resource = OpenShiftServerUtils.getResource(server, monitor);
 		return OpenShiftServerUtils.loadPodPath(resource, server, monitor);
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/DockerImageLabelsTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/DockerImageLabelsTest.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2017 Red Hat, Inc. 
+ * Copyright (c) 2017-2019 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -11,9 +11,9 @@
 package org.jboss.tools.openshift.test.core.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.jboss.tools.openshift.test.util.ResourceMocks.createConnection;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -23,21 +23,29 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.jboss.tools.openshift.core.connection.Connection;
 import org.jboss.tools.openshift.core.server.DockerImageLabels;
 import org.jboss.tools.openshift.test.util.ResourceMocks;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.images.DockerImageURI;
+import com.openshift.restclient.model.IContainer;
 import com.openshift.restclient.model.IDeploymentConfig;
 import com.openshift.restclient.model.IResource;
 import com.openshift.restclient.model.deploy.DeploymentTriggerType;
@@ -46,36 +54,123 @@ import com.openshift.restclient.model.deploy.IDeploymentImageChangeTrigger;
 @RunWith(MockitoJUnitRunner.class)
 public class DockerImageLabelsTest {
 
-	private static final String NODEJS_IMAGESTREAM_TAG_URL = "/resources/imageStreamTag_nodejs_latest.json";
+	private static final String DOCKER_IMAGE_TAG = "nodejs:latest";
 
-	private Connection connection;
-	private IDeploymentConfig dc;
+	private static final String NODEJS_IMAGESTREAM_TAG_URI = "/resources/imageStreamTag_nodejs_latest.json";
+
 	private TestableDockerImageLabels labels;
-	private TestableDockerImageLabels labelsThatFailsToLoad;
+	private TestableDockerImageLabels labelsThatFailsToLoadImageStreamTag;
+	private TestableDockerImageLabels labelsThatHaveNoDc;
+	private TestableDockerImageLabels labelsThatHaveNoImage;
+	private TestableDockerImageLabels labelsThatHaveOnlyTrigger;
+	private TestableDockerImageLabels labelsThatHaveOnlyContainer;
 
 	@Before
 	public void setup() throws IOException {
-		this.connection = createConnection("https://localhost:8181", "aUser");
+		Connection connection = ResourceMocks.createConnection("https://localhost:8181", "aUser");
+		this.labelsThatHaveNoDc = new TestableDockerImageLabels(null, connection);
 
-		this.labelsThatFailsToLoad = spy(new TestableDockerImageLabels(null, connection));
+		IDeploymentConfig dc = ResourceMocks.createDeploymentConfig("aDeploymentConfig",
+				ResourceMocks.createProject("aProject"), null, null);
+		this.labelsThatHaveNoImage = new TestableDockerImageLabels(dc, connection);
 
-		this.dc = ResourceMocks.createDeploymentConfig("aDeploymentConfig", ResourceMocks.createProject("aProject"),
-				null, null);
-		IDeploymentImageChangeTrigger trigger = ResourceMocks
-				.createDeploymentImageChangeTrigger(DeploymentTriggerType.IMAGE_CHANGE, "nodejs:latest");
-		ResourceMocks.mockGetTriggers(Collections.singletonList(trigger), dc);
+		connection = ResourceMocks.createConnection("https://localhost:8282", "aUser");
+		dc = mockDeploymentConfig(null, null);
+		this.labelsThatHaveNoImage = new TestableDockerImageLabels(dc, connection);
 
-		IResource imageStreamTag = mockImageStreamTag(NODEJS_IMAGESTREAM_TAG_URL);
-		doReturn(imageStreamTag).when(connection).getResource(eq(ResourceKind.IMAGE_STREAM_TAG), anyString(),
-				anyString());
+		connection = ResourceMocks.createConnection("https://localhost:8383", "aUser");
+		dc = mockDeploymentConfig(DOCKER_IMAGE_TAG, null);
+		mockImageStreamTag(NODEJS_IMAGESTREAM_TAG_URI, connection);
+		this.labelsThatHaveOnlyTrigger = spy(new TestableDockerImageLabels(dc, connection));
 
+		connection = ResourceMocks.createConnection("https://localhost:8484", "aUser");
+		dc = mockDeploymentConfig(null, DOCKER_IMAGE_TAG);
+		mockImageStreamTag(NODEJS_IMAGESTREAM_TAG_URI, connection);
+		this.labelsThatHaveOnlyContainer = spy(new TestableDockerImageLabels(dc, connection));
+
+		connection = ResourceMocks.createConnection("https://localhost:8585", "aUser");
+		dc = mockDeploymentConfig(DOCKER_IMAGE_TAG, DOCKER_IMAGE_TAG);
+		mockImageStreamTag(NODEJS_IMAGESTREAM_TAG_URI, connection);
 		this.labels = spy(new TestableDockerImageLabels(dc, connection));
+
+		connection = ResourceMocks.createConnection("https://localhost:8686", "aUser");
+		dc = mockDeploymentConfig(DOCKER_IMAGE_TAG, DOCKER_IMAGE_TAG);
+		this.labelsThatFailsToLoadImageStreamTag = spy(new TestableDockerImageLabels(dc, connection));
+		doReturn(null)
+			.when(labelsThatFailsToLoadImageStreamTag)
+				.getImageStreamTag(any(DockerImageURI.class), anyString(), any(IProgressMonitor.class));
+	}
+
+	private IDeploymentConfig mockDeploymentConfig(String triggerImageUri, String containerImageUri) {
+		IDeploymentConfig withChangeTriggerAndContainerImage = 
+				ResourceMocks.createDeploymentConfig("dc", 
+						ResourceMocks.createProject("aProject"), null, null);
+		mockImageChangeTrigger(triggerImageUri, withChangeTriggerAndContainerImage);
+		mockContainer(containerImageUri, withChangeTriggerAndContainerImage);
+		return withChangeTriggerAndContainerImage;
+	}
+
+	private void mockImageChangeTrigger(String imageUri, IDeploymentConfig dc) {
+		if (imageUri == null) {
+			return;
+		}
+		IDeploymentImageChangeTrigger trigger = ResourceMocks
+				.createDeploymentImageChangeTrigger(DeploymentTriggerType.IMAGE_CHANGE, imageUri);
+		ResourceMocks.mockGetTriggers(Collections.singletonList(trigger), dc);
+	}
+
+	private void mockContainer(String imageUri, IDeploymentConfig dc) {
+		if (StringUtils.isEmpty(imageUri)) {
+			return;
+		}
+		ResourceMocks.mockGetImages(Collections.singletonList(imageUri), dc);
+	}
+
+	private void mockImageStreamTag(String url, Connection connection) throws IOException {
+		IResource imageStreamTag = mockImageStreamTag(url);
+		doReturn(imageStreamTag)
+			.when(connection).getResource(eq(ResourceKind.IMAGE_STREAM_TAG), anyString(), anyString());
 	}
 
 	private IResource mockImageStreamTag(String url) throws IOException {
 		IResource imageStreamTag = mock(IResource.class);
-		doReturn(IOUtils.toString(DockerImageLabelsTest.class.getResourceAsStream(url))).when(imageStreamTag).toJson();
+		doReturn(IOUtils.toString(DockerImageLabelsTest.class.getResourceAsStream(url), Charset.defaultCharset()))
+				.when(imageStreamTag).toJson();
 		return imageStreamTag;
+	}
+
+	@Test(expected = CoreException.class)
+	public void shouldThrowIfHasNoDc() throws CoreException {
+		// given
+		// when
+		labelsThatHaveNoDc.load(new NullProgressMonitor());
+	}
+
+	@Test(expected = CoreException.class)
+	public void shouldThrowIfCannotFindImage() throws CoreException {
+		// given
+		// when
+		labelsThatHaveNoImage.load(new NullProgressMonitor());
+	}
+
+	@Test
+	public void shouldHaveImageIfDcHasOnlyTrigger() throws CoreException {
+		// given
+		// when
+		labelsThatHaveOnlyTrigger.load(new NullProgressMonitor());
+		// then
+		verify(labelsThatHaveOnlyTrigger).getImageStreamTag(
+				argThat(new DockerImageURIArgumentMatcher()), anyString(), any(IProgressMonitor.class));
+	}
+
+	@Test
+	public void shouldHaveImageIfDcHasOnlyContainer() throws CoreException {
+		// given
+		// when
+		labelsThatHaveOnlyContainer.load(new NullProgressMonitor());
+		// then
+		verify(labelsThatHaveOnlyContainer).getImageStreamTag(
+				argThat(new DockerImageURIArgumentMatcher()), anyString(), any(IProgressMonitor.class));
 	}
 
 	@Test
@@ -92,28 +187,37 @@ public class DockerImageLabelsTest {
 	public void loadShouldReturnFalseGivenLoadFails() throws CoreException {
 		// given
 		// when
-		boolean success = labelsThatFailsToLoad.load(new NullProgressMonitor());
+		boolean success = labelsThatFailsToLoadImageStreamTag.load(new NullProgressMonitor());
 		// then
 		assertThat(success).isFalse();
+	}
+
+	@Test
+	public void loadShouldReturnTrueGivenLoadSucceeds() throws CoreException {
+		// given
+		// when
+		boolean success = labels.load(new NullProgressMonitor());
+		// then
+		assertThat(success).isTrue();
 	}
 
 	@Test
 	public void shouldNotBeAvailableGivenLoadFailsToLoadMetadata() throws CoreException {
 		// given
 		// when
-		labelsThatFailsToLoad.load(new NullProgressMonitor());
+		labelsThatFailsToLoadImageStreamTag.load(new NullProgressMonitor());
 		// then
-		verify(labelsThatFailsToLoad, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
-		assertThat(labels.isAvailable()).isFalse();
+		verify(labelsThatFailsToLoadImageStreamTag, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
+		assertThat(labelsThatFailsToLoadImageStreamTag.isAvailable()).isFalse();
 	}
 
 	@Test
 	public void shouldTryToLoadGivenDevmodeKeyIsRequested() throws CoreException {
 		// given
 		// when
-		String devmodeKey = labelsThatFailsToLoad.getDevmodeKey(new NullProgressMonitor());
+		String devmodeKey = labelsThatFailsToLoadImageStreamTag.getDevmodeKey(new NullProgressMonitor());
 		// then
-		verify(labelsThatFailsToLoad, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
+		verify(labelsThatFailsToLoadImageStreamTag, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
 		assertThat(devmodeKey).isNull();
 	}
 
@@ -121,10 +225,10 @@ public class DockerImageLabelsTest {
 	public void shouldTryToLoadAgainGivenPriorLoadFailed() throws CoreException {
 		// given
 		// when
-		labelsThatFailsToLoad.getDevmodeKey(new NullProgressMonitor());
-		labelsThatFailsToLoad.getDevmodeKey(new NullProgressMonitor());
+		labelsThatFailsToLoadImageStreamTag.getDevmodeKey(new NullProgressMonitor());
+		labelsThatFailsToLoadImageStreamTag.getDevmodeKey(new NullProgressMonitor());
 		// then
-		verify(labelsThatFailsToLoad, times(2)).load(any(IResource.class), any(IProgressMonitor.class));
+		verify(labelsThatFailsToLoadImageStreamTag, times(2)).load(any(IResource.class), any(IProgressMonitor.class));
 	}
 
 	@Test
@@ -141,9 +245,9 @@ public class DockerImageLabelsTest {
 	public void shouldTryToLoadGivenDevmodePortKeyIsRequested() throws CoreException {
 		// given
 		// when
-		String devmodePortKey = labelsThatFailsToLoad.getDevmodePortKey(new NullProgressMonitor());
+		String devmodePortKey = labelsThatFailsToLoadImageStreamTag.getDevmodePortKey(new NullProgressMonitor());
 		// then
-		verify(labelsThatFailsToLoad, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
+		verify(labelsThatFailsToLoadImageStreamTag, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
 		assertThat(devmodePortKey).isNull();
 	}
 
@@ -151,9 +255,9 @@ public class DockerImageLabelsTest {
 	public void shouldTryToLoadGivenDevmodePortValueIsRequested() throws CoreException {
 		// given
 		// when
-		String devmodePortValue = labelsThatFailsToLoad.getDevmodePortValue(new NullProgressMonitor());
+		String devmodePortValue = labelsThatFailsToLoadImageStreamTag.getDevmodePortValue(new NullProgressMonitor());
 		// then
-		verify(labelsThatFailsToLoad, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
+		verify(labelsThatFailsToLoadImageStreamTag, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
 		assertThat(devmodePortValue).isNull();
 	}
 
@@ -161,10 +265,25 @@ public class DockerImageLabelsTest {
 	public void shouldTryToLoadGivenPodPathIsRequested() throws CoreException {
 		// given
 		// when
-		String podPath = labelsThatFailsToLoad.getPodPath(new NullProgressMonitor());
+		String podPath = labelsThatFailsToLoadImageStreamTag.getPodPath(new NullProgressMonitor());
 		// then
-		verify(labelsThatFailsToLoad, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
+		verify(labelsThatFailsToLoadImageStreamTag, times(1)).load(any(IResource.class), any(IProgressMonitor.class));
 		assertThat(podPath).isNull();
+	}
+
+	private final class DockerImageURIArgumentMatcher extends ArgumentMatcher<DockerImageURI> {
+
+		@Override
+		public boolean matches(Object argument) {
+			if (!(argument instanceof DockerImageURI)) {
+				return false;
+			}
+			return DOCKER_IMAGE_TAG.equals(((DockerImageURI) argument).getAbsoluteUri());
+		}
+
+		@Override
+		public void describeTo(Description description) {				
+		}
 	}
 
 	public class TestableDockerImageLabels extends DockerImageLabels {
@@ -174,8 +293,13 @@ public class DockerImageLabelsTest {
 		}
 
 		@Override
-		protected String load(IResource resource, IProgressMonitor monitor) {
+		protected String load(IResource resource, IProgressMonitor monitor) throws CoreException {
 			return super.load(resource, monitor);
+		}
+
+		@Override
+		public String getImageStreamTag(DockerImageURI uri, String namespace, IProgressMonitor monitor) {
+			return super.getImageStreamTag(uri, namespace, monitor);
 		}
 
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/util/ResourceMocks.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/util/ResourceMocks.java
@@ -512,17 +512,31 @@ public class ResourceMocks {
 		doReturn(containers).when(dc).getContainers();
 	}
 
+	public static void mockGetImages(List<String> imageUris, IDeploymentConfig dc) {
+		doReturn(imageUris).when(dc).getImages();
+	}
+
+	public static IContainer createContainer(String name, String imageUri) {
+		return createContainer(name, new DockerImageURI(imageUri), Collections.emptySet(), null, null);
+	}
+
 	public static IContainer createContainer(String name, Set<IPort> ports) {
-		return createContainer(name, ports, null, null);
+		return createContainer(name, null, ports, null, null);
 	}
 
 	public static IContainer createContainer(String name, Set<IPort> ports, IProbe livenessProbe,
+			IProbe readinessProbe) {
+		return createContainer(name, null, ports, livenessProbe, readinessProbe);
+	}
+
+	public static IContainer createContainer(String name, DockerImageURI image, Set<IPort> ports, IProbe livenessProbe,
 			IProbe readinessProbe) {
 		IContainer container = mock(IContainer.class);
 		doReturn(name).when(container).getName();
 		doReturn(ports).when(container).getPorts();
 		doReturn(livenessProbe).when(container).getLivenessProbe();
 		doReturn(readinessProbe).when(container).getReadinessProbe();
+		doReturn(image).when(container).getImage();
 		return container;
 	}
 


### PR DESCRIPTION
Allow docker image uri (where the docker image labels for
deployment-dir, debug-mode & debug port are present) to be extracted
from dc>spec>template>spec>containers if there's no
dc>spec>trigger>ImageChange

Signed-off-by: Andre Dietisheim <adietish@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
