### PR TITLE
JBIDE-27588 Omit oc from crc initialization check

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/adapter/CRC100Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/adapter/CRC100Server.java
@@ -77,10 +77,6 @@ public class CRC100Server extends ServerDelegate {
 		if (!bin.exists() || !json.exists() || !log.exists()) {
 			return false;
 		}
-		File oc = new File(bin, "oc");
-		File ocExe = new File(bin, "oc.exe");
-		if( !oc.exists() && !ocExe.exists()) 
-			return false;
 		return true;
 	}
 


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
