### PR TITLE
JBIDE-27197: Unit test are randomly failing because of EGit cleanup

### DIFF
--- a/tests/org.jboss.tools.openshift.egit.test/src/org/jboss/tools/openshift/egit/internal/test/util/TestProject.java
+++ b/tests/org.jboss.tools.openshift.egit.test/src/org/jboss/tools/openshift/egit/internal/test/util/TestProject.java
@@ -81,12 +81,10 @@ public class TestProject {
 
 	public void dispose() throws CoreException, IOException {
 		if (project.exists())
-			project.delete(true, true, null);
-		else {
-			File f = new File(location);
-			if (f.exists())
-				FileUtils.delete(f, FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
-		}
+			project.delete(false, false, null);
+		File f = new File(location);
+		if (f.exists())
+			FileUtils.delete(f, FileUtils.RECURSIVE | FileUtils.RETRY | FileUtils.SKIP_MISSING);
 	}
 
 	public IFile getFile(String filepath) throws Exception {


### PR DESCRIPTION
- Change the way project files are deleted

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
