### PR TITLE
Fixing download runtime changed names

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32IntegrationTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32IntegrationTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 @CleanOpenShiftExplorer
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32ServerAdapterProfilesTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDK32ServerAdapterProfilesTest.java
@@ -49,7 +49,7 @@ import org.junit.runner.RunWith;
 @CleanOpenShiftExplorer
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		usernameProperty="developers.username",
 		passwordProperty="developers.password",
 		useExistingBinaryFromConfig=true,

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterSetupCDKTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/CDKServerAdapterSetupCDKTest.java
@@ -69,7 +69,7 @@ import org.junit.runner.RunWith;
 @CleanDockerExplorer
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryFailureTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryFailureTest.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlDiscoveryTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlValidatorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/adapter/openshift/CDKImageRegistryUrlValidatorTest.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/CDK32ServerEditorTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/CDK32ServerEditorTest.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(RedDeerSuite.class)
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/launch/CDKLaunchConfigurationTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/editor/launch/CDKLaunchConfigurationTest.java
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(RedDeerSuite.class)
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		useExistingBinaryFromConfig=true,
 		makeRuntimePersistent=true,
 		usernameProperty="developers.username",

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CDK32RuntimeDetectionTest.java
@@ -21,7 +21,7 @@ import org.jboss.tools.cdk.reddeer.requirements.RemoveCDKServersRequirement.Remo
 @DisableSecureStorage
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CDK3110,
+		version = CDKVersion.CDK3120,
 		usernameProperty="developers.username",
 		passwordProperty="developers.password",
 		createServerAdapter=false,

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CRCRuntimeDetectionTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/runtime/CRCRuntimeDetectionTest.java
@@ -25,7 +25,7 @@ import org.jboss.tools.cdk.ui.bot.test.CDKAbstractTest;
  */
 @RemoveCDKServers
 @ContainerRuntimeServer(
-		version = CDKVersion.CRC160,
+		version = CDKVersion.CRC180,
 		createServerAdapter=false,
 		useExistingBinaryInProperty="crc.binary",
 		adapterName = CDKAbstractTest.SERVER_ADAPTER_CRC)

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/CRCDownloadRuntimeTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/CRCDownloadRuntimeTest.java
@@ -35,7 +35,7 @@ public class CRCDownloadRuntimeTest extends DownloadContainerRuntimeAbstractTest
 
 	@Parameters(name = "{0}")
 	public static Collection<CDKVersion> data() {
-		return Arrays.asList(CDKVersion.CRC160);
+		return Arrays.asList(CDKVersion.CRC180);
 	}
 
 	@Override

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadContainerRuntimeDefaultSettingsTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadContainerRuntimeDefaultSettingsTest.java
@@ -27,7 +27,7 @@ public class DownloadContainerRuntimeDefaultSettingsTest extends DownloadContain
 	
 	@Test
 	public void testDownloadingCDK390RuntimeDefaults() {
-		downloadAndVerifyContainerRuntime(CDKVersion.CDK3110, USERNAME, PASSWORD, "", "", true, true);
+		downloadAndVerifyContainerRuntime(CDKVersion.CDK3120, USERNAME, PASSWORD, "", "", true, true);
 	}
 	
 	@Test

