### PR TITLE
Fixing changed crc running status string to align with tests

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CRCIntegrationTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CRCIntegrationTest.java
@@ -89,7 +89,7 @@ public class CRCIntegrationTest extends CDKServerAdapterAbstractTest {
 	@Test
 	public void testCRCServerAdapter() {
 		startServerAdapter(getCDKServer(), () -> {}, false);
-		CDKTestUtils.verifyConsoleContainsRegEx("\\bThe OpenShift cluster is running\\b");
+		CDKTestUtils.verifyConsoleContainsRegEx("\\bStarted the OpenShift cluster\\b");
 		OpenShift3Connection connection = null;
 		try {
 			connection = CDKTestUtils.findOpenShiftConnection(null, OPENSHIFT_CONNECTION);


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
