### PR TITLE
Remove check for bin folder created in older crc versions, fixes JBID…

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/adapter/CRC100Server.java
+++ b/plugins/org.jboss.tools.openshift.cdk.server/src/org/jboss/tools/openshift/internal/crc/server/core/adapter/CRC100Server.java
@@ -73,10 +73,14 @@ public class CRC100Server extends ServerDelegate {
 		File homeF = new File(home);
 		if( !homeF.exists() || !homeF.isDirectory())
 			return false;
+		
+		// Verification of crc being initialized
+		// this is very unreliable check and should be improved in future
+		// https://issues.redhat.com/browse/JBIDE-27921
 		File bin = new File(homeF, "bin");
 		File json = new File(homeF, "crc.json");
 		File log = new File(homeF, "crc.log");
-		if (!bin.exists() || !json.exists() || !log.exists()) {
+		if (!json.exists() || !log.exists()) {
 			return false;
 		}
 		
@@ -84,6 +88,9 @@ public class CRC100Server extends ServerDelegate {
 		if( matchesCRC_1_24_OrGreater(getServer()))
 			return true;
 		
+		if (!bin.exists()) {
+			return false;
+		}
 		File oc = new File(bin, "oc");
 		File ocExe = new File(bin, "oc.exe");
 		if( !oc.exists() && !ocExe.exists()) 


### PR DESCRIPTION
…E-27921 and JBIDE-27869

Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
