### PR TITLE
JBIDE-27796: BYOE does not install Oauth UI needed by devsandbox

### DIFF
--- a/features/org.jboss.tools.openshift.feature/feature.xml
+++ b/features/org.jboss.tools.openshift.feature/feature.xml
@@ -25,6 +25,7 @@
       <import feature="org.eclipse.linuxtools.docker.feature"/>
       <import plugin="org.jboss.tools.maven.springboot"/>
       <import plugin="org.jboss.tools.maven.core" version="1.9.0" match="greaterOrEqual"/>
+      <import feature="org.jboss.tools.common.oauth.feature"/>
    </requires>
 
    <plugin id="org.jboss.tools.openshift.client" download-size="0" install-size="0" version="0.0.0" unpack="false"/>


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
