### PR TITLE
[JBIDE-26746] remove old deployment when outputName changes

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServer.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServer.java
@@ -20,12 +20,10 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.internal.Server;
 import org.eclipse.wst.server.core.model.IURLProvider;
-import org.eclipse.wst.server.core.model.ServerBehaviourDelegate;
 import org.jboss.ide.eclipse.as.core.server.internal.DeployableServer;
 import org.jboss.ide.eclipse.as.core.server.internal.IExtendedPropertiesProvider;
 import org.jboss.ide.eclipse.as.core.server.internal.JBossServer;
 import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
-import org.jboss.ide.eclipse.as.wtp.core.server.behavior.ControllableServerBehavior;
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.IControllableServerBehavior;
 import org.jboss.ide.eclipse.as.wtp.core.util.ServerModelUtilities;
 import org.jboss.tools.as.core.server.controllable.systems.IDeploymentOptionsController;
@@ -102,7 +100,7 @@ public class OpenShiftServer extends DeployableServer
 	@Override
 	public String getDeployFolder() {
 		try {
-			IDeploymentOptionsController deployOpts = (IDeploymentOptionsController)getControllableBehavior().getController(IDeploymentOptionsController.SYSTEM_ID);
+			IDeploymentOptionsController deployOpts = getDeploymentOptionsController();
 			return deployOpts.getDeploymentsRootFolder(true);
 		} catch(CoreException ce) {
 			OpenShiftCoreActivator.logError(ce.getMessage(), ce);
@@ -113,22 +111,16 @@ public class OpenShiftServer extends DeployableServer
 	@Override
 	public String getTempDeployFolder() {
 		try {
-			IDeploymentOptionsController deployOpts = (IDeploymentOptionsController)getControllableBehavior().getController(IDeploymentOptionsController.SYSTEM_ID);
+			IDeploymentOptionsController deployOpts = getDeploymentOptionsController();
 			return deployOpts.getDeploymentsTemporaryFolder(true);
 		} catch(CoreException ce) {
 			OpenShiftCoreActivator.logError(ce.getMessage(), ce);
 			return super.getTempDeployFolder();
 		}
 	}
-	
-	
-	private IControllableServerBehavior getControllableBehavior() {
-		if( getServer() != null ) {
-			ServerBehaviourDelegate del = (ServerBehaviourDelegate)getServer().loadAdapter(ServerBehaviourDelegate.class, null);
-			if( del instanceof ControllableServerBehavior)
-				return (IControllableServerBehavior)del;
-		}
-		return null;
+
+	private IDeploymentOptionsController getDeploymentOptionsController() throws CoreException {
+		return (IDeploymentOptionsController) OpenShiftServerUtils.getAdapter(IControllableServerBehavior.class, getServer())
+				.getController(IDeploymentOptionsController.SYSTEM_ID);
 	}
-	
 }

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OpenShiftServerUtils.java
@@ -589,6 +589,18 @@ public class OpenShiftServerUtils {
 		return getOpenShiftServerBehaviour(ServerUtil.getServer(configuration));
 	}
 
+	public static OpenShiftServer getServerDelegate(IServer server) {
+		return getAdapter(OpenShiftServer.class, server);
+	}
+
+	public static <T> T getAdapter(Class<T> clazz, IServer server) {
+		T delegate = server.getAdapter(clazz);
+		if( delegate == null ) {
+			delegate = (T) server.loadAdapter(clazz, new NullProgressMonitor());
+		}
+		return delegate;
+	}
+	
 	/**
 	 * Creates an {@link RSync}
 	 * 

--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OutputNamesCacheFactory.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/server/OutputNamesCacheFactory.java
@@ -1,0 +1,148 @@
+/******************************************************************************* 
+ * Copyright (c) 2019 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.openshift.core.server;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.IServerAttributes;
+import org.eclipse.wst.server.core.IServerLifecycleListener;
+import org.eclipse.wst.server.core.ServerCore;
+import org.jboss.tools.as.core.internal.modules.ModuleDeploymentPrefsUtil;
+
+public class OutputNamesCacheFactory {
+
+	public static final OutputNamesCacheFactory INSTANCE = new OutputNamesCacheFactory();
+
+	private Map<String, OutputNamesCache> caches;
+
+	private OutputNamesCacheFactory() {
+		this(new HashMap<>());
+	}
+
+	/* for testing purposes */
+	protected OutputNamesCacheFactory(Map<String, OutputNamesCache> caches) {
+		this.caches = caches;
+	}
+
+	public OutputNamesCache get(IServer server) {
+		OutputNamesCache cache = caches.get(server.getId());
+		if (cache == null) {
+			cache = createCache(server);
+			onServerDeleted(server);
+		}
+		return cache;
+	}
+
+	private OutputNamesCache createCache(IServer server) {
+		OutputNamesCache cache;
+		cache = new OutputNamesCache(server);
+		caches.put(server.getId(), cache);
+		return cache;
+	}
+
+	private void onServerDeleted(final IServer cachedServer) {
+		ServerCore.addServerLifecycleListener(new IServerLifecycleListener() {
+
+			@Override
+			public void serverAdded(IServer server) {
+				// NOP
+			}
+
+			@Override
+			public void serverChanged(IServer server) {
+				// NOP
+			}
+
+			@Override
+			public void serverRemoved(IServer server) {
+				if (!cachedServer.equals(server)) {
+					return;
+				}
+				caches.remove(server.getId());
+				ServerCore.removeServerLifecycleListener(this);
+			}
+			
+		});
+	}
+
+	public static class OutputNamesCache {
+
+		protected Map<String, String> oldOutputNames = new HashMap<>();
+		protected Map<String, String> newOutputNames = new HashMap<>();
+		protected IServer server;
+
+		/* for testing purposes */
+		protected OutputNamesCache(IServer server) {
+			this.server = server;
+		}
+
+		public void collect() {
+			this.oldOutputNames = getModuleOutputNames(server);
+		}
+
+		public void onModified(IServerAttributes server) {
+			this.newOutputNames = getModuleOutputNames(server);
+		}
+
+		/**
+		 * Returns the output names for a given server or working copy.
+		 * 
+		 * @param server
+		 * @return
+		 */
+		private Map<String, String> getModuleOutputNames(final IServerAttributes server) {
+			return Arrays.stream(server.getModules()).collect(Collectors.toMap(
+					this::getModuleKey,
+					module -> getOutputName(module, server)));
+		}
+
+		public boolean isModified(IModule module) {
+			if (module == null) {
+				return false;
+			}
+			return newOutputNames.containsKey(getModuleKey(module))
+					&& !Objects.equals(newOutputNames.get(getModuleKey(module)), oldOutputNames.get(getModuleKey(module)));
+		}
+
+		protected String getOutputName(IModule module, IServerAttributes server) {
+			// Get the full path of where this module would be deployed to, and just take the last segment
+			// IF the array is of size 1, it will pull from prefs.
+			// If the array is larger, it will pull from the relative path of the child to its parent module
+			IPath path = new ModuleDeploymentPrefsUtil().getModuleNestedDeployPath(new IModule[] { module }, "/", server); //$NON-NLS-1$
+			return path.lastSegment();
+		}
+
+		public String getOldOutputName(IModule module) {
+			if (module == null) {
+				return null;
+			}
+			return oldOutputNames.get(getModuleKey(module));
+		}
+
+		private String getModuleKey(IModule module) {
+			if (module == null) {
+				return null;
+			}
+			return module.getId();
+		}
+
+		public void reset(IModule module) {
+			oldOutputNames.put(getModuleKey(module), newOutputNames.get(getModuleKey(module)));
+		}
+	}
+}

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftDeploymentPage.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/server/OpenShiftDeploymentPage.java
@@ -14,13 +14,18 @@ import java.util.Arrays;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorSite;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.IServerWorkingCopy;
 import org.eclipse.wst.server.core.internal.Server;
 import org.jboss.ide.eclipse.as.core.server.IServerWorkingCopyProvider;
 import org.jboss.ide.eclipse.as.ui.editor.DeploymentPage;
 import org.jboss.ide.eclipse.as.ui.editor.ModuleDeploymentOptionsComposite;
 import org.jboss.tools.as.core.internal.modules.DeploymentPreferencesLoader;
+import org.jboss.tools.openshift.core.server.OutputNamesCacheFactory;
+import org.jboss.tools.openshift.core.server.OutputNamesCacheFactory.OutputNamesCache;
 
 @SuppressWarnings("restriction")
 public class OpenShiftDeploymentPage extends DeploymentPage implements IServerWorkingCopyProvider {
@@ -44,22 +49,35 @@ public class OpenShiftDeploymentPage extends DeploymentPage implements IServerWo
 	}
 
 	@Override
+	public void init(IEditorSite site, IEditorInput input) {
+		super.init(site, input);
+
+		IServer server = getServer().getOriginal();
+		OutputNamesCache outputNamesCache = OutputNamesCacheFactory.INSTANCE.get(server);
+		outputNamesCache.collect();
+	}
+
+	@Override
 	public void doSave(IProgressMonitor monitor) {
+		IServerWorkingCopy workingCopy = getServer();
+		IServer server = getServer().getOriginal();
+
 		super.doSave(monitor);
+
+		OutputNamesCache outputNamesCache = OutputNamesCacheFactory.INSTANCE.get(server);
+		outputNamesCache.onModified(workingCopy);
 
 		/**
 		 * https://issues.jboss.org/browse/JBIDE-26744: triggering a full re-deploy so
 		 * that change in deployment name results in new artifacts to rsync to the pod.
 		 * Without it, nothing new shows up in the temp directory and rsync ends up
 		 * syncing nothing.
-		 */ 
-		Server server = (Server) getServer().getOriginal();
-		setPublishState(IServer.PUBLISH_STATE_FULL, server.getModules(), server);
+		 */
+		setPublishState(IServer.PUBLISH_STATE_FULL, server.getModules(), (Server) server);
 	}
-	
+
 	private void setPublishState(int state, IModule[] modules, Server server) {
 		Arrays.stream(modules).forEach(module -> 
 			server.setModulePublishState(new IModule[] { module }, state));
 	}
-	
 }

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/OutputNamesCacheTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/OutputNamesCacheTest.java
@@ -1,0 +1,196 @@
+/******************************************************************************* 
+ * Copyright (c) 2019 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.core.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IModule2;
+import org.eclipse.wst.server.core.IModuleType;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.IServerWorkingCopy;
+import org.eclipse.wst.server.core.internal.ProjectProperties;
+import org.eclipse.wst.server.core.internal.ServerPlugin;
+import org.jboss.ide.eclipse.as.core.util.IWTPConstants;
+import org.jboss.tools.openshift.core.server.OutputNamesCacheFactory;
+import org.jboss.tools.openshift.core.server.OutputNamesCacheFactory.OutputNamesCache;
+import org.jboss.tools.openshift.test.core.server.util.OpenShiftServerTestUtils;
+import org.jboss.tools.test.util.ResourcesUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OutputNamesCacheTest {
+
+	private OutputNamesCacheFactory factory;
+	private HashMap<String, OutputNamesCache> map;
+	private IServer server;
+	private IModule2 module1;
+	private IModule2 module2;
+	private IModule2 module3;
+	private IModule2 danglingModule;
+	private IServer serverWithoutModules;
+	
+	@Before
+	public void before() throws CoreException, IOException {
+		this.map = spy(new HashMap<String, OutputNamesCache>());
+		this.factory = new OutputNamesCacheFactory(map) {};
+
+		this.server = spy(OpenShiftServerTestUtils.createOpenshift3Server("42", "smurf", null));
+		this.module1 = mockModule("smurfette", "flower");
+		this.module2 = mockModule("papa smurf", "blue hat");
+		this.module3 = mockModule("clumsy", "white hat");
+		this.danglingModule = mockModule("gargamel", "no hat");
+		doReturn(new IModule[] { module1, module2, module3 }).when(server).getModules();
+
+		this.serverWithoutModules = OpenShiftServerTestUtils.createOpenshift3Server("84", "smurfette", null);
+	}
+	
+	public void shouldReturnSameInstanceForSameServer() {
+		// given
+		OutputNamesCache cache1 = factory.get(server);
+		// when
+		OutputNamesCache cache2 = factory.get(server);
+		// then
+		assertThat(cache2).isSameAs(cache1);
+	}
+
+	@Test
+	public void shouldReturnDifferentCacheForDifferentServers() throws UnsupportedEncodingException, MalformedURLException, CoreException {
+		// given
+		IServer server2 = OpenShiftServerTestUtils.createOpenshift3Server("84", "papa smurf");
+		// when
+		OutputNamesCache cache1 = factory.get(server);
+		OutputNamesCache cache2 = factory.get(server2);
+		// then
+		assertThat(cache2).isNotEqualTo(cache1);
+	}
+
+	@Test
+	public void shouldRemoveCacheWhenServerIsDeleted() throws CoreException {
+		// given
+		OutputNamesCache cache = factory.get(serverWithoutModules);
+		assertThat(map).containsValue(cache);
+		// when
+		serverWithoutModules.delete();
+		// then
+		assertThat(map).doesNotContainValue(cache);
+	}
+	
+	@Test
+	public void collectShouldStoreAllModuleOutputNames() {
+		// given
+		TestableOutputNamesCache cache = new TestableOutputNamesCache(server) {};
+		// when
+		cache.collect();
+		// then
+		assertThat(cache.getOldOutputNames()).containsValues(
+				cache.getOutputName(module1), 
+				cache.getOutputName(module2), 
+				cache.getOutputName(module3));
+		assertThat(cache.getOldOutputNames()).doesNotContainValue( 
+				cache.getOutputName(danglingModule));
+	}
+
+	@Test
+	public void onModifiedshouldStoreAllModuleOutputNames() throws CoreException {
+		// given
+		TestableOutputNamesCache cache = new TestableOutputNamesCache(server) {};
+		cache.collect();
+		doReturn("update").when(module2).getProperty(IModule2.PROP_DEPLOY_NAME);
+		// when
+		cache.onModified(server);
+		// then
+		assertThat(cache.getNewOutputNames()).containsValues(
+				cache.getOutputName(module1), 
+				cache.getOutputName(module2), 
+				cache.getOutputName(module3));
+	}
+
+	@Test
+	public void updatedModuleShouldBeModified() throws CoreException {
+		// given
+		TestableOutputNamesCache cache = new TestableOutputNamesCache(server) {};
+		cache.collect();
+		doReturn("update").when(module2).getProperty(IModule2.PROP_DEPLOY_NAME);
+		cache.onModified(server);
+		// when
+		boolean module1Modified = cache.isModified(module1);
+		boolean module2Modified = cache.isModified(module2);
+		boolean module3Modified = cache.isModified(module3);
+		// then
+		assertThat(module1Modified).isFalse();
+		assertThat(module2Modified).isTrue();
+		assertThat(module3Modified).isFalse();
+	}
+
+	@Test
+	public void resetShouldResetModification() throws CoreException {
+		// given
+		TestableOutputNamesCache cache = new TestableOutputNamesCache(server) {};
+		cache.collect();
+		doReturn("update").when(module2).getProperty(IModule2.PROP_DEPLOY_NAME);
+		cache.onModified(server);
+		assertThat(cache.isModified(module2)).isTrue();
+		// when
+		cache.reset(module2);
+		// then
+		assertThat(cache.isModified(module2)).isFalse();
+	}
+
+	private IModule2 mockModule(String id, String outputName) {
+		IModule2 module = mock(IModule2.class);
+		doReturn(id).when(module).getId();
+		doReturn(outputName).when(module).getProperty(IModule2.PROP_DEPLOY_NAME);
+		IModuleType type = mockModuleType();
+		doReturn(type).when(module).getModuleType();
+		return module;
+	}
+
+	private IModuleType mockModuleType() {
+		IModuleType type = mock(IModuleType.class);
+		doReturn(IWTPConstants.EXT_WAR).when(type).getId();
+		return type;
+	}
+
+	public static class TestableOutputNamesCache extends OutputNamesCache {
+
+		protected TestableOutputNamesCache(IServer server) {
+			super(server);
+		} 
+
+		public Map<String, String> getOldOutputNames() {
+			return oldOutputNames;
+		}
+	
+		public Map<String, String> getNewOutputNames() {
+			return newOutputNames;
+		}
+
+		public String getOutputName(IModule module) {
+			return getOutputName(module, this.server);
+		}
+	}
+}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/util/OpenShiftServerTestUtils.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/server/util/OpenShiftServerTestUtils.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.IServerType;
@@ -51,20 +52,39 @@ public class OpenShiftServerTestUtils {
 		return createOpenshift3Server(name, profile, null, null);
 	}
 
+	public static IServer createOpenshift3Server(String name, String profile, IFile file)
+			throws CoreException, UnsupportedEncodingException, MalformedURLException {
+		return createOpenshift3Server(name, profile, null, null, file);
+	}
+
 	public static IServer createOpenshift3Server(String name, String profile, IService service,
 			IOpenShiftConnection connection) throws CoreException, UnsupportedEncodingException, MalformedURLException {
-		IServerWorkingCopy workingCopy = createOpenshift3ServerWorkingCopy(name, profile, service, connection);
-		return workingCopy.save(false, null);
+		 return createOpenshift3Server(name, profile, service, connection, null);
+	}
+
+	public static IServer createOpenshift3Server(String name, String profile, IService service,
+			IOpenShiftConnection connection, IFile file) throws CoreException, UnsupportedEncodingException, MalformedURLException {
+		IServerWorkingCopy workingCopy = createOpenshift3ServerWorkingCopy(name, profile, service, connection, file);
+		return workingCopy.save(true, null);
 	}
 	
-	public static IServerWorkingCopy createOpenshift3ServerWorkingCopy(String name) throws CoreException {
+	public static IServerWorkingCopy createOpenshift3ServerWorkingCopy(String name, IFile file) throws CoreException {
 		IServerType type = OpenShiftServerUtils.getServerType();
-		return type.createServer(name, null, null);
+		return type.createServer(name, file, null);
+	}
+
+	public static IServerWorkingCopy createOpenshift3ServerWorkingCopy(String name) throws CoreException {
+		return createOpenshift3ServerWorkingCopy(name, null);
 	}
 
 	public static IServerWorkingCopy createOpenshift3ServerWorkingCopy(String name, String profile, IService service,
 			IOpenShiftConnection connection) throws CoreException, UnsupportedEncodingException, MalformedURLException {
-		IServerWorkingCopy wc = createOpenshift3ServerWorkingCopy(name);
+		return createOpenshift3ServerWorkingCopy(name, profile, service, connection, null);
+	}
+
+	public static IServerWorkingCopy createOpenshift3ServerWorkingCopy(String name, String profile, IService service,
+			IOpenShiftConnection connection, IFile file) throws CoreException, UnsupportedEncodingException, MalformedURLException {
+		IServerWorkingCopy wc = createOpenshift3ServerWorkingCopy(name, file);
 		String serviceId = service == null ? null : OpenShiftResourceUniqueId.get(service);
 		String connectionUrl = connection == null ? null : ConnectionURL.forConnection(connection).getUrl();
 		OpenShiftServerUtils.updateServer(name, "http://www.example.com", "dummy", connectionUrl, "dummy", serviceId,


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
