### PR TITLE
JBIDE-27829: Enhance navigation inside the Application Explorer

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
@@ -66,12 +66,14 @@ Require-Bundle: org.jboss.tools.openshift.common.ui;bundle-version="[3.0.0,4.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.openshift.internal.ui;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
+ org.jboss.tools.openshift.internal.ui.applicationexplorer;x-friends:="org.jboss.tools.openshift.reddeer,org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.comparators;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.dialog;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.explorer;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.handler;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.job;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.models;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
+ org.jboss.tools.openshift.internal.ui.models.applicationexplorer;x-friends:="org.jboss.tools.openshift.reddeer,org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.odo;x-friends:="org.jboss.tools.openshift.reddeer,org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.portforwading;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.preferences;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/applicationexplorer/OpenShiftApplicationExplorerContentProvider.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/applicationexplorer/OpenShiftApplicationExplorerContentProvider.java
@@ -24,11 +24,13 @@ import org.jboss.tools.openshift.internal.ui.models.IOpenshiftUIElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationExplorerUIModel;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ComponentElement;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.CreateComponentMessageElement;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.CreateProjectMessageElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.DevfileRegistriesElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.DevfileRegistryComponentTypeElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.DevfileRegistryComponentTypeStarterElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.DevfileRegistryElement;
-import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.MessageElement;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.LoginMessageElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ProjectElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ServiceElement;
 import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.StorageElement;
@@ -107,13 +109,16 @@ public class OpenShiftApplicationExplorerContentProvider extends ViewerComparato
   }
 
   private Object[] getChildren(ApplicationExplorerUIModel parentElement) {
+    List<Object> childs = new ArrayList<>();
     try {
-      List<ProjectElement> childs = new ArrayList<>();
       parentElement.getOdo().getProjects(parentElement.getClient()).forEach(project -> childs.add(new ProjectElement(project, parentElement)));
-      return childs.toArray();
     } catch (Exception e) {
-      return new Object[] { new MessageElement("Can't connect to cluster. Click to login.", parentElement) };
+      childs.add(new LoginMessageElement(parentElement));
     }
+    if (childs.isEmpty()) {
+      childs.add(new CreateProjectMessageElement(parentElement));
+    }
+    return childs.toArray();
   }
   
   private Object[] getRegistries() {
@@ -141,13 +146,16 @@ public class OpenShiftApplicationExplorerContentProvider extends ViewerComparato
   }
 
   private Object[] getChildren(ProjectElement parentElement) {
+    List<Object> childs = new ArrayList<>();
     try {
-      List<ApplicationElement> childs = new ArrayList<>();
       parentElement.getParent().getOdo().getApplications(parentElement.getWrapped().getMetadata().getName()).forEach(application -> childs.add(new ApplicationElement(application, parentElement)));
-      return childs.toArray();
     } catch (IOException e) {
-      return new Object[] { "Can't list applications" };
+      childs.add("Can't list applications");
     }
+    if (childs.isEmpty()) {
+      childs.add(new CreateComponentMessageElement<ProjectElement>(parentElement));
+    }
+    return childs.toArray();
   }
 
   private Object[] getChildren(ApplicationElement parentElement) {
@@ -161,6 +169,9 @@ public class OpenShiftApplicationExplorerContentProvider extends ViewerComparato
       if (childs.isEmpty()) {
         return new Object[] { "Can't list components" };
       }
+    }
+    if (childs.isEmpty()) {
+      childs.add(new CreateComponentMessageElement<ApplicationElement>(parentElement));
     }
     return childs.toArray();
   }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/applicationexplorer/OpenShiftApplicationExplorerLabelProvider.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/applicationexplorer/OpenShiftApplicationExplorerLabelProvider.java
@@ -80,7 +80,7 @@ public class OpenShiftApplicationExplorerLabelProvider extends BaseExplorerLabel
 		return super.getStyledText(element, limit);
 	}
 