--- a/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadRuntimesWizardTest.java
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/src/org/jboss/tools/cdk/ui/bot/test/server/wizard/download/DownloadRuntimesWizardTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  */
 public class DownloadRuntimesWizardTest extends DownloadContainerRuntimeAbstractTest {
 
-	private static final CDKVersion version = CDKVersion.CDK3110;
+	private static final CDKVersion version = CDKVersion.CDK3120;
 	
 	private static final String INVALID_CREDENTIALS = "credentials have failed to validate";
 	

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKServerAdapterType.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKServerAdapterType.java
@@ -17,11 +17,11 @@ package org.jboss.tools.cdk.reddeer.core.enums;
  */
 public enum CDKServerAdapterType {
 
-	CDK2 	("CDK", "org.jboss.tools.openshift.cdk.server.type", "CDK"),
-	CDK3 	("CDK 3.0+", "org.jboss.tools.openshift.cdk.server.type.v3", "CDK"),
-	CDK32 	("CDK 3.2+", "org.jboss.tools.openshift.cdk.server.type.v32", "CDK"),
+	CDK2 	("CDK", "org.jboss.tools.openshift.cdk.server.type", " Red Hat CDK"),
+	CDK3 	("CDK 3.0+", "org.jboss.tools.openshift.cdk.server.type.v3", "Red Hat CDK"),
+	CDK32 	("CDK 3.2+", "org.jboss.tools.openshift.cdk.server.type.v32", "Red Hat CDK"),
 	MINISHIFT17 ("Minishift", "org.jboss.tools.openshift.cdk.server.type.minishift.v17", "Minishift"),
-	CRC ("CRC 1.0", "org.jboss.tools.openshift.crc.server.type.crc.v100", "CRC"),
+	CRC ("CRC 1.0", "org.jboss.tools.openshift.crc.server.type.crc.v100", "Red Hat CRC"),
 	NO_CDK  ("", "", "");
 	
 	private final String runtimeTypeName;

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKVersion.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/core/enums/CDKVersion.java
@@ -11,7 +11,6 @@
 package org.jboss.tools.cdk.reddeer.core.enums;
 
 import org.jboss.tools.cdk.reddeer.core.label.CDKLabel;
-import org.jboss.tools.cdk.reddeer.core.enums.CDKServerAdapterType;
 
 /**
  * Enum holding information for CDK/Minshift container runtimes
@@ -33,7 +32,8 @@ public enum CDKVersion {
 	CDK380 	(CDKServerAdapterType.CDK32, "3.8.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.8.0-2-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
 	CDK390 	(CDKServerAdapterType.CDK32, "3.9.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.9.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
 	CDK3100 (CDKServerAdapterType.CDK32, "3.10.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.10.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
-	CDK3110 (CDKServerAdapterType.CDK32, "3.11.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.11.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
+	CDK3110 (CDKServerAdapterType.CDK32, "3.11.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.11.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),	
+	CDK3120 (CDKServerAdapterType.CDK32, "3.12.0", CDKLabel.Server.CDK32_SERVER_NAME, "cdk-3.12.0-1-minishift-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch() + CDKRuntimeOS.get().getSuffix()),
 	MINISHIFT1140 (CDKServerAdapterType.MINISHIFT17, "1.14.0", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.14.0-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1151 (CDKServerAdapterType.MINISHIFT17, "1.15.1", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.15.1-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
 	MINISHIFT1161 (CDKServerAdapterType.MINISHIFT17, "1.16.1", CDKLabel.Server.MINISHIFT_SERVER_NAME, "minishift-1.16.1-" + CDKRuntimeOS.get().getRuntimeFullName() + getArch()),
@@ -62,7 +62,10 @@ public enum CDKVersion {
 	CRC130 (CDKServerAdapterType.CRC, "1.3.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.3.0" + getArch()),
 	CRC140 (CDKServerAdapterType.CRC, "1.4.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.4.0" + getArch()),
 	CRC150 (CDKServerAdapterType.CRC, "1.5.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.5.0" + getArch()),
-	CRC160 (CDKServerAdapterType.CRC, "1.6.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.6.0" + getArch());
+	CRC160 (CDKServerAdapterType.CRC, "1.6.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.6.0" + getArch()),	
+	CRC170 (CDKServerAdapterType.CRC, "1.7.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.7.0" + getArch()),
+	CRC180 (CDKServerAdapterType.CRC, "1.8.0", CDKLabel.Server.CRC_SERVER_NAME, "crc-" + CDKRuntimeOS.get().getRuntimeFullName() + "-1.8.0" + getArch());
+
 	
 	private final CDKServerAdapterType type;
 	private final String version;

--- a/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/utils/CDKUtils.java
+++ b/test-framework/org.jboss.tools.cdk.reddeer/src/org/jboss/tools/cdk/reddeer/utils/CDKUtils.java
@@ -109,7 +109,7 @@ public final class CDKUtils {
 	}
 	
 	public static boolean isCDKServerType(String type) {
-		return Arrays.stream(CDKServerAdapterType.values()).filter(e -> e.serverTypeName() == "CDK").anyMatch(e -> e.serverType().equals(type));
+		return Arrays.stream(CDKServerAdapterType.values()).filter(e -> e.serverTypeName() == "Red Hat CDK").anyMatch(e -> e.serverType().equals(type));
 	}
 	
 	public static boolean isServerOfType(Server server, String type) {


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
