### PR TITLE
JBIDE-28283: Non odo components are not visible

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/odo/ComponentDeserializer.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/core/odo/ComponentDeserializer.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class ComponentDeserializer extends StdNodeBasedDeserializer<List<Component>> {
 
     public static final String DEVFILE_FIELD = "devfileComponents";
+    public static final String OTHER_FIELD = "otherComponents";
     public static final String METADATA_FIELD = "metadata";
     public static final String STATUS_FIELD = "status";
     public static final String STATE_FIELD = "state";
@@ -34,8 +35,9 @@ public class ComponentDeserializer extends StdNodeBasedDeserializer<List<Compone
     @Override
     public List<Component> convert(JsonNode root, DeserializationContext context) {
         List<Component> result = new ArrayList<>();
-        // two roots, s2i and devfiles
+        // two roots, devfileComponents and otherComponents
         result.addAll(parseComponents(root.get(DEVFILE_FIELD), ComponentKind.DEVFILE));
+        result.addAll(parseComponents(root.get(OTHER_FIELD), ComponentKind.DEVFILE));
         return result;
     }
 


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
