### PR TITLE
JBIDE-27595: Connection is configured with wrong oc path when startin…

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/listeners/ConfigureCRCFrameworksListener.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/listeners/ConfigureCRCFrameworksListener.java
@@ -156,7 +156,7 @@ public class ConfigureCRCFrameworksListener extends UnitedServerListener {
 	private File findOcBin(IServer server) {
 		String home = getServerHome(server);
 		String ocBinaryName = OCBinary.getInstance().getName();
-		return Paths.get(home, "bin", ocBinaryName).toFile();
+		return Paths.get(home, "bin", "oc", ocBinaryName).toFile();
 	}
 
 	private String getServerHome(IServer server) {


### PR DESCRIPTION
…g CRC

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
