### PR TITLE
JBIDE-27197: Unit test are randomly failing because of EGit cleanup

### DIFF
--- a/tests/org.jboss.tools.openshift.egit.test/src/org/jboss/tools/openshift/egit/internal/test/util/TestProject.java
+++ b/tests/org.jboss.tools.openshift.egit.test/src/org/jboss/tools/openshift/egit/internal/test/util/TestProject.java
@@ -85,7 +85,7 @@ public class TestProject {
 		else {
 			File f = new File(location);
 			if (f.exists())
-				FileUtils.delete(f, FileUtils.RECURSIVE | FileUtils.RETRY);
+				FileUtils.delete(f, FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
 		}
 	}
 

--- a/tests/org.jboss.tools.openshift.egit.test/src/org/jboss/tools/openshift/egit/internal/test/util/TestRepository.java
+++ b/tests/org.jboss.tools.openshift.egit.test/src/org/jboss/tools/openshift/egit/internal/test/util/TestRepository.java
@@ -538,7 +538,7 @@ public class TestRepository {
 		File repositoryDirectory = repository.getDirectory();
 		File repositoryParent = repositoryDirectory.getParentFile();
 		if (repositoryParent.exists()) {
-			FileUtils.delete(repositoryParent, FileUtils.RECURSIVE | FileUtils.RETRY);
+			FileUtils.delete(repositoryParent, FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
