### PR TITLE
JBIDE-28499: odo 2.5.1 extraction is broken on Windows and MacOS

### DIFF
--- a/plugins/org.jboss.tools.openshift.ui/resources/tools.json
+++ b/plugins/org.jboss.tools.openshift.ui/resources/tools.json
@@ -9,12 +9,12 @@
       "platforms": {
         "win32": {
           "url": "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v2.5.1/odo-windows-amd64.exe.zip",
-          "cmdFileName": "odo.exe",
+          "cmdFileName": "odo-windows-amd64.exe",
           "dlFileName": "odo-windows-amd64.exe.zip"
         },
         "macosx": {
           "url": "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/v2.5.1/odo-darwin-amd64.tar.gz",
-          "cmdFileName": "odo",
+          "cmdFileName": "odo-darwin-amd64",
           "dlFileName": "odo-darwin-amd64.tar.gz"
         },
         "linux": {


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
