### PR TITLE
JBIDE-28247: CDK tooling is deprecated

### DIFF
--- a/plugins/org.jboss.tools.openshift.cdk.server/plugin.properties
+++ b/plugins/org.jboss.tools.openshift.cdk.server/plugin.properties
@@ -1,24 +1,24 @@
 #Properties file for org.jboss.tools.runtime
 Bundle-Vendor=Red Hat
-Bundle-Name=Container Development Kit Support
+Bundle-Name=Container Development Kit Support (Deprecated)
 ProviderName=Red Hat
 
 enterpriseProviderName=Red Hat JBoss Middleware
 
-openshift.cdk.name=Red Hat Container Development Kit 2.x
+openshift.cdk.name=Red Hat Container Development Kit 2.x (Deprecated)
 openshift.cdk.description=Integration and support for the Red Hat Container Development Kit 2.x
 
-openshift.cdk3.name=Red Hat Container Development Kit 3
+openshift.cdk3.name=Red Hat Container Development Kit 3 (Deprecated)
 openshift.cdk3.description=Integration and support for the Red Hat Container Development Kit 3
 
-openshift.cdk32.name=Red Hat Container Development Kit 3.2+
+openshift.cdk32.name=Red Hat Container Development Kit 3.2+ (Deprecated)
 openshift.cdk32.description=Integration and support for the Red Hat Container Development Kit 3.2+
-openshift.minishift17.name=Minishift 1.7+
+openshift.minishift17.name=Minishift 1.7+ (Deprecated)
 openshift.minishift17.description=Integration and support for Minishift 1.7+
 
-launch_cdk_server=Launch Container Development Environment using Red Hat CDK
-cdk.detector.2x=Container Development Environment 2.x
-cdk.detector.3=Container Development Environment 3.x
+launch_cdk_server=Launch Container Development Environment using Red Hat CDK (Deprecated)
+cdk.detector.2x=Container Development Environment 2.x (Deprecated)
+cdk.detector.3=Container Development Environment 3.x (Deprecated)
 
 openshift.crc.100.name=Red Hat CodeReady Containers 1.0+
 openshift.crc.100.description=Integration and support for Red Hat CodeReady Containers 1.0+


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
