### PR TITLE
JBIDE-27921: CRC 1.28.0 setup on windows and mac does not provide bin…

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/cdk/server/core/detection/MinishiftVersionLoader.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/cdk/server/core/detection/MinishiftVersionLoader.java
@@ -31,7 +31,7 @@ public class MinishiftVersionLoader {
 		Properties ret = new Properties();
 		try {
 			String[] lines = ProcessLaunchUtility.call(commandPath, new String[] { "version" },
-					new File(commandPath).getParentFile(), new HashMap<String, String>(), 10000, false);
+					new File(commandPath).getParentFile(), new HashMap<>(), 30000, false);
 
 			for (int i = 0; i < lines.length; i++) {
 				if (lines[i].trim().isEmpty())


### PR DESCRIPTION
…/oc anymore and prevent CRC tooling to start

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
