### PR TITLE
JBIDE-28121: Create component broken since alizer api changes

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
@@ -67,7 +67,8 @@ Require-Bundle: org.jboss.tools.openshift.common.ui;bundle-version="[3.0.0,4.0.0
  org.eclipse.osgi
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Export-Package: org.jboss.tools.openshift.internal.ui;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
+Export-Package: com.redhat.devtools.alizer.api;x-friends:="org.jboss.tools.openshift.test",
+ org.jboss.tools.openshift.internal.ui;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.applicationexplorer;x-friends:="org.jboss.tools.openshift.reddeer,org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.comparators;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.dialog;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
@@ -107,5 +108,6 @@ Import-Package: org.eclipse.core.runtime,
  org.eclipse.core.runtime.jobs,
  org.eclipse.core.runtime.preferences,
  org.eclipse.osgi.util,
- org.osgi.framework
+ org.osgi.framework,
+ org.slf4j
 Automatic-Module-Name: org.jboss.tools.openshift.ui

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/util/LanguageRecognizerTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/core/util/LanguageRecognizerTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.core.util;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.redhat.devtools.alizer.api.Language;
+import com.redhat.devtools.alizer.api.LanguageRecognizer;
+import com.redhat.devtools.alizer.api.RecognizerFactory;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * 
+ */
+
+public class LanguageRecognizerTest {
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+	
+	@Test
+	public void checkLanguageRecognizerOnEmptyFolder() throws IOException {
+		LanguageRecognizer recognize = new RecognizerFactory().createLanguageRecognizer();
+		List<Language> languages = recognize.analyze(folder.newFolder().getAbsolutePath());
+		assertTrue(languages.isEmpty());
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
