### PR TITLE
[JBIDE-26813] use openshift-restclient-java 8.0.1

### DIFF
--- a/plugins/org.jboss.tools.openshift.client/.classpath
+++ b/plugins/org.jboss.tools.openshift.client/.classpath
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/commons-compress-1.19.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-8.0.0.Final.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/openshift-restclient-java-8.0.1-SNAPSHOT.jar" sourcepath="/openshift-restclient-java"/>
+	<classpathentry exported="true" kind="lib" path="lib/kotlin-stdlib-1.3.50.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/okhttp-4.1.1.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/okhttp-3.14.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/okio-1.17.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/okio-2.4.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jboss-dmr-1.3.0.Final.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/commons-compress-1.19.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-codec-1.6.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-lang-2.6.jar"/>

--- a/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.client/META-INF/MANIFEST.MF
@@ -6,9 +6,10 @@ Bundle-Version: 3.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
-Bundle-ClassPath: lib/openshift-restclient-java-8.0.0.Final.jar,
- lib/okhttp-3.14.2.jar,
- lib/okio-1.17.2.jar,
+Bundle-ClassPath: lib/openshift-restclient-java-8.0.1-SNAPSHOT.jar,
+ lib/okhttp-4.1.1.jar,
+ lib/okio-2.4.0.jar,
+ lib/kotlin-stdlib-1.3.50.jar,
  lib/jboss-dmr-1.3.0.Final.jar,
  lib/commons-codec-1.6.jar,
  lib/commons-compress-1.19.jar,

--- a/plugins/org.jboss.tools.openshift.client/pom.xml
+++ b/plugins/org.jboss.tools.openshift.client/pom.xml
@@ -16,9 +16,10 @@
 			https://repository.jboss.org/nexus/content/repositories/snapshots/com/openshift/openshift-restclient-java/7.1.1-SNAPSHOT/
 			https://repository.jboss.org/nexus/service/local/repositories/releases/content/com/openshift/openshift-restclient-java/7.1.1-SNAPSHOT/openshift-restclient-java-7.1.1-SNAPSHOT.jar
 		-->
-		<openshift-restclient-java.version>8.0.0.Final</openshift-restclient-java.version>
-		<ok-http.version>3.14.2</ok-http.version>
-		<ok-io.version>1.17.2</ok-io.version>
+		<openshift-restclient-java.version>8.0.1-SNAPSHOT</openshift-restclient-java.version>
+		<ok-http.version>4.1.1</ok-http.version>
+		<ok-io.version>2.4.0</ok-io.version>
+		<kotlin-stdlib.version>1.3.50</kotlin-stdlib.version>
 		<jboss-dmr.version>1.3.0.Final</jboss-dmr.version>
 		<commons-compress.version>1.19</commons-compress.version>
 		<log4j.version>1.2.17</log4j.version>
@@ -76,6 +77,11 @@
 						    <version>${ok-io.version}</version>
 						</artifactItem>
 						<artifactItem>
+							<groupId>org.jetbrains.kotlin</groupId>
+							<artifactId>kotlin-stdlib</artifactId>
+							<version>${kotlin-stdlib.version}</version>
+						</artifactItem>
+  						<artifactItem>
 							<groupId>org.jboss</groupId>
 							<artifactId>jboss-dmr</artifactId>
 							<version>${jboss-dmr.version}</version>

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ConnectionWrapper.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/ConnectionWrapper.java
@@ -269,7 +269,7 @@ public class ConnectionWrapper extends AbstractOpenshiftUIElement<IOpenShiftConn
 		updateWithResources(loadProjects());
 		state.set(LoadingState.LOADED);
 		fireChanged();
-		for (ProjectWrapper project : projects.values()) {
+		for (ProjectWrapper project : new ArrayList<>(projects.values())) {
 			project.refresh();
 		}
 	}


### PR DESCRIPTION
this depends on https://github.com/openshift/openshift-restclient-java/issues/395 being merged and the client library 8.0.1 being published to maven repo.

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
