### PR TITLE
JBIDE-26880 - fix default naming for crc servers

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/adapter/CRC100Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/adapter/CRC100Server.java
@@ -19,14 +19,38 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.model.ServerDelegate;
+import org.jboss.ide.eclipse.as.core.util.ServerNamingUtility;
 import org.jboss.tools.openshift.common.core.utils.StringUtils;
 import org.jboss.tools.openshift.internal.cdk.server.core.BinaryUtility;
+import org.jboss.tools.openshift.internal.cdk.server.core.adapter.CDKServer;
 
 public class CRC100Server extends ServerDelegate {
 	public static final String CRC_100_SERVER_TYPE_ID = "org.jboss.tools.openshift.crc.server.type.crc.v100";
 	private static final String CRC_10_BASE_NAME = "CodeReady Containers 1.0";
 	public static final String PROPERTY_PULL_SECRET_FILE = "crc.pullsecret.file";
 	public static final String PROPERTY_BINARY_FILE = "crc.binary.file";
+
+	
+	@Override
+	public void setDefaults(IProgressMonitor monitor) {
+		getServerWorkingCopy().setHost("localhost"); //$NON-NLS-1$
+		setDefaultServerName(monitor);
+	}
+
+	/**
+	 * Initializes this server with a default server name. 
+	 * This method is called when a new server is created so that the server 
+	 * can be initialized with a name suitable to the server type. 
+	 * 
+	 * This method currently overrides a *nonexistant* upstream method, which
+	 * is only proposed in upstream bug. 
+	 * 
+	 * @param monitor a progress monitor, or <code>null</code> if progress
+	 *    reporting and cancellation are not desired
+	 */
+	public void setDefaultServerName(IProgressMonitor monitor) {
+		getServerWorkingCopy().setName(ServerNamingUtility.getDefaultServerName(getBaseName()));
+	}
 
 	public static String getServerTypeBaseName() {
 		return CRC_10_BASE_NAME;


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

We typically don't add the (Tech Preview) to the server name itself, but rather to the server type. The server names should not have rogue (tech Preview) hanging out there forever because then when the user updates their workspace, those old servers will still be named tech preview, which is not desirable. 

This PR fixes the default naming for the server type to remove the Tech Preview and make sure both methods of creating runtimes use the same default name logic. 


# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
