### PR TITLE
JBIDE-28197: Component are displayed using their id not name

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.openshift.ui/META-INF/MANIFEST.MF
@@ -90,6 +90,7 @@ Export-Package: com.redhat.devtools.alizer.api;x-friends:="org.jboss.tools.opens
  org.jboss.tools.openshift.internal.ui.utils;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.validator;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.webhooks;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
+ org.jboss.tools.openshift.internal.ui.wizard.applicationexplorer;x-friends:="org.jboss.tools.openshift.test",
  org.jboss.tools.openshift.internal.ui.wizard.common;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.wizard.connection;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",
  org.jboss.tools.openshift.internal.ui.wizard.deployimage;x-friends:="org.jboss.tools.openshift.test,org.jboss.tools.openshift.reddeer",

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/applicationexplorer/ComponentTypeColumLabelProvider.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/wizard/applicationexplorer/ComponentTypeColumLabelProvider.java
@@ -13,7 +13,6 @@ package org.jboss.tools.openshift.internal.ui.wizard.applicationexplorer;
 import java.util.Objects;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
-import org.jboss.tools.openshift.core.odo.ComponentType;
 import org.jboss.tools.openshift.core.odo.DevfileComponentType;
 
 /**
@@ -24,12 +23,10 @@ public class ComponentTypeColumLabelProvider extends ColumnLabelProvider {
 
 	@Override
 	public String getText(Object element) {
-	  if (element instanceof ComponentType) {
-	    String text = ((ComponentType)element).getName();
+	  if (element instanceof DevfileComponentType) {
 	    if (element instanceof DevfileComponentType) {
-	      text += " (from " + ((DevfileComponentType)element).getDevfileRegistry().getName() + ")";
+	      return ((DevfileComponentType)element).getDisplayName() +" (from " + ((DevfileComponentType)element).getDevfileRegistry().getName() + ")";
 	    }
-	    return text;
 	  }
 	  return Objects.toString(element);
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/applicationexplorer/ComponentTypeColumLabelProviderTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/applicationexplorer/ComponentTypeColumLabelProviderTest.java
@@ -34,10 +34,7 @@ public class ComponentTypeColumLabelProviderTest {
 	public void checkDisplayNameIsUsed() {
 		DevfileRegistry registry = mock(DevfileRegistry.class);
 		when(registry.getName()).thenReturn("registry name");
-		DevfileComponentType type = mock(DevfileComponentType.class);
-		when(type.getName()).thenReturn("myname");
-		when(type.getDisplayName()).thenReturn("my display name");
-		when(type.getDevfileRegistry()).thenReturn(registry);
+		DevfileComponentType type = new DevfileComponentType("my name", "my display name", "my description", registry, null, null);
 		String result = provider.getText(type);
 		assertTrue(result.equals("my display name (from registry name)"));
 	}

--- a/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/applicationexplorer/ComponentTypeColumLabelProviderTest.java
+++ b/tests/org.jboss.tools.openshift.test/src/org/jboss/tools/openshift/test/ui/applicationexplorer/ComponentTypeColumLabelProviderTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.openshift.test.ui.applicationexplorer;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.jboss.tools.openshift.core.odo.DevfileComponentType;
+import org.jboss.tools.openshift.core.odo.DevfileRegistry;
+import org.jboss.tools.openshift.internal.ui.wizard.applicationexplorer.ComponentTypeColumLabelProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class ComponentTypeColumLabelProviderTest {
+
+	private ComponentTypeColumLabelProvider provider;
+
+	@Before
+	public void setup() throws Exception {
+		provider = new ComponentTypeColumLabelProvider();
+	}
+	
+	@Test
+	public void checkDisplayNameIsUsed() {
+		DevfileRegistry registry = mock(DevfileRegistry.class);
+		when(registry.getName()).thenReturn("registry name");
+		DevfileComponentType type = mock(DevfileComponentType.class);
+		when(type.getName()).thenReturn("myname");
+		when(type.getDisplayName()).thenReturn("my display name");
+		when(type.getDevfileRegistry()).thenReturn(registry);
+		String result = provider.getText(type);
+		assertTrue(result.equals("my display name (from registry name)"));
+	}
+ }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
