### PR TITLE
JBIDE-28823: vert.x component missing from supported debugger

### DIFF
--- a/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/stack/JavaRemoteStackDebugger.java
+++ b/plugins/org.jboss.tools.openshift.core/src/org/jboss/tools/openshift/internal/core/stack/JavaRemoteStackDebugger.java
@@ -30,7 +30,7 @@ import org.jboss.tools.openshift.core.stack.RemoteStackDebugger;
  *
  */
 public class JavaRemoteStackDebugger implements RemoteStackDebugger {
-	private static final List<String> SUPPORTED = List.of("maven", "openliberty", "websphereliberty", "quarkus", "spring", "vertx", "wildfly", "java");
+	private static final List<String> SUPPORTED = List.of("maven", "openliberty", "websphereliberty", "quarkus", "spring", "vertx", "wildfly", "java", "vert.x");
 
 	@Override
 	public boolean isValid(String stackType) {

--- a/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/ComponentElement.java
+++ b/plugins/org.jboss.tools.openshift.ui/src/org/jboss/tools/openshift/internal/ui/models/applicationexplorer/ComponentElement.java
@@ -17,10 +17,16 @@ import org.jboss.tools.openshift.internal.ui.models.AbstractOpenshiftUIElement;
  * @author Red Hat Developers
  *
  */
-public class ComponentElement extends AbstractOpenshiftUIElement<Component, NamespaceElement, ApplicationExplorerUIModel> {
-	
+public class ComponentElement
+		extends AbstractOpenshiftUIElement<Component, NamespaceElement, ApplicationExplorerUIModel> {
+
 	public ComponentElement(Component component, NamespaceElement parentElement) {
 		super(parentElement, component);
+	}
+
+	@Override
+	public void refresh() {
+		fireChanged(this);
 	}
 
 }


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
