### PR TITLE
Fixing RedDeer 3.0.0 dependency

### DIFF
--- a/itests/org.jboss.tools.cdk.ui.bot.test/META-INF/MANIFEST.MF
+++ b/itests/org.jboss.tools.cdk.ui.bot.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.cdk.ui.bot.test
 Bundle-Version: 3.11.0.qualifier
 Bundle-Vendor: Red Hat
 Require-Bundle: org.junit,
- org.eclipse.reddeer.go;bundle-version="[2.1.0,3.0.0)",
+ org.eclipse.reddeer.go;bundle-version="3.0.0",
  org.eclipse.wst.server.core;bundle-version="1.5.0",
  org.eclipse.wst.server.ui;bundle-version="1.5.200",
  org.eclipse.jdt.launching;bundle-version="3.7.0",

--- a/test-framework/org.jboss.tools.cdk.reddeer/META-INF/MANIFEST.MF
+++ b/test-framework/org.jboss.tools.cdk.reddeer/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
- org.eclipse.reddeer.go;bundle-version="[2.1.0,3.0.0)",
+ org.eclipse.reddeer.go;bundle-version="3.0.0",
  org.eclipse.ui.forms,
  org.eclipse.wst.server.core,
  org.eclipse.linuxtools.docker.reddeer,


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
