### PR TITLE
JBIDE-27349 Add refresh button for cluster in OpenShift Application

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/plugin.xml
+++ b/plugins/org.jboss.tools.openshift.ui/plugin.xml
@@ -1229,6 +1229,27 @@ $            <command
                 </visibleWhen>
             </command>
         </menuContribution>
+        <!-- menu: Refresh -->
+        <menuContribution
+                          allPopups="false"
+                          locationURI="popup:org.jboss.tools.openshift.common.ui.applicationExplorer.applicationExplorerView.popup?after=group.common">
+            <command
+                     commandId="org.jboss.tools.openshift.ui.command.applicationexplorer.refresh"
+                     style="push"
+                     tooltip="Refresh">
+                <visibleWhen
+                             checkEnabled="false">
+                    <and>
+                        <count
+                               value="1" />
+                        <iterate>
+                                <adapt
+                                       type="org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationExplorerUIModel" />
+                        </iterate>
+                    </and>
+                </visibleWhen>
+            </command>
+        </menuContribution>
         <!-- menu: About -->
         <menuContribution
                           allPopups="false"
@@ -1940,6 +1961,10 @@ $            <command
                  class="org.jboss.tools.openshift.internal.ui.handler.applicationexplorer.DebugHandler"
                  commandId="org.jboss.tools.openshift.ui.command.applicationexplorer.component.debug">
         </handler>        
+        <handler
+                 class="org.jboss.tools.openshift.internal.ui.handler.applicationexplorer.RefreshHandler"
+                 commandId="org.jboss.tools.openshift.ui.command.applicationexplorer.refresh">
+        </handler>  
     </extension>
 
     <!-- adapters -->
@@ -2200,6 +2225,10 @@ $            <command
         <command
                  id="org.jboss.tools.openshift.ui.command.applicationexplorer.component.debug"
                  name="Debug">
+        </command>
+        <command
+                 id="org.jboss.tools.openshift.ui.command.applicationexplorer.refresh"
+                 name="Refresh">
         </command>
         
     </extension>

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/applicationexplorer/RefreshHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/applicationexplorer/RefreshHandler.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.internal.ui.handler.applicationexplorer;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.jboss.tools.common.ui.notification.LabelNotification;
+import org.jboss.tools.openshift.internal.common.ui.utils.UIUtils;
+import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationExplorerUIModel;
+
+/**
+ * @author Red Hat Developers
+ */
+public class RefreshHandler extends OdoHandler {
+
+	@Override
+	public Object execute(final ExecutionEvent event) throws ExecutionException {
+		ISelection selection = HandlerUtil.getCurrentSelection(event);
+		ApplicationExplorerUIModel cluster = UIUtils.getFirstElement(selection, ApplicationExplorerUIModel.class);
+		if (cluster == null) {
+			return OpenShiftUIActivator.statusFactory().cancelStatus("No cluster selected"); //$NON-NLS-1$
+		}
+		Shell parent = Display.getDefault().getActiveShell();
+		executeInJob("Refresh cluster", monitor -> execute(parent, cluster));
+		return null;
+	}
+
+	/**
+	 * @param cluster
+	 * @param value
+	 * @return
+	 */
+	private void execute(Shell shell, ApplicationExplorerUIModel cluster) {
+		LabelNotification notification = LabelNotification.openNotification(shell, "Refresh cluster");
+		try {
+			cluster.refresh();
+			LabelNotification.openNotification(notification, shell, "Cluster refreshed");
+		} catch (Exception e) {
+			shell.getDisplay().asyncExec(() -> {
+				notification.close();
+				MessageDialog.openError(shell, "Error during refresh", "Cannot refresh cluster");
+			});
+		}
+	}
+
+}


### PR DESCRIPTION
Explorer

Signed-off-by: Josef Kopriva <jkopriva@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
