### PR TITLE
[JBIDE-26408] warn that debugging nodejs only supports node.js <=7

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.core/plugin.xml
@@ -118,6 +118,7 @@
 		id="org.jboss.tools.openshift.core.connection.registryprovider"
 		name="registryprovider"
 		schema="schema/org.jboss.tools.openshift.core.connection.registryprovider.exsd"/>
+    <extension-point id="org.jboss.tools.openshift.core.dialogProvider" name="dialogProvider" schema="schema/org.jboss.tools.openshift.core.dialogProvider.exsd"/>
 
 	<extension
  		point="org.jboss.ide.eclipse.as.wtp.core.serverSubsystem">

--- a/plugins/org.jboss.tools.openshift.core/schema/org.jboss.tools.openshift.core.dialogProvider.exsd
+++ b/plugins/org.jboss.tools.openshift.core/schema/org.jboss.tools.openshift.core.dialogProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.jboss.tools.openshift.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.jboss.tools.openshift.core" id="org.jboss.tools.openshift.core.dialogProvider" name="dialogProvider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="dialogProvider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="dialogProvider">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.jboss.tools.openshift.core.IDialogProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/IDialogProvider.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/IDialogProvider.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.core;
+
+public interface IDialogProvider {
+
+	void warn(String title, String message, String preferencesKey);
+}

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/IDialogProvider.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/IDialogProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -231,7 +231,6 @@ public class OpenShiftServerUtils {
 		server.setAttribute(IDeployableServer.DEPLOY_DIRECTORY_TYPE, IDeployableServer.DEPLOY_CUSTOM);
 		server.setAttribute(IDeployableServer.ZIP_DEPLOYMENTS_PREF, true);
 		server.setAttribute(Server.PROP_AUTO_PUBLISH_TIME, DEFAULT_AUTO_PUBLISH_DELAY);
-
 	}
 
 	public static void updateServerProject(String connectionUrl, IResource resource, String sourcePath, String podPath,

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -231,6 +231,7 @@ public class OpenShiftServerUtils {
 		server.setAttribute(IDeployableServer.DEPLOY_DIRECTORY_TYPE, IDeployableServer.DEPLOY_CUSTOM);
 		server.setAttribute(IDeployableServer.ZIP_DEPLOYMENTS_PREF, true);
 		server.setAttribute(Server.PROP_AUTO_PUBLISH_TIME, DEFAULT_AUTO_PUBLISH_DELAY);
+
 	}
 
 	public static void updateServerProject(String connectionUrl, IResource resource, String sourcePath, String podPath,

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/Dialogs.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/Dialogs.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.core;
+
+import org.eclipse.osgi.util.NLS;
+import org.jboss.tools.openshift.common.core.utils.ExtensionUtils;
+import org.jboss.tools.openshift.core.IDialogProvider;
+
+public class Dialogs implements IDialogProvider {
+
+	private static final String EXTENSION = "org.jboss.tools.openshift.core.dialogProvider";
+	private static final String ATTRIBUTE_CLASS = "class";
+
+	public static final Dialogs INSTANCE = new Dialogs();
+
+	private IDialogProvider provider;
+
+	private Dialogs() {
+		this.provider = get();
+	}
+
+	@Override
+	public void warn(String title, String message, String preferencesKey) {
+		if (provider == null) {
+			OpenShiftCoreActivator.pluginLog().logError(NLS.bind("Could not find extension ", EXTENSION));
+			return;
+		}
+		provider.warn(title, message, preferencesKey);
+	}
+	
+	private IDialogProvider get() {
+		return ExtensionUtils.getFirstExtension(EXTENSION, ATTRIBUTE_CLASS);
+	}
+
+}

--- a/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/server/behaviour/OpenShiftNodejsLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/server/behaviour/OpenShiftNodejsLaunchController.java
@@ -35,7 +35,7 @@ public class OpenShiftNodejsLaunchController extends OpenShiftLaunchController i
 		// https://issues.jboss.org/browse/JBIDE-26408
 		Dialogs.INSTANCE.warn("Node.js 8+ unsupported	", 
 				"Debugging is only supported up to Node.js 7. If your Node.js is newer, debugging will not work.\n"
-				+ "If using an OpenShift template to create the application, set 'NODEJS_PROPERTY' to '6'", 
+				+ "If using an OpenShift template to create the application, set 'NODEJS_PROPERTY' to '7'", 
 				WARN_NEWER_THAN_NODEJS7_UNSUPPORTED);
 		IDebugListener listener = new IDebugListener() {
 

--- a/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/server/behaviour/OpenShiftNodejsLaunchController.java
+++ b/plugins/org.jboss.tools.openshift.js/src/org/jboss/tools/openshift/js/server/behaviour/OpenShiftNodejsLaunchController.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.ISubsystemController;
 import org.jboss.tools.openshift.core.server.OpenShiftServerBehaviour;
 import org.jboss.tools.openshift.core.server.behavior.OpenShiftLaunchController;
+import org.jboss.tools.openshift.internal.core.Dialogs;
 import org.jboss.tools.openshift.internal.core.server.debug.DebugContext;
 import org.jboss.tools.openshift.internal.core.server.debug.IDebugListener;
 import org.jboss.tools.openshift.internal.core.server.debug.OpenShiftDebugMode;
@@ -23,12 +24,19 @@ import org.jboss.tools.openshift.js.launcher.NodeDebugLauncher;
 
 public class OpenShiftNodejsLaunchController extends OpenShiftLaunchController implements ISubsystemController {
 
+	private static final String WARN_NEWER_THAN_NODEJS7_UNSUPPORTED = "org.jboss.tools.openshift.js.dontwarnNodeJs7";
+
 	public OpenShiftNodejsLaunchController() {
 		super();
 	}
 
 	@Override
 	protected void startDebugging(OpenShiftServerBehaviour beh, DebugContext context, IProgressMonitor monitor) {
+		// https://issues.jboss.org/browse/JBIDE-26408
+		Dialogs.INSTANCE.warn("Node.js 8+ unsupported	", 
+				"Debugging is only supported up to Node.js 7. If your Node.js is newer, debugging will not work.\n"
+				+ "If using an OpenShift template to create the application, set 'NODEJS_PROPERTY' to '6'", 
+				WARN_NEWER_THAN_NODEJS7_UNSUPPORTED);
 		IDebugListener listener = new IDebugListener() {
 
 			@Override

--- a/plugins/org.jboss.tools.openshift.ui/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.ui/plugin.xml
@@ -1469,6 +1469,42 @@ $            <command
                                  connection="org.jboss.tools.openshift.core.connection.Connection">
         </importApplicationWizard>
     </extension>
+    <extension
+          point="org.jboss.tools.openshift.core.sslCertificateCallbackUI">
+       <sslCertificateCallbackUI
+             class="org.jboss.tools.openshift.internal.ui.wizard.connection.SSLCertificateCallback">
+       </sslCertificateCallbackUI>
+    </extension>
+    <extension
+          point="org.jboss.tools.openshift.core.routeChooser">
+       <routeChooser
+             class="org.jboss.tools.openshift.internal.ui.route.RouteChooser">
+       </routeChooser>
+    </extension>
+    <extension
+          point="org.jboss.tools.openshift.ui.connectionEditor.advanced">
+       <connectionEditorAdvanced
+             class="org.jboss.tools.openshift.internal.ui.wizard.connection.AdvancedConnectionEditor">
+       </connectionEditorAdvanced>
+    </extension>
+    <extension
+          point="org.jboss.tools.jmx.ui.providerUI">
+       <providerUI
+             editable="false"
+             icon="icons/openshift-logo-white-icon.png"
+             id="org.jboss.tools.openshift.core.server.OpenshiftJMXConnection"
+             name="Openshift JMX">
+          <connectionLabelProvider
+                class="org.jboss.tools.openshift.internal.ui.server.OpenshiftJMXLabelProvider">
+          </connectionLabelProvider>
+       </providerUI>
+    </extension>
+    <extension
+          point="org.jboss.tools.openshift.core.dialogProvider">
+       <dialogProvider
+             class="org.jboss.tools.openshift.internal.ui.dialog.DialogProvider">
+       </dialogProvider>
+    </extension>
 
 	<!-- Edit Connection -->
 	<extension
@@ -1730,19 +1766,19 @@ $            <command
                                      id="org.jboss.tools.openshift.internal.ui.server.OpenShiftLaunchConfigurationTabGroup"
                                      type="org.jboss.tools.openshift.internal.core.behaviour.launchType"/>
     </extension>
+    <extension
+          point="org.eclipse.core.expressions.propertyTesters">
+       <propertyTester
+             class="org.jboss.tools.openshift.internal.ui.propertytester.ServerAdapterPropertyTester"
+             id="org.jboss.tools.openshift.ui.serverAdapterPropertyTester"
+             namespace="org.jboss.tools.openshift.ui"
+             properties="isServerAdapterAllowed"
+             type="com.openshift.restclient.model.IResource">
+       </propertyTester>
+    </extension>
 
     <!-- Core UI Integration: ssl certificate callback -->
-    <extension
-               point="org.jboss.tools.openshift.core.sslCertificateCallbackUI">
-        <sslCertificateCallbackUI
-                                  class="org.jboss.tools.openshift.internal.ui.wizard.connection.SSLCertificateCallback" />
-    </extension>
     <!-- Core UI Integration: route chooser -->
-    <extension
-               point="org.jboss.tools.openshift.core.routeChooser">
-        <routeChooser
-                      class="org.jboss.tools.openshift.internal.ui.route.RouteChooser" />
-    </extension>
 
     <extension point="org.eclipse.ui.editors.documentProviders"> 
         <provider 
@@ -2031,34 +2067,6 @@ $            <command
                                       icon="icons/openshift-logo-white-icon.png"
                                       configTypeID="org.jboss.tools.openshift.internal.core.behaviour.launchType"
                                       id="org.jboss.tools.openshift.internal.core.behaviour.launchIcon"/>
-    </extension>
-    <extension
-               point="org.jboss.tools.openshift.ui.connectionEditor.advanced">
-        <connectionEditorAdvanced
-                                  class="org.jboss.tools.openshift.internal.ui.wizard.connection.AdvancedConnectionEditor">
-        </connectionEditorAdvanced>
-    </extension>
-    <extension
-               point="org.jboss.tools.jmx.ui.providerUI">
-        <providerUI
-                    editable="false"
-                    icon="icons/openshift-logo-white-icon.png"
-                    id="org.jboss.tools.openshift.core.server.OpenshiftJMXConnection"
-                    name="Openshift JMX">
-            <connectionLabelProvider
-                                     class="org.jboss.tools.openshift.internal.ui.server.OpenshiftJMXLabelProvider">
-            </connectionLabelProvider>
-        </providerUI>
-    </extension>
-    <extension
-               point="org.eclipse.core.expressions.propertyTesters">
-        <propertyTester
-                        class="org.jboss.tools.openshift.internal.ui.propertytester.ServerAdapterPropertyTester"
-                        id="org.jboss.tools.openshift.ui.serverAdapterPropertyTester"
-                        namespace="org.jboss.tools.openshift.ui"
-                        properties="isServerAdapterAllowed"
-                        type="com.openshift.restclient.model.IResource">
-        </propertyTester>
     </extension>
 
 </plugin>

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dialog/DialogProvider.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/dialog/DialogProvider.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.ui.dialog;
+
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.widgets.Display;
+import org.jboss.tools.openshift.core.IDialogProvider;
+import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
+
+public class DialogProvider implements IDialogProvider {
+
+	@Override
+	public void warn(String title, String message, String preferencesKey) {
+		IPreferenceStore preferences = OpenShiftUIActivator.getDefault().getPreferenceStore();
+		String prefsValue = preferences.getString(preferencesKey);
+		boolean warn = !MessageDialogWithToggle.ALWAYS.equals(prefsValue);
+		if (warn) {
+			Display.getDefault().syncExec(() ->
+				MessageDialogWithToggle.openWarning(
+						Display.getDefault().getActiveShell(),
+						title,
+						message,
+						"Dont remind me again",
+						!warn,
+						preferences,
+						preferencesKey)
+			);
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Andre Dietisheim <adietish@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
