### PR TITLE
JBIDE-27927: CDK tooling cannot get into Started state even though cd…

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/cdk/server/core/adapter/controllers/CDKLaunchUtility.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/cdk/server/core/adapter/controllers/CDKLaunchUtility.java
@@ -147,7 +147,7 @@ public class CDKLaunchUtility {
 
 	public String[] callMachineReadable(String rootCommand, String[] args, File dir,
 			Map<String, String> env) throws IOException, CommandTimeoutException {
-		return ProcessLaunchUtility.call(rootCommand, args, dir, env, 30000, false);
+		return ProcessLaunchUtility.call(rootCommand, args, dir, env, 90000, false);
 	}
 
 	public Process callInteractive(IServer s, String args, String launchConfigName, boolean skipCredentials) throws CoreException, IOException {

--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/cdk/server/core/listeners/ServiceManagerEnvironmentLoader.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/cdk/server/core/listeners/ServiceManagerEnvironmentLoader.java
@@ -127,7 +127,7 @@ public abstract class ServiceManagerEnvironmentLoader {
 			throws IOException {
 		String[] lines = null;
 		try {
-			lines = ProcessLaunchUtility.call(cmdLoc, args, wd, env, 30000, false);
+			lines = ProcessLaunchUtility.call(cmdLoc, args, wd, env, 90000, false);
 		} catch (IOException ce) {
 			throw ce;
 		} catch (CommandTimeoutException ce) {
@@ -156,7 +156,7 @@ public abstract class ServiceManagerEnvironmentLoader {
 			throws IOException {
 		String[] lines = null;
 		try {
-			lines = ProcessLaunchUtility.call(cmdLoc, args, wd, env, 30000, false);
+			lines = ProcessLaunchUtility.call(cmdLoc, args, wd, env, 90000, false);
 		} catch (IOException ioe) {
 			throw ioe;
 		} catch (CommandTimeoutException ce) {


### PR DESCRIPTION
…k is actually started on windows 10

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