-	private StyledString getStyledText(MessageElement messageElement) {
+	private StyledString getStyledText(MessageElement<?> messageElement) {
 		StyledString styledString = new StyledString();
 		styledString.append(messageElement.getWrapped(), new Styler() {
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/applicationexplorer/NewProjectHandler.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/handler/applicationexplorer/NewProjectHandler.java
@@ -17,7 +17,6 @@ import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.window.Window;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.jboss.tools.common.ui.notification.LabelNotification;
@@ -38,19 +37,23 @@ public class NewProjectHandler extends OdoHandler {
 			return OpenShiftUIActivator.statusFactory().cancelStatus("No cluster selected"); //$NON-NLS-1$
 		}
 		Shell shell = HandlerUtil.getActiveShell(event);
-		InputDialog dialog = new InputDialog(shell, "New project", "Project name:", null, null);
+		openDialog(cluster, shell);
+		return null;
+	}
+
+  private static void openDialog(ApplicationExplorerUIModel cluster, Shell shell) {
+    InputDialog dialog = new InputDialog(shell, "New project", "Project name:", null, null);
 		if (dialog.open() == Window.OK) {
 			executeInJob("Create project", monitor -> execute(shell, cluster, dialog.getValue()));
 		}
-		return null;
-	}
+  }
 
 	/**
 	 * @param cluster
 	 * @param value
 	 * @return
 	 */
-	private void execute(Shell shell, ApplicationExplorerUIModel cluster, String project) {
+	private static void execute(Shell shell, ApplicationExplorerUIModel cluster, String project) {
 		LabelNotification notification = LabelNotification.openNotification(shell, "Creating project " + project);
 		try {
 			cluster.getOdo().createProject(project);
@@ -63,5 +66,13 @@ public class NewProjectHandler extends OdoHandler {
 			});
 		}
 	}
+
+  /**
+   * @param shell
+   * @param root
+   */
+  public static void openDialog(Shell shell, ApplicationExplorerUIModel root) {
+    openDialog(root, shell);
+  }
 
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/ApplicationExplorerUIModel.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/ApplicationExplorerUIModel.java
@@ -61,10 +61,10 @@ public class ApplicationExplorerUIModel extends AbstractOpenshiftUIModel<Applica
     return INSTANCE;
   }
   
-  static class ClusterInfo {
+  public static class ClusterInfo {
     private OpenShiftClient client = loadClient();
     
-    Odo getOdo() throws IOException {
+    public Odo getOdo() throws IOException {
       return OdoCli.get();
     }
 
@@ -96,14 +96,18 @@ public class ApplicationExplorerUIModel extends AbstractOpenshiftUIModel<Applica
     private Config config;
 
     private DevfileRegistriesElement registries;
+    
+    protected ApplicationExplorerUIModel(ClusterInfo clusterInfo) {
+      super(null, clusterInfo);
+      loadProjects();
+      watcherJob = Job.createSystem("Watching kubeconfig", this::startWatcher);
+      watcherJob.schedule();
+      this.config = loadConfig();
+      ResourcesPlugin.getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.POST_CHANGE);
+    }
 
   private ApplicationExplorerUIModel() {
-    super(null, new ClusterInfo());
-    loadProjects();
-    watcherJob = Job.createSystem("Watching kubeconfig", this::startWatcher);
-    watcherJob.schedule();
-    this.config = loadConfig();
-    ResourcesPlugin.getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.POST_CHANGE);
+    this(new ClusterInfo());
   }
 
 

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/CreateComponentMessageElement.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/CreateComponentMessageElement.java
@@ -10,16 +10,23 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.ui.models.applicationexplorer;
 
+import org.eclipse.ui.PlatformUI;
 import org.jboss.tools.openshift.internal.common.ui.explorer.ILink;
+import org.jboss.tools.openshift.internal.ui.handler.applicationexplorer.CreateComponentHandler;
 import org.jboss.tools.openshift.internal.ui.models.AbstractOpenshiftUIElement;
 
 /**
  * @author Red Hat Developers
  *
  */
-public abstract class MessageElement<P extends AbstractOpenshiftUIElement<?, ?, ApplicationExplorerUIModel>> extends AbstractOpenshiftUIElement<String, P, ApplicationExplorerUIModel> implements ILink {
+public class CreateComponentMessageElement<T extends AbstractOpenshiftUIElement<?, ?, ApplicationExplorerUIModel>> extends MessageElement<T> implements ILink {
 	
-	protected MessageElement(P parentElement, String message) {
-		super(parentElement, message);
+	public CreateComponentMessageElement(T parentElement) {
+		super(parentElement, "No deployments, click here to create one.");
 	}
+
+	@Override
+  public void execute() {
+    CreateComponentHandler.openDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), getParent());
+  }
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/CreateProjectMessageElement.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/CreateProjectMessageElement.java
@@ -10,16 +10,22 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.ui.models.applicationexplorer;
 
+import org.eclipse.ui.PlatformUI;
 import org.jboss.tools.openshift.internal.common.ui.explorer.ILink;
-import org.jboss.tools.openshift.internal.ui.models.AbstractOpenshiftUIElement;
+import org.jboss.tools.openshift.internal.ui.handler.applicationexplorer.NewProjectHandler;
 
 /**
  * @author Red Hat Developers
  *
  */
-public abstract class MessageElement<P extends AbstractOpenshiftUIElement<?, ?, ApplicationExplorerUIModel>> extends AbstractOpenshiftUIElement<String, P, ApplicationExplorerUIModel> implements ILink {
+public class CreateProjectMessageElement extends MessageElement<ApplicationExplorerUIModel> implements ILink {
 	
-	protected MessageElement(P parentElement, String message) {
-		super(parentElement, message);
+	public CreateProjectMessageElement(ApplicationExplorerUIModel parentElement) {
+		super(parentElement, "No namespaces/projects, click here to create one.");
 	}
+
+	@Override
+  public void execute() {
+    NewProjectHandler.openDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), getRoot());
+  }
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/LoginMessageElement.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/LoginMessageElement.java
@@ -10,16 +10,29 @@
  ******************************************************************************/
 package org.jboss.tools.openshift.internal.ui.models.applicationexplorer;
 
+import java.io.IOException;
+
+import org.eclipse.ui.PlatformUI;
 import org.jboss.tools.openshift.internal.common.ui.explorer.ILink;
-import org.jboss.tools.openshift.internal.ui.models.AbstractOpenshiftUIElement;
+import org.jboss.tools.openshift.internal.ui.OpenShiftUIActivator;
+import org.jboss.tools.openshift.internal.ui.handler.applicationexplorer.LoginHandler;
 
 /**
  * @author Red Hat Developers
  *
  */
-public abstract class MessageElement<P extends AbstractOpenshiftUIElement<?, ?, ApplicationExplorerUIModel>> extends AbstractOpenshiftUIElement<String, P, ApplicationExplorerUIModel> implements ILink {
+public class LoginMessageElement extends MessageElement<ApplicationExplorerUIModel> implements ILink {
 	
-	protected MessageElement(P parentElement, String message) {
-		super(parentElement, message);
+	public LoginMessageElement(ApplicationExplorerUIModel parentElement) {
+		super(parentElement, "Can't connect to cluster. Click to login.");
+	}
+
+	@Override
+	public void execute() {
+		try {
+			LoginHandler.openDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), getRoot());
+		} catch (IOException e) {
+			OpenShiftUIActivator.getDefault().getLogger().logError(e);
+		}
 	}
 }

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/odo/OdoCli.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/odo/OdoCli.java
@@ -670,8 +670,12 @@ public class OdoCli implements Odo {
 
   @Override
   public List<ServiceInstance> getServices(OpenShiftClient client, String project, String application) {
-    ServiceCatalogClient sc = client.adapt(ServiceCatalogClient.class);
-    return sc.serviceInstances().inNamespace(project).withLabelSelector(new LabelSelectorBuilder().addToMatchLabels(KubernetesLabels.APP_LABEL, application).build()).list().getItems();
+    try {
+      ServiceCatalogClient sc = client.adapt(ServiceCatalogClient.class);
+      return sc.serviceInstances().inNamespace(project).withLabelSelector(new LabelSelectorBuilder().addToMatchLabels(KubernetesLabels.APP_LABEL, application).build()).list().getItems();
+    } catch (KubernetesClientException e) {
+      return Collections.emptyList();
+    }
   }
 
   protected LabelSelector getLabelSelector(String application, String component) {

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/applicationexplorer/OpenShiftApplicationExplorerContentProviderTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/applicationexplorer/OpenShiftApplicationExplorerContentProviderTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2017 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.ui.applicationexplorer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.tools.openshift.core.odo.Application;
+import org.jboss.tools.openshift.core.odo.Odo;
+import org.jboss.tools.openshift.internal.ui.applicationexplorer.OpenShiftApplicationExplorerContentProvider;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationElement;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationExplorerUIModel;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ApplicationExplorerUIModel.ClusterInfo;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.CreateComponentMessageElement;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.CreateProjectMessageElement;
+import org.jboss.tools.openshift.internal.ui.models.applicationexplorer.ProjectElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.Project;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * @author jeff.cantrill
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OpenShiftApplicationExplorerContentProviderTest {
+
+	private static final String OPENSHIFT_SERVER_URL = "https://localhost:8442";
+
+	private OpenShiftApplicationExplorerContentProvider provider;
+	private ApplicationExplorerUIModel model;
+	private Odo odo;
+
+	@Before
+	public void setup() throws Exception {
+	  odo = mock(Odo.class);
+	  ClusterInfo info = mock(ClusterInfo.class);
+	  doReturn(odo).when(info).getOdo();
+		this.model = new ApplicationExplorerUIModel(info) {
+		};
+		this.provider = new OpenShiftApplicationExplorerContentProvider(model) {
+		};
+	}
+
+  protected Project mockProject(String name) {
+    Project project = mock(Project.class);
+    ObjectMeta meta = mock(ObjectMeta.class);
+    doReturn(name).when(meta).getName();
+    doReturn(meta).when(project).getMetadata();
+    doReturn(Collections.singletonList(project)).when(odo).getProjects(any(OpenShiftClient.class));
+    return project;
+  }
+
+  @Test
+	public void checkEmptyClusterReturnsLinkToCreateProject() throws InterruptedException, TimeoutException {
+	  Object[] childs = provider.getChildren(model);
+	  assertEquals(1, childs.length);
+	  Object element = childs[0];
+	  assertTrue(element instanceof CreateProjectMessageElement);
+	}
+	
+	 @Test
+   public void checkClusterWithSingleProjectReturnsLinkToCreateComponent()
+       throws InterruptedException, TimeoutException {
+	   mockProject("myproject");
+     Object[] childs = provider.getChildren(model);
+     assertEquals(1, childs.length);
+     Object element = childs[0];
+     assertTrue(element instanceof ProjectElement);
+     childs = provider.getChildren(element);
+     assertEquals(1, childs.length);
+     element = childs[0];
+     assertTrue(element instanceof CreateComponentMessageElement<?>);
+   }
+	 
+   @Test
+   public void checkClusterWithSingleProjectAndSingleAppReturnsLinkToCreateComponent()
+       throws InterruptedException, TimeoutException, IOException {
+     mockProject("myproject");
+     Application app = mock(Application.class);
+     doReturn(Collections.singletonList(app)).when(odo).getApplications(eq("myproject"));
+     Object[] childs = provider.getChildren(model);
+     assertEquals(1, childs.length);
+     Object element = childs[0];
+     assertTrue(element instanceof ProjectElement);
+     childs = provider.getChildren(element);
+     assertEquals(1, childs.length);
+     element = childs[0];
+     assertTrue(element instanceof ApplicationElement);
+     childs = provider.getChildren(element);
+     assertEquals(1, childs.length);
+     element = childs[0];
+     assertTrue(element instanceof CreateComponentMessageElement<?>);
+   }
+
+ }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Test
- Have a cluster with no projects, you should see a node with a link under the cluster node that allows to create a new project
- Have a project without deployments, you should see a node with a link under the project node that allows you to create a component
- Have an application without deployments (hard to reproduce go to OpenShift console and create a devfile based sample), you should see a node with a link under the application node that allows you to create a component
