### PR TITLE
JBIDE-28500: StyledTextUtils causes Not properly disposed SWT resource

### DIFF
--- a/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/StyledTextUtils.java
+++ b/plugins/org.jboss.tools.openshift.common.ui/src/org/jboss/tools/openshift/internal/common/ui/utils/StyledTextUtils.java
@@ -49,7 +49,7 @@ public class StyledTextUtils {
 	private static void configureLinkWidget(StyledText styledText) {
 		setTransparent(styledText);
 		styledText.setEditable(false);
-		styledText.setCursor(new Cursor(styledText.getShell().getDisplay(), SWT.CURSOR_HAND));
+		styledText.setCursor(styledText.getShell().getDisplay().getSystemCursor(SWT.CURSOR_HAND));
 
 		//emulate disablement
 		styledText.setCaret(null);


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
